### PR TITLE
fix: add global fallback for Floating UI loading

### DIFF
--- a/src/BlazorUI.Primitives/wwwroot/js/primitives/positioning.js
+++ b/src/BlazorUI.Primitives/wwwroot/js/primitives/positioning.js
@@ -35,10 +35,16 @@ const cleanupRegistry = new Map();
 let cleanupIdCounter = 0;
 
 /**
- * Lazy loads Floating UI from CDN with local fallback
+ * Lazy loads Floating UI from preloaded global or CDN with fallback
  */
 async function loadFloatingUI() {
     if (floatingUI) return floatingUI;
+
+    // Check for preloaded global first (from App.razor script)
+    if (window.FloatingUIDOM) {
+        floatingUI = window.FloatingUIDOM;
+        return floatingUI;
+    }
 
     try {
         // Try CDN first


### PR DESCRIPTION
## Summary

- Adds check for preloaded `window.FloatingUIDOM` global before attempting CDN dynamic import
- Enables Blazor Server compatibility where dynamic ES module imports may fail
- Allows users to bundle Floating UI locally or preload it via script tag

## Changes

The `loadFloatingUI()` function in `positioning.js` now checks for a preloaded global first:

```javascript
// Check for preloaded global first (from App.razor script)
if (window.FloatingUIDOM) {
    floatingUI = window.FloatingUIDOM;
    return floatingUI;
}
```

This maintains full backwards compatibility - if no global is present, it falls back to the existing CDN loading strategy (jsdelivr → unpkg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)