### PR TITLE
fix: migrate all components to ClassNames.cn() for TailwindMerge support

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Accordion/Accordion.razor
+++ b/src/BlazorBlueprint.Components/Components/Accordion/Accordion.razor
@@ -66,5 +66,5 @@
     [Parameter]
     public string? Class { get; set; }
 
-    private string CssClass => $"{Class}".Trim();
+    private string? CssClass => ClassNames.cn(Class);
 }

--- a/src/BlazorBlueprint.Components/Components/Accordion/AccordionContent.razor
+++ b/src/BlazorBlueprint.Components/Components/Accordion/AccordionContent.razor
@@ -36,6 +36,9 @@
     [Parameter]
     public string? Class { get; set; }
 
-    private string CssClass =>
-        $"grid grid-rows-[0fr] transition-[grid-template-rows] duration-200 ease-out data-[state=open]:grid-rows-[1fr] {Class}".Trim();
+    private string CssClass => ClassNames.cn(
+        "grid grid-rows-[0fr] transition-[grid-template-rows] duration-200 ease-out",
+        "data-[state=open]:grid-rows-[1fr]",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Accordion/AccordionItem.razor
+++ b/src/BlazorBlueprint.Components/Components/Accordion/AccordionItem.razor
@@ -37,6 +37,5 @@
     [Parameter]
     public string? Class { get; set; }
 
-    private string CssClass =>
-        $"border-b {Class}".Trim();
+    private string CssClass => ClassNames.cn("border-b", Class);
 }

--- a/src/BlazorBlueprint.Components/Components/Avatar/Avatar.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Avatar/Avatar.razor.cs
@@ -1,5 +1,5 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
-using System.Text;
 
 namespace BlazorBlueprint.Components.Avatar;
 
@@ -75,32 +75,16 @@ public partial class Avatar : ComponentBase
     /// - Size-specific classes (dimensions, font-size)
     /// - Custom classes from the Class parameter
     /// </remarks>
-    private string CssClass
-    {
-        get
+    private string CssClass => ClassNames.cn(
+        "relative flex shrink-0 overflow-hidden rounded-full",
+        Size switch
         {
-            var builder = new StringBuilder();
-
-            // Base avatar styles (from shadcn/ui)
-            builder.Append("relative flex shrink-0 overflow-hidden rounded-full ");
-
-            // Size-specific styles
-            builder.Append(Size switch
-            {
-                AvatarSize.Small => "h-8 w-8 text-xs ",
-                AvatarSize.Default => "h-10 w-10 text-sm ",
-                AvatarSize.Large => "h-12 w-12 text-base ",
-                AvatarSize.ExtraLarge => "h-16 w-16 text-lg ",
-                _ => "h-10 w-10 text-sm "
-            });
-
-            // Custom classes (if provided)
-            if (!string.IsNullOrWhiteSpace(Class))
-            {
-                builder.Append(Class);
-            }
-
-            return builder.ToString().Trim();
-        }
-    }
+            AvatarSize.Small => "h-8 w-8 text-xs",
+            AvatarSize.Default => "h-10 w-10 text-sm",
+            AvatarSize.Large => "h-12 w-12 text-base",
+            AvatarSize.ExtraLarge => "h-16 w-16 text-lg",
+            _ => "h-10 w-10 text-sm"
+        },
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Avatar/AvatarFallback.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Avatar/AvatarFallback.razor.cs
@@ -1,5 +1,5 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
-using System.Text;
 
 namespace BlazorBlueprint.Components.Avatar;
 
@@ -70,23 +70,9 @@ public partial class AvatarFallback : ComponentBase
     /// - Background and text colors from design system
     /// - Font weight for initials
     /// </remarks>
