### PR TITLE
fix(DropdownMenu): keyboard navigation highlights individual items when using Href

### DIFF
--- a/src/BlazorBlueprint.Components/Components/DropdownMenu/BbDropdownMenuContent.razor
+++ b/src/BlazorBlueprint.Components/Components/DropdownMenu/BbDropdownMenuContent.razor
@@ -110,7 +110,7 @@
     public string? Style { get; set; }
 
     private string CssClass => ClassNames.cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover outline-none",
         "text-popover-foreground shadow-md",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",

--- a/src/BlazorBlueprint.Components/Components/Menubar/BbMenubarContent.razor
+++ b/src/BlazorBlueprint.Components/Components/Menubar/BbMenubarContent.razor
@@ -148,7 +148,7 @@
     };
 
     private string CssClass => ClassNames.cn(
-        "absolute top-full mt-1 z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "absolute top-full mt-1 z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-none",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",

--- a/src/BlazorBlueprint.Components/Components/NavigationMenu/BbNavigationMenuLink.razor
+++ b/src/BlazorBlueprint.Components/Components/NavigationMenu/BbNavigationMenuLink.razor
@@ -52,7 +52,7 @@
     private string CssClass => ClassNames.cn(
         "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium",
         "transition-colors hover:bg-accent hover:text-accent-foreground",
-        "focus:bg-accent focus:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "outline-none focus:bg-accent focus:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         "disabled:pointer-events-none disabled:opacity-50",
         Class
     );

--- a/src/BlazorBlueprint.Components/wwwroot/css/blazorblueprint-input.css
+++ b/src/BlazorBlueprint.Components/wwwroot/css/blazorblueprint-input.css
@@ -117,29 +117,6 @@
   }
 }
 
-/* Navigation Menu keyboard navigation focus styling */
-@layer components {
-  /* Remove browser default focus outline from the menu container */
-  [role="menu"]:focus,
-  [role="menu"]:focus-visible {
-    outline: none;
-  }
-
-  /* Style the parent container when a link inside is focused */
-  [role="menu"] div:has(> a:focus),
-  [role="menu"] div:has(> a:focus-visible) {
-    outline: 2px solid var(--ring);
-    outline-offset: -2px;
-    border-radius: 0.5rem;
-    background-color: var(--accent);
-  }
-
-  /* Remove default focus outline from the link itself */
-  [role="menu"] a:focus,
-  [role="menu"] a:focus-visible {
-    outline: none;
-  }
-}
 
 
 /* Global theme overrides - utilities layer ensures these override Tailwind's reset */

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/menu-keyboard.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/menu-keyboard.js
@@ -23,6 +23,22 @@ function getEnabledMenuItems(container) {
 }
 
 /**
+ * Focus a menu item reliably. Uses preventScroll and falls back to
+ * temporarily setting tabindex="0" if the initial focus() call fails
+ * (can happen with anchor elements in some browser/framework contexts).
+ */
+function focusMenuItem(item) {
+  if (!item) return;
+  item.focus({ preventScroll: true });
+  if (document.activeElement !== item) {
+    const prev = item.getAttribute('tabindex');
+    item.setAttribute('tabindex', '0');
+    item.focus({ preventScroll: true });
+    item.setAttribute('tabindex', prev ?? '-1');
+  }
+}
+
+/**
  * Navigate to the next enabled menu item.
  */
 function navigateNext(container, loop) {
@@ -40,7 +56,7 @@ function navigateNext(container, loop) {
     nextIndex = currentIndex + 1;
   }
 
-  items[nextIndex]?.focus();
+  focusMenuItem(items[nextIndex]);
 }
 
 /**
@@ -61,7 +77,7 @@ function navigatePrevious(container, loop) {
     prevIndex = currentIndex - 1;
   }
 
-  items[prevIndex]?.focus();
+  focusMenuItem(items[prevIndex]);
 }
 
 /**
@@ -70,7 +86,7 @@ function navigatePrevious(container, loop) {
 function navigateFirst(container) {
   const items = getEnabledMenuItems(container);
   if (items.length > 0) {
-    items[0].focus();
+    focusMenuItem(items[0]);
   }
 }
 
@@ -80,7 +96,7 @@ function navigateFirst(container) {
 function navigateLast(container) {
   const items = getEnabledMenuItems(container);
   if (items.length > 0) {
-    items[items.length - 1].focus();
+    focusMenuItem(items[items.length - 1]);
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixed a bug where keyboard navigation (Arrow Up/Down) in DropdownMenu highlighted the entire container instead of individual menu items when items used the `Href` property (rendered as `<a>` elements)
- Root cause: a global CSS rule `[role="menu"] div:has(> a:focus)` in the Tailwind input CSS was targeting ALL `[role="menu"]` elements, applying background/outline to the parent `<div>` wrapper instead of the focused `<a>` item
- Removed the overly broad CSS rules (originally meant for NavigationMenu, but each component already handles focus styling via Tailwind utility classes)
- Added `outline-none` to DropdownMenuContent and MenubarContent containers for consistency with ContextMenu
- Added a `focusMenuItem()` helper in `menu-keyboard.js` with a tabindex fallback for reliable anchor element focus

## Test plan
- [x] Open a DropdownMenu containing items with `Href` property
- [x] Press Arrow Down/Up — each individual item should highlight (bg-accent), not the entire container
- [x] Verify items with `OnClick` (no Href) still highlight correctly
- [x] Verify NavigationMenu keyboard navigation still works correctly
- [x] Verify ContextMenu keyboard navigation is unaffected
- [x] Verify Menubar keyboard navigation is unaffected