### PR TITLE
feat(DataGrid): improve pinned column UX and column visibility guards

### DIFF
--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor
@@ -142,6 +142,17 @@
                                             {
                                                 <span>@column.Title</span>
                                             }
+                                            @if (column.Pinned != ColumnPinning.None)
+                                            {
+                                                <BbTooltip>
+                                                    <BbTooltipTrigger AsChild="false" Focusable="false" Class="inline-flex items-center">
+                                                        <LucideIcon Name="pin" Class="w-3.5 h-3.5 text-muted-foreground" />
+                                                    </BbTooltipTrigger>
+                                                    <BbTooltipContent Side="PopoverSide.Bottom">
+                                                        This column is pinned and cannot be moved
+                                                    </BbTooltipContent>
+                                                </BbTooltip>
+                                            }
                                             @if (column.Sortable && sortDirection != SortDirection.None)
                                             {
                                                 @if (sortDirection == SortDirection.Ascending)

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridColumnVisibility.razor
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridColumnVisibility.razor
@@ -30,10 +30,18 @@
         {
             var columnId = column.ColumnId;
             var isVisible = ParentGrid!.EffectiveState.Columns.IsVisible(columnId);
+            var isPinned = column.Pinned != BlazorBlueprint.Primitives.DataGrid.ColumnPinning.None;
+            var isLastVisible = isVisible && GetVisibleHideableCount() <= 1;
+            var isDisabled = isPinned || isLastVisible;
             <BbDropdownMenuCheckboxItem
                 Checked="@isVisible"
+                Disabled="@isDisabled"
                 CheckedChanged="@((bool v) => HandleVisibilityChanged(columnId, v))">
                 @(column.Title ?? columnId)
+                @if (isPinned)
+                {
+                    <span class="ml-auto text-xs text-muted-foreground">Pinned</span>
+                }
             </BbDropdownMenuCheckboxItem>
         }
     </BbDropdownMenuContent>

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridColumnVisibility.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridColumnVisibility.razor.cs
@@ -55,6 +55,16 @@ public partial class BbDataGridColumnVisibility<TData> : ComponentBase
         return ParentGrid.GetAllColumns().Where(c => c.Hideable);
     }
 
+    private int GetVisibleHideableCount()
+    {
+        if (ParentGrid == null)
+        {
+            return 0;
+        }
+
+        return GetHideableColumns().Count(c => ParentGrid.EffectiveState.Columns.IsVisible(c.ColumnId));
+    }
+
     private Task HandleVisibilityChanged(string columnId, bool visible) =>
         ParentGrid?.HandleColumnVisibilityChangedAsync(columnId, visible) ?? Task.CompletedTask;
 }


### PR DESCRIPTION
## Summary
- Add a pin icon with tooltip to pinned column headers to visually indicate the column is pinned and cannot be moved
- Disable pinned columns in the column visibility dropdown so they cannot be hidden (shown ghosted with a "Pinned" label)
- Prevent hiding the last remaining visible column in the column visibility dropdown by disabling it

## Test plan
- [x] Verify pinned columns display a small pin icon next to the column title
- [x] Hover over the pin icon and confirm the tooltip reads "This column is pinned and cannot be moved"
- [x] Open the column visibility dropdown and verify pinned columns are greyed out and non-interactive
- [x] Hide columns until only one remains and verify the last column is greyed out and cannot be hidden
- [x] Verify unpinned columns with multiple visible columns can still be toggled normally