-    private string CssClass
-    {
-        get
-        {
-            var builder = new StringBuilder();
-
-            // Base fallback styles (from shadcn/ui)
-            builder.Append("flex h-full w-full items-center justify-center rounded-full ");
-            builder.Append("bg-muted text-muted-foreground font-medium ");
-
-            // Custom classes (if provided)
-            if (!string.IsNullOrWhiteSpace(Class))
-            {
-                builder.Append(Class);
-            }
-
-            return builder.ToString().Trim();
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "flex h-full w-full items-center justify-center rounded-full",
+        "bg-muted text-muted-foreground font-medium",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Avatar/AvatarImage.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Avatar/AvatarImage.razor.cs
@@ -1,5 +1,5 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
-using System.Text;
 
 namespace BlazorBlueprint.Components.Avatar;
 
@@ -67,25 +67,10 @@ public partial class AvatarImage : ComponentBase
     /// Applies styles for proper sizing, positioning, and rendering
     /// within the circular avatar container.
     /// </remarks>
-    private string CssClass
-    {
-        get
-        {
-            var builder = new StringBuilder();
-
-            // Base image styles (from shadcn/ui)
-            // Use absolute positioning to overlay the fallback
-            builder.Append("absolute inset-0 aspect-square h-full w-full object-cover ");
-
-            // Custom classes (if provided)
-            if (!string.IsNullOrWhiteSpace(Class))
-            {
-                builder.Append(Class);
-            }
-
-            return builder.ToString().Trim();
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "absolute inset-0 aspect-square h-full w-full object-cover",
+        Class
+    );
 
     private bool isLoaded = true;
     private bool hasError;

--- a/src/BlazorBlueprint.Components/Components/Breadcrumb/Breadcrumb.razor
+++ b/src/BlazorBlueprint.Components/Components/Breadcrumb/Breadcrumb.razor
@@ -13,5 +13,5 @@
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
-    private string CssClass => Class ?? string.Empty;
+    private string? CssClass => ClassNames.cn(Class);
 }

--- a/src/BlazorBlueprint.Components/Components/Checkbox/Checkbox.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Checkbox/Checkbox.razor.cs
@@ -1,7 +1,7 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace BlazorBlueprint.Components.Checkbox;
 
@@ -160,37 +160,14 @@ public partial class Checkbox : ComponentBase
     /// - Focus ring for keyboard navigation
     /// - Custom classes from the Class parameter
     /// </remarks>
-    private string CssClass
-    {
-        get
-        {
-            var builder = new StringBuilder();
-
-            // Base checkbox styles (from shadcn/ui)
-            builder.Append("peer h-4 w-4 shrink-0 rounded-sm border border-primary ");
-            builder.Append("ring-offset-background focus-visible:outline-none focus-visible:ring-2 ");
-            builder.Append("focus-visible:ring-ring focus-visible:ring-offset-2 ");
-            builder.Append("disabled:cursor-not-allowed disabled:opacity-50 ");
-
-            // Checked or indeterminate state styling
-            if (Checked || Indeterminate)
-            {
-                builder.Append("bg-primary text-primary-foreground ");
-            }
-            else
-            {
-                builder.Append("bg-background ");
-            }
-
-            // Custom classes (if provided)
-            if (!string.IsNullOrWhiteSpace(Class))
-            {
-                builder.Append(Class);
-            }
-
-            return builder.ToString().Trim();
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "peer h-4 w-4 shrink-0 rounded-sm border border-primary",
+        "ring-offset-background focus-visible:outline-none focus-visible:ring-2",
+        "focus-visible:ring-ring focus-visible:ring-offset-2",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        (Checked || Indeterminate) ? "bg-primary text-primary-foreground" : "bg-background",
+        Class
+    );
 
     /// <summary>
     /// Handles the checked state change and notifies EditContext for form validation.

--- a/src/BlazorBlueprint.Components/Components/Collapsible/Collapsible.razor
+++ b/src/BlazorBlueprint.Components/Components/Collapsible/Collapsible.razor
@@ -4,6 +4,6 @@
 <BlazorBlueprint.Primitives.Collapsible.Collapsible Open="@_isOpen"
                       OpenChanged="@HandleOpenChanged"
                       Disabled="@Disabled"
-                      class="@Class">
+                      class="@CssClass">
     @ChildContent
 </BlazorBlueprint.Primitives.Collapsible.Collapsible>

--- a/src/BlazorBlueprint.Components/Components/Collapsible/Collapsible.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Collapsible/Collapsible.razor.cs
@@ -1,3 +1,4 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
 
 namespace BlazorBlueprint.Components.Collapsible;
@@ -172,6 +173,8 @@ public partial class Collapsible : ComponentBase
             _isOpen = Open;
         }
     }
+
+    private string? CssClass => ClassNames.cn(Class);
 
     private async Task HandleOpenChanged(bool newValue)
     {

--- a/src/BlazorBlueprint.Components/Components/Collapsible/CollapsibleContent.razor
+++ b/src/BlazorBlueprint.Components/Components/Collapsible/CollapsibleContent.razor
@@ -2,7 +2,7 @@
 
 <BlazorBlueprint.Primitives.Collapsible.CollapsibleContent ForceMount="true" class="@GridCssClass">
     <div class="overflow-hidden min-h-0">
-        <div class="@Class">
+        <div class="@CssClass">
             @ChildContent
         </div>
     </div>

--- a/src/BlazorBlueprint.Components/Components/Collapsible/CollapsibleContent.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Collapsible/CollapsibleContent.razor.cs
@@ -1,3 +1,4 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
 
 namespace BlazorBlueprint.Components.Collapsible;
@@ -94,6 +95,8 @@ public partial class CollapsibleContent : ComponentBase
     /// These classes are applied to the outer container to enable smooth height transitions.
     /// User's custom classes are applied to an inner wrapper to avoid padding affecting the grid collapse.
     /// </remarks>
+    private string? CssClass => ClassNames.cn(Class);
+
     private static string GridCssClass =>
         "grid grid-rows-[0fr] transition-[grid-template-rows] duration-200 ease-out data-[state=open]:grid-rows-[1fr]";
 }

--- a/src/BlazorBlueprint.Components/Components/Collapsible/CollapsibleTrigger.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Collapsible/CollapsibleTrigger.razor.cs
@@ -1,3 +1,4 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
 
 namespace BlazorBlueprint.Components.Collapsible;
@@ -86,16 +87,5 @@ public partial class CollapsibleTrigger : ComponentBase
     /// <value>
     /// A string containing all CSS classes to be applied to the button element.
     /// </value>
-    private string CssClass
-    {
-        get
-        {
-            var classes = new List<string> { "group" };
-            if (!string.IsNullOrWhiteSpace(Class))
-            {
-                classes.Add(Class);
-            }
-            return string.Join(" ", classes);
-        }
-    }
+    private string CssClass => ClassNames.cn("group", Class);
 }

