### PR TITLE
chore: merge release changes from components/v2.5.0

### DIFF
--- a/src/BlazorBlueprint.Components/BlazorBlueprint.Components.csproj
+++ b/src/BlazorBlueprint.Components/BlazorBlueprint.Components.csproj
@@ -49,7 +49,7 @@
 
   <ItemGroup Condition="'$(UsePackageReferences)' == 'true'">
     <PackageReference Include="BlazorBlueprint.Icons.Lucide" Version="2.0.0" />
-    <PackageReference Include="BlazorBlueprint.Primitives" Version="2.2.0" />
+    <PackageReference Include="BlazorBlueprint.Primitives" Version="2.3.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Release Changes

This PR merges changes made during the release of **BlazorBlueprint.Components v2.5.0** back to main.

**Commits made during release:** 1

### Changes included:
- 9d7c2b0 chore: bump BlazorBlueprint.Primitives to 2.3.2

---
*Auto-generated by release script*