### PR TITLE
chore: merge release changes from components/v3.0.1

### DIFF
--- a/src/BlazorBlueprint.Components/BlazorBlueprint.Components.csproj
+++ b/src/BlazorBlueprint.Components/BlazorBlueprint.Components.csproj
@@ -48,7 +48,7 @@
 
   <ItemGroup Condition="'$(UsePackageReferences)' == 'true'">
     <PackageReference Include="BlazorBlueprint.Icons.Lucide" Version="2.0.0" />
-    <PackageReference Include="BlazorBlueprint.Primitives" Version="3.0.0" />
+    <PackageReference Include="BlazorBlueprint.Primitives" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Release Changes

This PR merges changes made during the release of **BlazorBlueprint.Components v3.0.1** back to main.

**Commits made during release:** 1

### Changes included:
- 76c70ca chore: bump BlazorBlueprint.Primitives to 3.0.1

---
*Auto-generated by release script*