--- a/src/BlazorBlueprint.Components/Components/Combobox/Combobox.razor
+++ b/src/BlazorBlueprint.Components/Components/Combobox/Combobox.razor
@@ -12,7 +12,7 @@
                            aria-controls="@($"{Id}-listbox")"
                            aria-haspopup="listbox"
                            disabled="@Disabled"
-                           class="@($"{ButtonCssClass} {Class}")">
+                           class="@ButtonCssClass">
                 <span class="@(string.IsNullOrWhiteSpace(Value) ? "text-muted-foreground" : "")">
                     @SelectedDisplayText
                 </span>

--- a/src/BlazorBlueprint.Components/Components/Combobox/Combobox.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Combobox/Combobox.razor.cs
@@ -1,4 +1,5 @@
 using BlazorBlueprint.Components.Command;
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
 
 namespace BlazorBlueprint.Components.Combobox;
@@ -269,26 +270,14 @@ public partial class Combobox<TItem> : ComponentBase
     /// <summary>
     /// Gets the CSS class for the button element (styled like ButtonVariant.Outline).
     /// </summary>
-    private string ButtonCssClass
-    {
-        get
-        {
-            // Base button styles matching Button component
-            var baseStyles = "inline-flex items-center justify-between rounded-md text-sm font-medium " +
-                           "transition-colors focus-visible:outline-none focus-visible:ring-2 " +
-                           "focus-visible:ring-ring focus-visible:ring-offset-2 " +
-                           "disabled:opacity-50 disabled:pointer-events-none ";
-
-            // Outline variant styles (matching ButtonVariant.Outline)
-            var variantStyles = "border border-input bg-background hover:bg-accent hover:text-accent-foreground ";
-
-            // Size styles (matching ButtonSize.Small for more compact appearance)
-            var sizeStyles = "h-9 px-3 ";
-
-            // Default width (can be overridden by Class parameter)
-            var defaultWidth = string.IsNullOrWhiteSpace(Class) ? PopoverWidth : "";
-
-            return $"{baseStyles}{variantStyles}{sizeStyles}{defaultWidth}".Trim();
-        }
-    }
+    private string ButtonCssClass => ClassNames.cn(
+        "inline-flex items-center justify-between rounded-md text-sm font-medium",
+        "transition-colors focus-visible:outline-none focus-visible:ring-2",
+        "focus-visible:ring-ring focus-visible:ring-offset-2",
+        "disabled:opacity-50 disabled:pointer-events-none",
+        "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        "h-9 px-3",
+        string.IsNullOrWhiteSpace(Class) ? PopoverWidth : null,
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Command/CommandEmpty.razor
+++ b/src/BlazorBlueprint.Components/Components/Command/CommandEmpty.razor
@@ -29,14 +29,10 @@
     /// <summary>
     /// Gets the computed CSS classes for the empty state container.
     /// </summary>
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "py-6 text-center text-sm text-muted-foreground";
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "py-6 text-center text-sm text-muted-foreground",
+        Class
+    );
 
     protected override void OnInitialized()
     {

--- a/src/BlazorBlueprint.Components/Components/Command/CommandGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Command/CommandGroup.razor
@@ -49,14 +49,13 @@
     /// <summary>
     /// Gets the computed CSS classes for the group container.
     /// </summary>
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "overflow-hidden p-1 text-foreground [&_[data-command-group-heading]]:px-2 [&_[data-command-group-heading]]:py-1.5 [&_[data-command-group-heading]]:text-xs [&_[data-command-group-heading]]:font-medium [&_[data-command-group-heading]]:text-muted-foreground";
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "overflow-hidden p-1 text-foreground",
+        "[&_[data-command-group-heading]]:px-2 [&_[data-command-group-heading]]:py-1.5",
+        "[&_[data-command-group-heading]]:text-xs [&_[data-command-group-heading]]:font-medium",
+        "[&_[data-command-group-heading]]:text-muted-foreground",
+        Class
+    );
 
     protected override void OnInitialized()
     {

--- a/src/BlazorBlueprint.Components/Components/Command/CommandInput.razor
+++ b/src/BlazorBlueprint.Components/Components/Command/CommandInput.razor
@@ -78,14 +78,10 @@
     /// <summary>
     /// Gets the computed CSS classes for the input container.
     /// </summary>
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "flex items-center border-b border-border px-3";
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "flex items-center border-b border-border px-3",
+        Class
+    );
 
     protected override void OnParametersSet()
     {

--- a/src/BlazorBlueprint.Components/Components/Command/CommandList.razor
+++ b/src/BlazorBlueprint.Components/Components/Command/CommandList.razor
@@ -26,12 +26,8 @@
     /// <summary>
     /// Gets the computed CSS classes for the list container.
     /// </summary>
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "max-h-[300px] overflow-y-auto overflow-x-hidden";
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "max-h-[300px] overflow-y-auto overflow-x-hidden",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Command/CommandSeparator.razor
+++ b/src/BlazorBlueprint.Components/Components/Command/CommandSeparator.razor
@@ -22,14 +22,10 @@
     /// <summary>
     /// Gets the computed CSS classes for the separator.
     /// </summary>
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "-mx-1 h-px bg-border";
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "-mx-1 h-px bg-border",
+        Class
+    );
 
     protected override void OnInitialized()
     {

--- a/src/BlazorBlueprint.Components/Components/Command/CommandShortcut.razor
+++ b/src/BlazorBlueprint.Components/Components/Command/CommandShortcut.razor
@@ -20,12 +20,8 @@
     /// <summary>
     /// Gets the computed CSS classes for the shortcut.
     /// </summary>
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "ml-auto text-xs tracking-widest text-muted-foreground";
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Command/CommandVirtualizedGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Command/CommandVirtualizedGroup.razor
@@ -237,14 +237,10 @@
         StateHasChanged();
     }
 
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "p-1 text-foreground";
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "p-1 text-foreground",
+        Class
+    );
 
     private string GetItemId(int index) => $"vgroup-{_id}-item-{index}";
 

