### PR TITLE
fix: DataGrid click intercept, keyboard nav, and row expansion

### DIFF
--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor
@@ -49,6 +49,7 @@
                     OnSortChange="HandleSortChange"
                     OnSelectionChange="HandleSelectionChange"
                     OnRowClick="HandleRowClick"
+                    OnToggleExpand="@(DetailTemplate != null ? EventCallback.Factory.Create<TData>(this, HandleRowExpandToggle) : default)"
                     OnRowContextMenu="@(RowContextMenu != null ? (EventCallback<(TData, double, double)>)EventCallback.Factory.Create<(TData, double, double)>(this, HandleRowContextMenu) : default)"
                     Class="@ClassNames.cn("w-full caption-bottom text-sm", HasTableFixed() ? "table-fixed" : "")"
                     AriaLabel="@AriaLabel">

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/BbDataGrid.razor.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/BbDataGrid.razor.cs
@@ -99,6 +99,12 @@ public partial class BbDataGrid<TData> : ComponentBase, IDisposable where TData 
     public EventCallback<(TData Item, double ClientX, double ClientY)> OnRowContextMenu { get; set; }
 
     /// <summary>
+    /// Event callback invoked to toggle expansion of a row.
+    /// </summary>
+    [Parameter]
+    public EventCallback<TData> OnToggleExpand { get; set; }
+
+    /// <summary>
     /// Event callback invoked when a column's visibility changes.
     /// </summary>
     [Parameter]
@@ -289,6 +295,25 @@ public partial class BbDataGrid<TData> : ComponentBase, IDisposable where TData 
             });
             TrackTask(task);
         };
+
+        if (OnToggleExpand.HasDelegate)
+        {
+            context.OnToggleExpand = (item) =>
+            {
+                var task = InvokeAsync(async () =>
+                {
+                    try
+                    {
+                        await OnToggleExpand.InvokeAsync(item);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"Error in OnToggleExpand: {ex.Message}");
+                    }
+                });
+                TrackTask(task);
+            };
+        }
 
         if (OnRowContextMenu.HasDelegate)
         {

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/BbDataGridRow.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/BbDataGridRow.razor
@@ -55,11 +55,13 @@
 
     private bool IsSelectable => Context != null && Context.SelectionMode != Table.SelectionMode.None;
 
+    private bool IsExpandable => Context?.OnToggleExpand != null;
+
     private bool IsDataRow => Item != null;
 
     private bool NeedsClickIntercept => IsDataRow && (IsSelectable || Context?.OnRowClick != null);
 
-    private bool IsKeyboardNavigable => IsSelectable && Context != null && Context.EnableKeyboardNavigation;
+    private bool IsKeyboardNavigable => IsDataRow && Context != null && Context.EnableKeyboardNavigation;
 
     private const string FocusRingClasses = "relative focus:outline-none focus:z-10";
 
@@ -100,10 +102,23 @@
 
     private bool HasContextMenuHandler => Context?.OnRowContextMenu != null;
 
-    private void HandleClick()
+    private async Task HandleClick()
     {
         if (Item != null && Context != null)
         {
+            // When the click interceptor is active, check whether the click
+            // targeted an interactive child (user-provided button/link/input
+            // inside a cell template).  If so, skip row-level handling.
+            if (clickInterceptAttached && navModule != null)
+            {
+                var wasInteractive = await navModule.InvokeAsync<bool>(
+                    "consumeInteractiveClickFlag", elementRef);
+                if (wasInteractive)
+                {
+                    return;
+                }
+            }
+
             Context.OnRowClick?.Invoke(Item);
 
             if (IsSelectable)
@@ -136,9 +151,30 @@
             }
         }
 
-        if (IsSelectable && Item != null && (e.Key == "Enter" || e.Key == " "))
+        if (Item != null)
         {
-            Context.ToggleRowSelection(Item);
+            if (e.Key == " ")
+            {
+                if (IsSelectable)
+                {
+                    Context!.ToggleRowSelection(Item);
+                }
+                else if (IsExpandable)
+                {
+                    Context!.OnToggleExpand!(Item);
+                }
+            }
+            else if (e.Key == "Enter")
+            {
+                if (IsExpandable)
+                {
+                    Context!.OnToggleExpand!(Item);
+                }
+                else if (IsSelectable)
+                {
+                    Context!.ToggleRowSelection(Item);
+                }
+            }
         }
     }
 

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridContext.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridContext.cs
@@ -74,6 +74,12 @@ public class DataGridContext<TData> : PrimitiveContextWithEvents<DataGridState<T
     public Action<TData, double, double>? OnRowContextMenu { get; set; }
 
     /// <summary>
