### PR TITLE
fix: Resolve MultiSelect stale callback bug

### DIFF
--- a/src/BlazorUI.Primitives/Primitives/Combobox/ComboboxContext.cs
+++ b/src/BlazorUI.Primitives/Primitives/Combobox/ComboboxContext.cs
@@ -175,6 +175,30 @@ public class ComboboxContext : PrimitiveContextWithEvents<ComboboxState>
     }
 
     /// <summary>
+    /// Updates an existing item's registration.
+    /// Called when component parameters change to ensure callbacks stay current.
+    /// </summary>
+    /// <param name="index">The index of the item to update.</param>
+    /// <param name="value">The value of the item.</param>
+    /// <param name="searchText">The text used for filtering.</param>
+    /// <param name="disabled">Whether the item is disabled.</param>
+    /// <param name="onSelect">The callback to invoke when the item is selected.</param>
+    public void UpdateItem(int index, string? value, string? searchText, bool disabled, EventCallback onSelect)
+    {
+        if (index >= 0 && index < Items.Count)
+        {
+            Items[index] = new ComboboxItemMetadata
+            {
+                Value = value,
+                SearchText = searchText,
+                Disabled = disabled,
+                OnSelect = onSelect
+            };
+            InvalidateFilterCache();
+        }
+    }
+
+    /// <summary>
     /// Unregisters an item from the combobox context.
     /// </summary>
     /// <param name="index">The index of the item to unregister.</param>

--- a/src/BlazorUI.Primitives/Primitives/Combobox/ComboboxItem.razor
+++ b/src/BlazorUI.Primitives/Primitives/Combobox/ComboboxItem.razor
@@ -86,6 +86,24 @@
         UpdateVisibility();
     }
 
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        // Update registration when parameters change (especially OnSelect callback)
+        // This ensures callbacks stay current when parent re-renders with new lambdas
+        if (_index >= 0 && Context != null)
+        {
+            Context.UpdateItem(
+                index: _index,
+                value: Value,
+                searchText: SearchText ?? Value,
+                disabled: Disabled,
+                onSelect: OnSelect
+            );
+        }
+    }
+
     private async Task HandleClick()
     {
         if (Disabled) return;


### PR DESCRIPTION
## Summary

Fix for MultiSelect component where subsequent selections don't work after the first selection.

## Root Cause

`ComboboxItem` registered callbacks only in `OnInitialized()`, but parent re-renders create new lambda closures that were never propagated to the Context. Subsequent selections invoked stale callbacks with outdated closure state.

## Changes

- **ComboboxContext.cs**: Add `UpdateItem()` method to update existing item registrations
- **ComboboxItem.razor**: Add `OnParametersSet()` lifecycle method to refresh callbacks when parent re-renders

## Test Plan

- [ ] Single MultiSelect: First selection works
- [ ] Single MultiSelect: Subsequent selections work
- [ ] Multiple MultiSelects on same page work independently
- [ ] Selecting in one doesn't break others
- [ ] Search/filter still works after selections
- [ ] Keyboard navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)