### PR TITLE
fix: prevent infinite loops with nested portals

### DIFF
--- a/demo/BlazorUI.Demo/Pages/Components/DialogDemo.razor
+++ b/demo/BlazorUI.Demo/Pages/Components/DialogDemo.razor
@@ -1,5 +1,6 @@
 @page "/components/dialog"
 @using BlazorUI.Components.Dialog
+@using BlazorUI.Components.Combobox
 
 <PageTitle>Dialog Component - BlazorUI</PageTitle>
 
@@ -274,6 +275,53 @@
     </div>
 
     <div class="space-y-4">
+        <h2 class="text-2xl font-semibold">Combobox in Dialog</h2>
+        <p class="text-sm text-muted-foreground">
+            Dialog containing a Combobox for selecting items. Tests nested portal behavior.
+        </p>
+
+        <Dialog>
+            <DialogTrigger class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
+                Open Dialog with Combobox
+            </DialogTrigger>
+
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Select a Framework</DialogTitle>
+                    <DialogDescription>
+                        Use the combobox below to search and select a framework.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div class="py-4">
+                    <Combobox TItem="ComboboxFramework"
+                             Items="comboboxFrameworks"
+                             @bind-Value="selectedComboboxFramework"
+                             ValueSelector="@(f => f.Value)"
+                             DisplaySelector="@(f => f.Label)"
+                             Placeholder="Select framework..."
+                             SearchPlaceholder="Search framework..."
+                             EmptyMessage="No framework found."
+                             PopoverWidth="w-[300px]" />
+                    @if (!string.IsNullOrEmpty(selectedComboboxFramework))
+                    {
+                        <p class="text-sm mt-2">Selected: <strong>@GetComboboxFrameworkLabel(selectedComboboxFramework)</strong></p>
+                    }
+                </div>
+
+                <DialogFooter>
+                    <BlazorUI.Primitives.Dialog.DialogClose class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">
+                        Cancel
+                    </BlazorUI.Primitives.Dialog.DialogClose>
+                    <button class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
+                        Confirm Selection
+                    </button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    </div>
+
+    <div class="space-y-4">
         <h2 class="text-2xl font-semibold">Features</h2>
         <ul class="list-disc list-inside space-y-2 text-sm">
             <li>Full keyboard navigation support</li>
@@ -317,10 +365,31 @@
 
 @code {
     private bool isDialogOpen = false;
+    private string? selectedComboboxFramework;
+
+    private readonly List<ComboboxFramework> comboboxFrameworks = new()
+    {
+        new ComboboxFramework { Value = "blazor", Label = "Blazor" },
+        new ComboboxFramework { Value = "react", Label = "React" },
+        new ComboboxFramework { Value = "vue", Label = "Vue" },
+        new ComboboxFramework { Value = "angular", Label = "Angular" },
+        new ComboboxFramework { Value = "svelte", Label = "Svelte" },
+        new ComboboxFramework { Value = "nextjs", Label = "Next.js" },
+        new ComboboxFramework { Value = "nuxt", Label = "Nuxt" }
+    };
 
     private void HandleSave()
     {
         // Handle save logic
         isDialogOpen = false;
+    }
+
+    private string GetComboboxFrameworkLabel(string? value) =>
+        comboboxFrameworks.FirstOrDefault(f => f.Value == value)?.Label ?? value ?? "";
+
+    public class ComboboxFramework
+    {
+        public required string Value { get; set; }
+        public required string Label { get; set; }
     }
 }

--- a/src/BlazorUI.Primitives/Primitives/Dialog/DialogPortal.razor
+++ b/src/BlazorUI.Primitives/Primitives/Dialog/DialogPortal.razor
@@ -61,14 +61,14 @@
         // Update portal registration based on open state
         if (Context.IsOpen || ForceMount)
         {
-            if (_isRegistered)
-            {
-                UpdatePortal();
-            }
-            else
+            if (!_isRegistered)
             {
                 RegisterPortal();
             }
+            // Note: We do NOT call UpdatePortal() here because it would cause infinite loops
+            // when nested portals (like Combobox inside Dialog) are used. The RenderFragment
+            // returned by GetPortalContent() captures ChildContent by reference, so when
+            // PortalHost renders, it will always use the latest content.
         }
         else
         {
@@ -87,14 +87,6 @@
         {
             PortalService.RegisterPortal(_portalId, GetPortalContent());
             _isRegistered = true;
-        }
-    }
-
-    private void UpdatePortal()
-    {
-        if (_isRegistered && ChildContent != null)
-        {
-            PortalService.UpdatePortalContent(_portalId, GetPortalContent());
         }
     }
 

--- a/src/BlazorUI.Primitives/Primitives/Popover/PopoverContent.razor
+++ b/src/BlazorUI.Primitives/Primitives/Popover/PopoverContent.razor
@@ -114,12 +114,10 @@
     {
         base.OnParametersSet();
 
-        // Update portal content when parameters change (e.g., ChildContent)
-        // This ensures the portal reflects the latest content from the parent
-        if (_isInitialized && Context.IsOpen && !string.IsNullOrEmpty(_portalId))
-        {
-            PortalService.UpdatePortalContent(_portalId, RenderPopoverContent());
-        }
+        // Note: We do NOT call UpdatePortalContent() here because it would cause infinite loops
+        // when nested portals (like Combobox inside Dialog) are used. The RenderFragment
+        // returned by RenderPopoverContent() captures ChildContent by reference, so when
+        // PortalHost renders, it will always use the latest content.
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)


### PR DESCRIPTION
## Summary
- Remove `UpdatePortalContent()` calls from `DialogPortal` and `PopoverContent` that caused infinite render loops when nested portals (like Combobox inside Dialog) were used
- The RenderFragment captures ChildContent by reference, so PortalHost always uses the latest content without explicit updates
- Adds demo example showing Combobox inside Dialog

## Test plan
- [ ] Open Dialog demo page and test the new "Combobox in Dialog" example
- [ ] Verify no infinite loops or console errors occur
- [ ] Confirm Combobox functions correctly inside the Dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)