### PR TITLE
chore: merge release changes from components/v1.9.6

### DIFF
--- a/src/BlazorUI.Components/BlazorUI.Components.csproj
+++ b/src/BlazorUI.Components/BlazorUI.Components.csproj
@@ -47,7 +47,7 @@
 
   <ItemGroup Condition="'$(UsePackageReferences)' == 'true'">
     <PackageReference Include="BlazorUI.Icons.Lucide" Version="1.0.0" />
-    <PackageReference Include="BlazorUI.Primitives" Version="1.9.3" />
+    <PackageReference Include="BlazorUI.Primitives" Version="1.9.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Release Changes

This PR merges changes made during the release of **BlazorUI.Components v1.9.6** back to main.

**Commits made during release:** 1

### Changes included:
- 96b6a79 chore: bump BlazorUI.Primitives to 1.9.4

---
*Auto-generated by release script*