+    /// Callback invoked to toggle expansion of a row.
+    /// Set by the Components layer when a DetailTemplate is provided.
+    /// </summary>
+    public Action<TData>? OnToggleExpand { get; set; }
+
+    /// <summary>
     /// Callback invoked when a column's visibility changes.
     /// </summary>
     public Action<string, bool>? OnColumnVisibilityChange { get; set; }

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/table-row-nav.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/table-row-nav.js
@@ -13,10 +13,16 @@ const INTERACTIVE_SELECTOR =
   '[role="menuitem"],[role="option"],[role="tab"]';
 
 /**
- * Attaches a capture-phase click listener on the row that stops propagation
- * when the click originates from an interactive child element.
- * This prevents row selection / OnRowClick from firing when the user
- * clicks buttons, links, checkboxes, etc. inside a cell.
+ * Attaches a capture-phase click listener on the row that flags clicks
+ * originating from interactive child elements.  Instead of calling
+ * stopPropagation (which would prevent Blazor's root-level event
+ * delegation from seeing the event at all), we set a property on the
+ * row element that the C# HandleClick can read via JS interop.
+ *
+ * Library-owned interactive elements (expand button, selection checkbox)
+ * already use Blazor's @onclick:stopPropagation="true" to suppress the
+ * row handler through Blazor's internal dispatch.  This interceptor
+ * handles user-provided interactive content in cell templates.
  *
  * @param {HTMLElement} rowElement - The <tr> element
  * @returns {{ dispose(): void }} Cleanup handle
@@ -25,15 +31,11 @@ export function interceptInteractiveClicks(rowElement) {
   if (!rowElement) return { dispose: () => {} };
 
   const handler = (e) => {
-    // Walk from the actual click target up to (but not including) the row.
-    // If we hit an interactive element, swallow the event.
     const interactive = e.target.closest(INTERACTIVE_SELECTOR);
-    if (interactive && rowElement.contains(interactive) && interactive !== rowElement) {
-      e.stopPropagation();
-    }
+    rowElement._bbInteractiveClick = !!(interactive && rowElement.contains(interactive) && interactive !== rowElement);
   };
 
-  // Capture phase so we run before Blazor's bubble-phase @onclick binding.
+  // Capture phase so the flag is set before Blazor dispatches the row click.
   rowElement.addEventListener('click', handler, { capture: true });
 
   return {
@@ -41,6 +43,20 @@ export function interceptInteractiveClicks(rowElement) {
       rowElement.removeEventListener('click', handler, { capture: true });
     }
   };
+}
+
+/**
+ * Returns true if the last click on this row targeted an interactive
+ * child element, then resets the flag.
+ *
+ * @param {HTMLElement} rowElement - The <tr> element
+ * @returns {boolean}
+ */
+export function consumeInteractiveClickFlag(rowElement) {
+  if (!rowElement) return false;
+  const flag = rowElement._bbInteractiveClick === true;
+  rowElement._bbInteractiveClick = false;
+  return flag;
 }
 
 /**
@@ -79,27 +95,23 @@ export function moveFocusToPreviousRow(element) {
     if (!element) return;
 
     let prevRow = element.previousElementSibling;
-    while (prevRow && prevRow.getAttribute('tabindex') === '-1') {
+    while (prevRow && prevRow.getAttribute('tabindex') !== '0') {
         prevRow = prevRow.previousElementSibling;
     }
-    if (prevRow && prevRow.getAttribute('tabindex') === '0') {
-        prevRow.focus();
-    }
+    prevRow?.focus();
 }
 
 /**
  * Moves focus to the next focusable row.
- * Skips rows with tabindex="-1".
+ * Skips siblings without tabindex="0" (detail rows, non-navigable rows, etc.).
  * @param {HTMLElement} element - The current row element
  */
 export function moveFocusToNextRow(element) {
     if (!element) return;
 
     let nextRow = element.nextElementSibling;
-    while (nextRow && nextRow.getAttribute('tabindex') === '-1') {
+    while (nextRow && nextRow.getAttribute('tabindex') !== '0') {
         nextRow = nextRow.nextElementSibling;
     }
-    if (nextRow && nextRow.getAttribute('tabindex') === '0') {
-        nextRow.focus();
-    }
+    nextRow?.focus();
 }


### PR DESCRIPTION
## Summary
- **Click intercept fix**: Replaced `stopPropagation()` in the JS capture-phase interceptor with a flag-based approach. The old approach prevented Blazor's root-level event delegation from seeing click events, breaking the expand button and selection checkbox. The new approach sets a flag on the row element that `HandleClick` checks via JS interop.
- **Keyboard nav decoupled from selection**: `IsKeyboardNavigable` no longer requires `IsSelectable` — rows are navigable whenever `EnableKeyboardNavigation` is true, regardless of selection mode.
- **Keyboard row expansion**: Added `OnToggleExpand` callback through `DataGridContext` so rows can trigger expansion via keyboard. Enter toggles expansion, Space toggles selection; each falls back to the other when only one feature is enabled.
- **Arrow-key nav over detail rows**: Fixed `moveFocusToNextRow`/`moveFocusToPreviousRow` to skip any sibling without `tabindex="0"` (previously only skipped `tabindex="-1"`, causing navigation to get stuck on expanded detail `<tr>` elements with no tabindex).
