### PR TITLE
feat: add Href and Target parameters to Button for navigation links

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ButtonDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ButtonDemo.razor
@@ -33,6 +33,48 @@
         </div>
     </div>
 
+    <!-- As Link -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">As Link</h2>
+            <p class="text-sm text-muted-foreground">
+                When <code>Href</code> is provided, the button renders as an <code>&lt;a&gt;</code> element for navigation while preserving all visual styling.
+            </p>
+        </div>
+        <div class="space-y-4">
+            <div class="space-y-2">
+                <h3 class="text-lg font-medium">Navigation Links</h3>
+                <div class="flex flex-wrap gap-4">
+                    <Button Href="/components/badge">Go to Badge</Button>
+                    <Button Href="https://github.com" Target="_blank" Variant="ButtonVariant.Outline" IconPosition="IconPosition.End">
+                        <Icon>
+                            <LucideIcon Name="external-link" Size="16" />
+                        </Icon>
+                        <ChildContent>GitHub</ChildContent>
+                    </Button>
+                </div>
+            </div>
+            <div class="space-y-2">
+                <h3 class="text-lg font-medium">Variants as Links</h3>
+                <div class="flex flex-wrap gap-4">
+                    <Button Href="/components/badge" Variant="ButtonVariant.Default">Default</Button>
+                    <Button Href="/components/badge" Variant="ButtonVariant.Destructive">Destructive</Button>
+                    <Button Href="/components/badge" Variant="ButtonVariant.Outline">Outline</Button>
+                    <Button Href="/components/badge" Variant="ButtonVariant.Secondary">Secondary</Button>
+                    <Button Href="/components/badge" Variant="ButtonVariant.Ghost">Ghost</Button>
+                    <Button Href="/components/badge" Variant="ButtonVariant.Link">Link</Button>
+                </div>
+            </div>
+            <div class="space-y-2">
+                <h3 class="text-lg font-medium">Disabled Links</h3>
+                <div class="flex flex-wrap gap-4">
+                    <Button Href="/components/badge" Disabled="true">Disabled Link</Button>
+                    <Button Href="/components/badge" Disabled="true" Variant="ButtonVariant.Outline">Disabled Outline Link</Button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- All Sizes -->
     <div class="space-y-4">
         <div class="space-y-2">
@@ -245,6 +287,9 @@
             <p>✓ Focus ring appears on keyboard focus (focus-visible:ring-2)</p>
             <p>✓ Color contrast meets WCAG 2.1 AA standards</p>
             <p>✓ Semantic HTML button element with proper role</p>
+            <p>✓ Renders as &lt;a&gt; when Href is provided, preserving link semantics for navigation</p>
+            <p>✓ Disabled links remove href, set aria-disabled, and prevent focus</p>
+            <p>✓ Automatically adds rel="noopener noreferrer" for target="_blank" links</p>
             <p>✓ Screen readers announce button text and state correctly</p>
         </div>
     </div>

--- a/src/BlazorBlueprint.Components/Components/Button/Button.razor
+++ b/src/BlazorBlueprint.Components/Components/Button/Button.razor
@@ -1,31 +1,61 @@
 @namespace BlazorBlueprint.Components.Button
 
