### PR TITLE
chore: merge release changes from components/v2.3.0

### DIFF
--- a/src/BlazorBlueprint.Components/BlazorBlueprint.Components.csproj
+++ b/src/BlazorBlueprint.Components/BlazorBlueprint.Components.csproj
@@ -48,7 +48,7 @@
 
   <ItemGroup Condition="'$(UsePackageReferences)' == 'true'">
     <PackageReference Include="BlazorBlueprint.Icons.Lucide" Version="2.0.0" />
-    <PackageReference Include="BlazorBlueprint.Primitives" Version="2.0.0" />
+    <PackageReference Include="BlazorBlueprint.Primitives" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Release Changes

This PR merges changes made during the release of **BlazorBlueprint.Components v2.3.0** back to main.

**Commits made during release:** 1

### Changes included:
- bd97105 chore: bump BlazorBlueprint.Primitives to 2.1.1

---
*Auto-generated by release script*