### PR TITLE
fix: update Primitives package reference to 1.1.0

### DIFF
--- a/src/BlazorUI.Components/BlazorUI.Components.csproj
+++ b/src/BlazorUI.Components/BlazorUI.Components.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup Condition="'$(UsePackageReferences)' == 'true'">
     <PackageReference Include="BlazorUI.Icons.Lucide" Version="1.0.0" />
-    <PackageReference Include="BlazorUI.Primitives" Version="1.1.0-beta.0" />
+    <PackageReference Include="BlazorUI.Primitives" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Fixes the Components package reference to use `BlazorUI.Primitives` version `1.1.0` instead of `1.1.0-beta.0`.

This is needed for the Components NuGet publish workflow to succeed, as Primitives `1.1.0` is now published.

## Changes

- Updated `BlazorUI.Primitives` package reference from `1.1.0-beta.0` to `1.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)