### PR TITLE
fix: remove hidden class from desktop sidebar (#116)

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Sidebar/Sidebar.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Sidebar/Sidebar.razor.cs
@@ -51,7 +51,7 @@ public partial class Sidebar : IDisposable
 
     private string GetDesktopClasses()
     {
-        var baseClasses = "group peer hidden md:flex flex-col text-sidebar-foreground shrink-0";
+        var baseClasses = "group peer flex flex-col text-sidebar-foreground shrink-0";
 
         // Variant-specific classes
         var variantClasses = Context?.Variant switch


### PR DESCRIPTION
## Summary

- Removes the redundant `hidden md:flex` CSS classes from the desktop sidebar `<aside>` element, replacing with just `flex`
- The `<aside>` only renders on the desktop code path (mobile uses a Sheet component instead), so `hidden` was unnecessary and caused the sidebar to be invisible when `md:flex` was unavailable or stripped by TailwindMerge

Closes #116