--- a/src/BlazorBlueprint.Components/Components/Dialog/DialogDescription.razor
+++ b/src/BlazorBlueprint.Components/Components/Dialog/DialogDescription.razor
@@ -5,7 +5,7 @@
     Styled DialogDescription component with shadcn/ui classes.
 *@
 
-<BlazorBlueprint.Primitives.Dialog.DialogDescription class="@GetClassNames()" @attributes="AdditionalAttributes">
+<BlazorBlueprint.Primitives.Dialog.DialogDescription class="@CssClass" @attributes="AdditionalAttributes">
     @ChildContent
 </BlazorBlueprint.Primitives.Dialog.DialogDescription>
 
@@ -28,19 +28,8 @@
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string GetClassNames()
-    {
-        var classes = new List<string>
-        {
-            "text-sm",
-            "text-muted-foreground"
-        };
-
-        if (!string.IsNullOrWhiteSpace(Class))
-        {
-            classes.Add(Class);
-        }
-
-        return string.Join(" ", classes);
-    }
+    private string CssClass => ClassNames.cn(
+        "text-sm text-muted-foreground",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Dialog/DialogFooter.razor
+++ b/src/BlazorBlueprint.Components/Components/Dialog/DialogFooter.razor
@@ -4,7 +4,7 @@
     DialogFooter helper component for organizing dialog action buttons.
 *@
 
-<div class="@GetClassNames()">
+<div class="@CssClass">
     @ChildContent
 </div>
 
@@ -21,22 +21,8 @@
     [Parameter]
     public string? Class { get; set; }
 
-    private string GetClassNames()
-    {
-        var classes = new List<string>
-        {
-            "flex",
-            "flex-col-reverse",
-            "sm:flex-row",
-            "sm:justify-end",
-            "sm:space-x-2"
-        };
-
-        if (!string.IsNullOrWhiteSpace(Class))
-        {
-            classes.Add(Class);
-        }
-
-        return string.Join(" ", classes);
-    }
+    private string CssClass => ClassNames.cn(
+        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Dialog/DialogHeader.razor
+++ b/src/BlazorBlueprint.Components/Components/Dialog/DialogHeader.razor
@@ -4,7 +4,7 @@
     DialogHeader helper component for organizing dialog title and description.
 *@
 
-<div class="@GetClassNames()">
+<div class="@CssClass">
     @ChildContent
 </div>
 
@@ -21,22 +21,8 @@
     [Parameter]
     public string? Class { get; set; }
 
-    private string GetClassNames()
-    {
-        var classes = new List<string>
-        {
-            "flex",
-            "flex-col",
-            "space-y-1.5",
-            "text-center",
-            "sm:text-left"
-        };
-
-        if (!string.IsNullOrWhiteSpace(Class))
-        {
-            classes.Add(Class);
-        }
-
-        return string.Join(" ", classes);
-    }
+    private string CssClass => ClassNames.cn(
+        "flex flex-col space-y-1.5 text-center sm:text-left",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Dialog/DialogTitle.razor
+++ b/src/BlazorBlueprint.Components/Components/Dialog/DialogTitle.razor
@@ -5,7 +5,7 @@
     Styled DialogTitle component with shadcn/ui classes.
 *@
 
-<BlazorBlueprint.Primitives.Dialog.DialogTitle class="@GetClassNames()" @attributes="AdditionalAttributes">
+<BlazorBlueprint.Primitives.Dialog.DialogTitle class="@CssClass" @attributes="AdditionalAttributes">
     @ChildContent
 </BlazorBlueprint.Primitives.Dialog.DialogTitle>
 
@@ -28,21 +28,8 @@
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string GetClassNames()
-    {
-        var classes = new List<string>
-        {
-            "text-lg",
-            "font-semibold",
-            "leading-none",
-            "tracking-tight"
-        };
-
-        if (!string.IsNullOrWhiteSpace(Class))
-        {
-            classes.Add(Class);
-        }
-
-        return string.Join(" ", classes);
-    }
+    private string CssClass => ClassNames.cn(
+        "text-lg font-semibold leading-none tracking-tight",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Drawer/DrawerClose.razor
+++ b/src/BlazorBlueprint.Components/Components/Drawer/DrawerClose.razor
@@ -1,6 +1,6 @@
 @namespace BlazorBlueprint.Components.Drawer
 
-<div @onclick="HandleClick" class="@Class">
+<div @onclick="HandleClick" class="@CssClass">
     @ChildContent
 </div>
 
@@ -13,6 +13,8 @@
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    private string? CssClass => ClassNames.cn(Class);
 
     private async Task HandleClick()
     {

--- a/src/BlazorBlueprint.Components/Components/Drawer/DrawerTrigger.razor
+++ b/src/BlazorBlueprint.Components/Components/Drawer/DrawerTrigger.razor
@@ -1,6 +1,6 @@
 @namespace BlazorBlueprint.Components.Drawer
 
-<div @onclick="HandleClick" class="@Class">
+<div @onclick="HandleClick" class="@CssClass">
     @ChildContent
 </div>
 
@@ -13,6 +13,8 @@
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    private string? CssClass => ClassNames.cn(Class);
 
     private async Task HandleClick()
     {

--- a/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuCheckboxItem.razor
+++ b/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuCheckboxItem.razor
@@ -71,23 +71,14 @@
         await CheckedChanged.InvokeAsync(value);
     }
 
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 " +
-                            "text-sm outline-none transition-colors " +
-                            "focus:bg-accent focus:text-accent-foreground " +
-                            "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50";
-
-            if (!Disabled)
-            {
-                baseClasses += " hover:bg-accent hover:text-accent-foreground";
-            }
-
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2",
+        "text-sm outline-none transition-colors",
+        "focus:bg-accent focus:text-accent-foreground",
+        "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+        !Disabled ? "hover:bg-accent hover:text-accent-foreground" : null,
+        Class
+    );
 
     private const string IndicatorClass = "absolute left-2 flex h-3.5 w-3.5 items-center justify-center";
 }

--- a/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuContent.razor
+++ b/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuContent.razor
@@ -110,17 +110,12 @@
     [Parameter]
     public string? Style { get; set; }
 
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover " +
-                            "text-popover-foreground shadow-md " +
-                            "data-[state=open]:animate-in data-[state=closed]:animate-out " +
-                            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 " +
-                            "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95";
-
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover",
+        "text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuGroup.razor
@@ -1,6 +1,6 @@
 @namespace BlazorBlueprint.Components.DropdownMenu
 
-<div class="@Class" role="group">
+<div class="@CssClass" role="group">
     @ChildContent
 </div>
 
@@ -16,4 +16,6 @@
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    private string? CssClass => ClassNames.cn(Class);
 }

--- a/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuItem.razor
+++ b/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuItem.razor
@@ -40,21 +40,12 @@
     [Parameter]
     public bool CloseOnSelect { get; set; } = true;
 
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 " +
-                            "text-sm outline-none transition-colors " +
-                            "focus:bg-accent focus:text-accent-foreground " +
-                            "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50";
-
-            if (!Disabled)
-            {
-                baseClasses += " hover:bg-accent hover:text-accent-foreground";
-            }
-
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5",
+        "text-sm outline-none transition-colors",
+        "focus:bg-accent focus:text-accent-foreground",
+        "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+        !Disabled ? "hover:bg-accent hover:text-accent-foreground" : null,
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuLabel.razor
+++ b/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuLabel.razor
@@ -20,12 +20,8 @@
     /// <summary>
     /// Gets the computed CSS classes for the label.
     /// </summary>
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "px-2 py-1.5 text-sm font-semibold";
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "px-2 py-1.5 text-sm font-semibold",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuSeparator.razor
+++ b/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuSeparator.razor
@@ -12,12 +12,8 @@
     /// <summary>
     /// Gets the computed CSS classes for the separator.
     /// </summary>
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "-mx-1 my-1 h-px bg-muted";
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "-mx-1 my-1 h-px bg-muted",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuShortcut.razor
+++ b/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuShortcut.razor
@@ -20,12 +20,8 @@
     /// <summary>
     /// Gets the computed CSS classes for the shortcut.
     /// </summary>
-    private string CssClass
-    {
-        get
-        {
-            var baseClasses = "ms-auto text-xs tracking-widest opacity-60";
-            return string.IsNullOrWhiteSpace(Class) ? baseClasses : $"{baseClasses} {Class}";
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "ms-auto text-xs tracking-widest opacity-60",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuTrigger.razor
+++ b/src/BlazorBlueprint.Components/Components/DropdownMenu/DropdownMenuTrigger.razor
@@ -2,7 +2,7 @@
 @using BlazorBlueprint.Primitives.DropdownMenu
 
 @* Styled DropdownMenuTrigger - passthrough wrapper without layout interference *@
-<BlazorBlueprint.Primitives.DropdownMenu.DropdownMenuTrigger class="@Class"
+<BlazorBlueprint.Primitives.DropdownMenu.DropdownMenuTrigger class="@CssClass"
                                                             AsChild="@AsChild"
                                                             Disabled="@Disabled"
                                                             OnClick="@OnClick"
@@ -55,4 +55,6 @@
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string? CssClass => ClassNames.cn(Class);
 }

--- a/src/BlazorBlueprint.Components/Components/HoverCard/HoverCardContent.razor
+++ b/src/BlazorBlueprint.Components/Components/HoverCard/HoverCardContent.razor
@@ -45,6 +45,13 @@
     [Parameter]
     public string? Class { get; set; }
 
-    private string CssClass =>
-        $"z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 {Class}".Trim();
+    private string CssClass => ClassNames.cn(
+        "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/HoverCard/HoverCardTrigger.razor
+++ b/src/BlazorBlueprint.Components/Components/HoverCard/HoverCardTrigger.razor
@@ -31,5 +31,5 @@
     [Parameter]
     public string? Class { get; set; }
 
-    private string CssClass => $"{Class}".Trim();
+    private string? CssClass => ClassNames.cn(Class);
 }

--- a/src/BlazorBlueprint.Components/Components/Label/Label.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Label/Label.razor.cs
@@ -1,5 +1,5 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
-using System.Text;
 
 namespace BlazorBlueprint.Components.Label;
 
@@ -128,20 +128,8 @@ public partial class Label : ComponentBase
     /// reduced opacity and cursor-not-allowed styling.
     /// </para>
     /// </remarks>
-    private string CssClass
-    {
-        get
-        {
-            var builder = new StringBuilder();
-            builder.Append("text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70");
-
-            if (!string.IsNullOrWhiteSpace(Class))
-            {
-                builder.Append(' ');
-                builder.Append(Class);
-            }
-
-            return builder.ToString().Trim();
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/MultiSelect/MultiSelect.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/MultiSelect/MultiSelect.razor.cs
@@ -1,9 +1,9 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using System.Linq.Expressions;
-using System.Text;
 
 namespace BlazorBlueprint.Components.MultiSelect;
 
@@ -36,9 +36,7 @@ public partial class MultiSelect<TItem> : ComponentBase, IAsyncDisposable
     private readonly Dictionary<string, Func<Task>> _removeHandlerCache = new();
 
     // Cached CSS class strings to avoid recomputation on every render
-    private string? _cachedTriggerCssClass;
-    private string? _lastPopoverWidth;
-    private string? _lastClass;
+    // TriggerCssClass caching fields removed - ClassNames.cn handles this
 
     /// <summary>
     /// Gets or sets the cascaded EditContext from a parent EditForm.
@@ -632,50 +630,16 @@ public partial class MultiSelect<TItem> : ComponentBase, IAsyncDisposable
     /// Gets the CSS class for the trigger button.
     /// Uses caching to avoid recomputation on every render.
     /// </summary>
-    private string TriggerCssClass
-    {
-        get
-        {
-            // Return cached value if inputs haven't changed
-            if (_cachedTriggerCssClass != null &&
-                _lastPopoverWidth == PopoverWidth &&
-                _lastClass == Class)
-            {
-                return _cachedTriggerCssClass;
-            }
-
-            var builder = new StringBuilder();
-
-            // Base button styles
-            builder.Append("inline-flex items-center justify-between rounded-md text-sm font-medium ");
-            builder.Append("transition-colors focus-visible:outline-none focus-visible:ring-2 ");
-            builder.Append("focus-visible:ring-ring focus-visible:ring-offset-2 ");
-            builder.Append("disabled:opacity-50 disabled:pointer-events-none ");
-
-            // Outline variant styles
-            builder.Append("border border-input bg-background hover:bg-accent hover:text-accent-foreground ");
-
-            // Size styles
-            builder.Append("min-h-9 px-3 py-1.5 ");
-
-            // Width
-            builder.Append(PopoverWidth);
-            builder.Append(' ');
-
-            // Custom classes
-            if (!string.IsNullOrWhiteSpace(Class))
-            {
-                builder.Append(Class);
-            }
-
-            // Cache the result
-            _cachedTriggerCssClass = builder.ToString().Trim();
-            _lastPopoverWidth = PopoverWidth;
-            _lastClass = Class;
-
-            return _cachedTriggerCssClass;
-        }
-    }
+    private string TriggerCssClass => ClassNames.cn(
+        "inline-flex items-center justify-between rounded-md text-sm font-medium",
+        "transition-colors focus-visible:outline-none focus-visible:ring-2",
+        "focus-visible:ring-ring focus-visible:ring-offset-2",
+        "disabled:opacity-50 disabled:pointer-events-none",
+        "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        "min-h-9 px-3 py-1.5",
+        PopoverWidth,
+        Class
+    );
 
     /// <summary>
     /// Gets the CSS class for the tag remove button.

--- a/src/BlazorBlueprint.Components/Components/Pagination/PaginationItem.razor
+++ b/src/BlazorBlueprint.Components/Components/Pagination/PaginationItem.razor
@@ -1,6 +1,6 @@
 @namespace BlazorBlueprint.Components.Pagination
 
-<li class="@Class">
+<li class="@CssClass">
     @ChildContent
 </li>
 
@@ -10,4 +10,6 @@
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    private string? CssClass => ClassNames.cn(Class);
 }

--- a/src/BlazorBlueprint.Components/Components/Popover/PopoverContent.razor
+++ b/src/BlazorBlueprint.Components/Components/Popover/PopoverContent.razor
@@ -63,5 +63,13 @@
     // Otherwise use default w-72 for standard popover width
     private string WidthClass => MatchTriggerWidth ? "w-full" : "w-72";
 
-    private string CssClass => $"z-50 {WidthClass} rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 {Class}".Trim();
+    private string CssClass => ClassNames.cn(
+        "z-50", WidthClass, "rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/RadioGroup/RadioGroup.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/RadioGroup/RadioGroup.razor.cs
@@ -1,3 +1,4 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
@@ -132,20 +133,7 @@ public partial class RadioGroup<TValue> : ComponentBase
     /// <summary>
     /// Gets the computed CSS classes for the radio group container.
     /// </summary>
-    private string CssClass
-    {
-        get
-        {
-            var classes = "grid gap-2";
-
-            if (!string.IsNullOrWhiteSpace(Class))
-            {
-                classes += " " + Class;
-            }
-
-            return classes.Trim();
-        }
-    }
+    private string CssClass => ClassNames.cn("grid gap-2", Class);
 
     /// <summary>
     /// Handles the value change and notifies EditContext for form validation.

--- a/src/BlazorBlueprint.Components/Components/RadioGroup/RadioGroupItem.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/RadioGroup/RadioGroupItem.razor.cs
@@ -1,5 +1,5 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
-using System.Text;
 using BlazorBlueprint.Primitives.RadioGroup;
 
 namespace BlazorBlueprint.Components.RadioGroup;
@@ -104,55 +104,23 @@ public partial class RadioGroupItem<TValue> : ComponentBase
     /// <summary>
     /// Gets the computed CSS classes for the radio item button.
     /// </summary>
-    private string CssClass
-    {
-        get
-        {
-            var builder = new StringBuilder();
-
-            // Base radio button styles (from shadcn/ui)
-            builder.Append("aspect-square h-4 w-4 rounded-full border border-primary ");
-            builder.Append("text-primary ring-offset-background ");
-            builder.Append("focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ");
-            builder.Append("disabled:cursor-not-allowed disabled:opacity-50 ");
-
-            // Layout for centering the inner circle
-            builder.Append("flex items-center justify-center ");
-
-            // Custom classes (if provided)
-            if (!string.IsNullOrWhiteSpace(Class))
-            {
-                builder.Append(Class);
-            }
-
-            return builder.ToString().Trim();
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "aspect-square h-4 w-4 rounded-full border border-primary",
+        "text-primary ring-offset-background",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "flex items-center justify-center",
+        Class
+    );
 
     /// <summary>
     /// Gets the computed CSS classes for the inner circle indicator.
     /// </summary>
-    private string CircleIndicatorClass
-    {
-        get
-        {
-            var builder = new StringBuilder();
-
-            // Inner circle that appears when selected
-            builder.Append("h-2.5 w-2.5 rounded-full bg-current ");
-
-            // Only visible when checked
-            if (!IsChecked)
-            {
-                builder.Append("scale-0 ");
-            }
-
-            // Transition for smooth appearance
-            builder.Append("transition-transform duration-100");
-
-            return builder.ToString().Trim();
-        }
-    }
+    private string CircleIndicatorClass => ClassNames.cn(
+        "h-2.5 w-2.5 rounded-full bg-current",
+        !IsChecked ? "scale-0" : null,
+        "transition-transform duration-100"
+    );
 
     /// <summary>
     /// Focuses this radio item programmatically.

--- a/src/BlazorBlueprint.Components/Components/Separator/Separator.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Separator/Separator.razor.cs
@@ -1,5 +1,5 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
-using System.Text;
 
 namespace BlazorBlueprint.Components.Separator;
 
@@ -79,32 +79,11 @@ public partial class Separator : ComponentBase
     /// - Orientation-specific classes (width/height)
     /// - Custom classes from the Class parameter
     /// </remarks>
-    private string CssClass
-    {
-        get
-        {
-            var builder = new StringBuilder();
-
-            // Base separator styles (from shadcn/ui)
-            builder.Append("shrink-0 bg-border ");
-
-            // Orientation-specific styles
-            if (Orientation == SeparatorOrientation.Horizontal)
-            {
-                builder.Append("h-[1px] w-full ");
-            }
-            else // Vertical
-            {
-                builder.Append("h-full w-[1px] ");
-            }
-
-            // Custom classes (if provided)
-            if (!string.IsNullOrWhiteSpace(Class))
-            {
-                builder.Append(Class);
-            }
-
-            return builder.ToString().Trim();
-        }
-    }
+    private string CssClass => ClassNames.cn(
+        "shrink-0 bg-border",
+        Orientation == SeparatorOrientation.Horizontal
+            ? "h-[1px] w-full"
+            : "h-full w-[1px]",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Skeleton/Skeleton.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Skeleton/Skeleton.razor.cs
@@ -1,5 +1,5 @@
+using BlazorBlueprint.Components.Utilities;
 using Microsoft.AspNetCore.Components;
-using System.Text;
 
 namespace BlazorBlueprint.Components.Skeleton;
 
@@ -95,26 +95,14 @@ public partial class Skeleton : ComponentBase
     /// <item>Custom classes: Any classes provided via the <see cref="Class"/> parameter</item>
     /// </list>
     /// </remarks>
-    private string CssClass
-    {
-        get
+    private string CssClass => ClassNames.cn(
+        "animate-pulse bg-muted",
+        Shape switch
         {
-            var builder = new StringBuilder();
-            builder.Append("animate-pulse bg-muted ");
-
-            builder.Append(Shape switch
-            {
-                SkeletonShape.Circular => "rounded-full ",
-                SkeletonShape.Rectangular => "rounded-md ",
-                _ => "rounded-md "
-            });
-
-            if (!string.IsNullOrWhiteSpace(Class))
-            {
-                builder.Append(Class);
-            }
-
-            return builder.ToString().Trim();
-        }
-    }
+            SkeletonShape.Circular => "rounded-full",
+            SkeletonShape.Rectangular => "rounded-md",
+            _ => "rounded-md"
+        },
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Tabs/Tabs.razor
+++ b/src/BlazorBlueprint.Components/Components/Tabs/Tabs.razor
@@ -6,7 +6,7 @@
     Wraps the Tabs primitive with shadcn/ui styling.
 *@
 
-<div class="@Class" @attributes="AdditionalAttributes">
+<div class="@CssClass" @attributes="AdditionalAttributes">
     <BlazorBlueprint.Primitives.Tabs.Tabs Value="@Value"
                                    ValueChanged="@ValueChanged"
                                    DefaultValue="@DefaultValue"
@@ -76,4 +76,6 @@
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string? CssClass => ClassNames.cn(Class);
 }

--- a/src/BlazorBlueprint.Components/Components/Tabs/TabsContent.razor
+++ b/src/BlazorBlueprint.Components/Components/Tabs/TabsContent.razor
@@ -38,6 +38,9 @@
     [Parameter]
     public string? Class { get; set; }
 
-    private string CssClass =>
-        $"mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 {Class}".Trim();
+    private string CssClass => ClassNames.cn(
+        "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2",
+        "focus-visible:ring-ring focus-visible:ring-offset-2",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Tabs/TabsList.razor
+++ b/src/BlazorBlueprint.Components/Components/Tabs/TabsList.razor
@@ -24,6 +24,8 @@
     [Parameter]
     public string? Class { get; set; }
 
-    private string CssClass =>
-        $"inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground {Class}".Trim();
+    private string CssClass => ClassNames.cn(
+        "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Tabs/TabsTrigger.razor
+++ b/src/BlazorBlueprint.Components/Components/Tabs/TabsTrigger.razor
@@ -38,6 +38,12 @@
     [Parameter]
     public string? Class { get; set; }
 
-    private string CssClass =>
-        $"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm {Class}".Trim();
+    private string CssClass => ClassNames.cn(
+        "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5",
+        "text-sm font-medium ring-offset-background transition-all",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "disabled:pointer-events-none disabled:opacity-50",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Tooltip/TooltipContent.razor
+++ b/src/BlazorBlueprint.Components/Components/Tooltip/TooltipContent.razor
@@ -74,26 +74,18 @@
         }
     }
 
-    private string CssClass
-    {
-        get
+    private string CssClass => ClassNames.cn(
+        "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5",
+        "text-sm text-popover-foreground shadow-md",
+        "animate-in fade-in-0 zoom-in-95 max-w-md",
+        EffectiveSide switch
         {
-            var baseClasses = "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md " +
-                            "animate-in fade-in-0 zoom-in-95 max-w-md";
-
-            // Add slide animation based on effective side
-            var slideClass = EffectiveSide switch
-            {
-                PopoverSide.Top => " slide-in-from-bottom-2",
-                PopoverSide.Bottom => " slide-in-from-top-2",
-                PopoverSide.Left => " slide-in-from-right-2",
-                PopoverSide.Right => " slide-in-from-left-2",
-                _ => " slide-in-from-bottom-2"
-            };
-
-            var result = baseClasses + slideClass;
-
-            return string.IsNullOrWhiteSpace(Class) ? result : $"{result} {Class}";
-        }
-    }
+            PopoverSide.Top => "slide-in-from-bottom-2",
+            PopoverSide.Bottom => "slide-in-from-top-2",
+            PopoverSide.Left => "slide-in-from-right-2",
+            PopoverSide.Right => "slide-in-from-left-2",
+            _ => "slide-in-from-bottom-2"
+        },
+        Class
+    );
 }

--- a/src/BlazorBlueprint.Components/Components/Tooltip/TooltipTrigger.razor
+++ b/src/BlazorBlueprint.Components/Components/Tooltip/TooltipTrigger.razor
@@ -70,5 +70,5 @@ else
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
-    private string WrapperClass => string.IsNullOrWhiteSpace(Class) ? "contents" : $"contents {Class}";
+    private string WrapperClass => ClassNames.cn("contents", Class);
 }


### PR DESCRIPTION
## Summary
- Migrated all 52 component files across 17 component families from string concatenation/StringBuilder to `ClassNames.cn()` (TailwindMerge)
- Ensures user-provided `Class` overrides properly resolve Tailwind CSS conflicts instead of just appending classes
- Replaced three non-compliant patterns: `$"{baseClasses} {Class}"`, `StringBuilder.Append(Class)`, and direct `class="@Class"` passthrough

## Components Updated
**DropdownMenu** (8), **Command** (7), **Dialog** (4), **Tabs** (4), **Accordion** (3), **Avatar** (3), **Collapsible** (3), **RadioGroup** (2), **Tooltip** (2), **HoverCard** (2), **Drawer** (2), **Skeleton**, **Label**, **Separator**, **Checkbox**, **Combobox**, **MultiSelect**, **PopoverContent**, **Breadcrumb**, **PaginationItem**

## Exceptions
- `ChartBase` (abstract base class, derived charts already use `cn()`)
- `ToastData` (data class, not a visual component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)