### PR TITLE
[fix] Respect DataTable ColumnData Format for global search

### DIFF
--- a/src/BlazorBlueprint.Components/Components/DataTable/DataTable.razor
+++ b/src/BlazorBlueprint.Components/Components/DataTable/DataTable.razor
@@ -162,8 +162,7 @@
                                         }
                                         else
                                         {
-                                            var value = column.Property(item);
-                                            @(value is IFormattable formattable && column.Format is not null ? formattable.ToString(column.Format, null) : value?.ToString() ?? "")
+                                            @column.ToStringFunc(item)
                                         }
                                     </TableCell>
                                 }

--- a/src/BlazorBlueprint.Components/Components/DataTable/DataTable.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataTable/DataTable.razor.cs
@@ -57,6 +57,10 @@ public partial class DataTable<TData> : ComponentBase where TData : class
         public RenderFragment<TData>? CellTemplate { get; set; }
         public string? CellClass { get; set; }
         public string? HeaderClass { get; set; }
+        public Func<TData, string> ToStringFunc => item =>
+            Property(item) is IFormattable formattable && Format is not null
+                ? formattable.ToString(Format, null)
+                : Property(item)?.ToString() ?? string.Empty;
     }
 
     private List<ColumnData> _columns = new();
@@ -350,12 +354,12 @@ public partial class DataTable<TData> : ComponentBase where TData : class
             try
             {
                 var value = column.Property(item);
-                if (value == null)
+                if (value is null)
                 {
                     continue;
                 }
 
-                var stringValue = value.ToString();
+                var stringValue = column.ToStringFunc(item);
                 if (!string.IsNullOrEmpty(stringValue) &&
                     stringValue.Contains(searchValue, StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
## Description

Fixes `DataTable` global search by respecting the `Format` property when provided for a column. Clean up code by using a consistent `Func` property on `ColumnData` to get the string formatted value of `TData`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes)

## Testing Checklist

- [x] Blazor Server
- [x] Blazor WebAssembly
- [x] Blazor Hybrid (MAUI)
- [x] Keyboard navigation / accessibility
- [x] Dark mode

## Related Issues

Fixes #90 