-<button
-    type="@HtmlType"
-    class="@CssClass"
-    id="@(TriggerContext?.TriggerId)"
-    @ref="_buttonRef"
-    disabled="@Disabled"
-    tabindex="@(Disabled ? -1 : 0)"
-    aria-label="@AriaLabel"
-    aria-disabled="@Disabled.ToString().ToLower()"
-    aria-haspopup="@(TriggerContext?.AriaHasPopup)"
-    aria-expanded="@(TriggerContext != null ? TriggerContext.IsOpen.ToString().ToLower() : null)"
-    aria-controls="@(TriggerContext?.AriaControls)"
-    @onclick="HandleClick"
-    @onkeydown="HandleKeyDown"
-    @onmouseenter="HandleMouseEnter"
-    @onmouseleave="HandleMouseLeave"
-    @onfocus="HandleFocus"
-    @onblur="HandleBlur"
-    @attributes="AdditionalAttributes">
-    @if (Icon != null && IconPosition == IconPosition.Start)
-    {
-        <span class="me-2">@Icon</span>
-    }
-    @ChildContent
-    @if (Icon != null && IconPosition == IconPosition.End)
-    {
-        <span class="ms-2">@Icon</span>
-    }
-</button>
+@if (HasHref)
+{
+    <a href="@(Disabled ? null : Href)"
+       target="@Target"
+       rel="@Rel"
+       class="@CssClass"
+       tabindex="@(Disabled ? -1 : 0)"
+       aria-label="@AriaLabel"
+       aria-disabled="@(Disabled ? "true" : null)"
+       @onclick="HandleClick"
+       @onkeydown="HandleKeyDown"
+       @onmouseenter="HandleMouseEnter"
+       @onmouseleave="HandleMouseLeave"
+       @onfocus="HandleFocus"
+       @onblur="HandleBlur"
+       @attributes="AdditionalAttributes">
+        @if (Icon != null && IconPosition == IconPosition.Start)
+        {
+            <span class="me-2">@Icon</span>
+        }
+        @ChildContent
+        @if (Icon != null && IconPosition == IconPosition.End)
+        {
+            <span class="ms-2">@Icon</span>
+        }
+    </a>
+}
+else
+{
+    <button
+        type="@HtmlType"
+        class="@CssClass"
+        id="@(TriggerContext?.TriggerId)"
+        @ref="_buttonRef"
+        disabled="@Disabled"
+        tabindex="@(Disabled ? -1 : 0)"
+        aria-label="@AriaLabel"
+        aria-disabled="@Disabled.ToString().ToLower()"
+        aria-haspopup="@(TriggerContext?.AriaHasPopup)"
+        aria-expanded="@(TriggerContext != null ? TriggerContext.IsOpen.ToString().ToLower() : null)"
+        aria-controls="@(TriggerContext?.AriaControls)"
+        @onclick="HandleClick"
+        @onkeydown="HandleKeyDown"
+        @onmouseenter="HandleMouseEnter"
+        @onmouseleave="HandleMouseLeave"
+        @onfocus="HandleFocus"
+        @onblur="HandleBlur"
+        @attributes="AdditionalAttributes">
+        @if (Icon != null && IconPosition == IconPosition.Start)
+        {
+            <span class="me-2">@Icon</span>
+        }
+        @ChildContent
+        @if (Icon != null && IconPosition == IconPosition.End)
+        {
+            <span class="ms-2">@Icon</span>
+        }
+    </button>
+}

--- a/src/BlazorBlueprint.Components/Components/Button/Button.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Button/Button.razor.cs
@@ -140,6 +140,18 @@ public partial class Button : ComponentBase
     public IconPosition IconPosition { get; set; } = IconPosition.Start;
 
     /// <summary>
+    /// Gets or sets the URL to navigate to. When set, the component renders as an &lt;a&gt; element instead of &lt;button&gt;.
+    /// </summary>
+    [Parameter]
+    public string? Href { get; set; }
+
+    /// <summary>
+    /// Gets or sets the anchor target attribute (e.g., "_blank"). Only applies when <see cref="Href"/> is set.
+    /// </summary>
+    [Parameter]
+    public string? Target { get; set; }
+
+    /// <summary>
     /// Gets or sets additional HTML attributes to apply to the button element.
     /// </summary>
     /// <remarks>
@@ -164,6 +176,16 @@ public partial class Button : ComponentBase
     /// Reference to the button element for positioning support when used with AsChild.
     /// </summary>
     private ElementReference _buttonRef;
+
+    /// <summary>
+    /// Gets whether the component should render as an anchor element.
+    /// </summary>
+    private bool HasHref => !string.IsNullOrEmpty(Href);
+
+    /// <summary>
+    /// Gets the rel attribute value. Returns "noopener noreferrer" when Target is "_blank" for security.
+    /// </summary>
+    private string? Rel => Target == "_blank" ? "noopener noreferrer" : null;
 
     /// <summary>
     /// Gets the computed CSS classes for the button element.
@@ -204,6 +226,8 @@ public partial class Button : ComponentBase
             ButtonSize.IconLarge => "h-11 w-11",
             _ => "h-10 px-4 py-2"
         },
+        // Disabled anchor styles (`:disabled` pseudo-class doesn't work on `<a>` elements)
+        HasHref && Disabled ? "pointer-events-none opacity-50" : null,
         // Custom classes (if provided)
         Class
     );


### PR DESCRIPTION
## Summary

- Add `Href` and `Target` parameters to the Button component so it renders as an `<a>` element for navigation while preserving all visual styling (variants, sizes, icons)
- Auto-apply `rel="noopener noreferrer"` when `Target="_blank"` for security
- Accessible disabled state: removes `href`, sets `aria-disabled="true"`, prevents focus via `tabindex="-1"`, and applies CSS dimming (`pointer-events-none opacity-50`) since `:disabled` doesn't work on `<a>` elements
- Add "As Link" demo section with internal navigation, external links, variant links, and disabled link states

Closes #64