### PR TITLE
fix: resolve coding standard errors in Timeline and TailwindMerge

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Timeline/Timeline.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Timeline/Timeline.razor.cs
@@ -75,10 +75,8 @@ public partial class Timeline : ComponentBase
     /// </summary>
     internal int RegisterItem() => _itemCounter++;
 
-    protected override void OnParametersSet()
-    {
+    protected override void OnParametersSet() =>
         _itemCounter = 0;
-    }
 
     private string CssClass => ClassNames.cn(
         // Base styles

--- a/src/BlazorBlueprint.Components/Components/Timeline/TimelineItem.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Timeline/TimelineItem.razor.cs
@@ -120,10 +120,8 @@ public partial class TimelineItem : ComponentBase
 
     private bool IsReversed => Align == TimelineAlign.Alternate && _itemIndex % 2 != 0;
 
-    protected override void OnInitialized()
-    {
+    protected override void OnInitialized() =>
         _itemIndex = ParentTimeline?.RegisterItem() ?? 0;
-    }
 
     private string CssClass => ClassNames.cn(
         "relative w-full",

--- a/src/BlazorBlueprint.Components/Utilities/TailwindMerge.cs
+++ b/src/BlazorBlueprint.Components/Utilities/TailwindMerge.cs
@@ -302,7 +302,9 @@ public static class TailwindMerge
         // Check directional border width (border-l-2, border-t-4, etc.)
         var borderSideMatch = BorderSideWidthRegex.Match(className);
         if (borderSideMatch.Success)
+        {
             return $"border-{borderSideMatch.Groups[1].Value}-width";
+        }
 
         // Check opacity
         if (OpacityRegex.IsMatch(className))


### PR DESCRIPTION
## Summary
- Convert `OnInitialized()` and `OnParametersSet()` to expression bodies in Timeline components (IDE0022)
- Add braces to `if` statement in TailwindMerge border-side-width check (IDE0011)

## Test plan
- [x] Build passes with 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)