### PR TITLE
fix: prevent Select scroll flash when opening with selected item

### DIFF
--- a/src/BlazorUI.Primitives/Primitives/Select/SelectContent.razor
+++ b/src/BlazorUI.Primitives/Primitives/Select/SelectContent.razor
@@ -130,6 +130,12 @@
     {
         if (_context == null || _jsModule == null) return;
 
+        // CRITICAL: Scroll to selected item FIRST, before any awaits.
+        // This ensures the scroll position is set before the rAF visibility callback
+        // from FloatingPortal's ApplyPositionAsync can paint the visible content.
+        var selectedValue = _context.State.Value?.ToString();
+        await _jsModule.InvokeVoidAsync("focusInitialOption", _context.ContentId, selectedValue);
+
         // Focus the selected item or first item (updates Blazor state)
         _context.FocusSelectedOrFirst();
 
@@ -142,10 +148,6 @@
             _dotNetRef = DotNetObjectReference.Create(this);
             await _jsModule.InvokeVoidAsync("setupKeyboardNavigation", _context.ContentId, _dotNetRef);
             _isKeyboardSetup = true;
-
-            // Focus the initially selected option (handles scroll within dropdown)
-            var selectedValue = _context.State.Value?.ToString();
-            await _jsModule.InvokeVoidAsync("focusInitialOption", _context.ContentId, selectedValue);
         }
     }
 


### PR DESCRIPTION
## Summary

- Fixes visual flash when opening a Select with a selected item near the bottom of a long list
- Moves `focusInitialOption` call to execute first in `HandleFloatingReady`, before any async operations
- Ensures scroll position is set before the rAF visibility callback from FloatingPortal can paint content

## Problem

When opening a Select with many items where a selected item is near the bottom, users saw a flash where the first items appeared briefly before the view scrolled to the selected item. This was caused by a race condition between visibility and scroll positioning.

## Solution

Reorder operations in `HandleFloatingReady` to call `focusInitialOption` **first**, before `SetupClickOutsideAsync` or other async calls. This ensures the scroll position is set synchronously in the JS engine before the pending rAF from `applyPosition` can fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)