### PR TITLE
feat(DataGrid): add Home/End keyboard navigation

### DIFF
--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/BbDataGridRow.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/BbDataGridRow.razor
@@ -119,6 +119,22 @@
                 }
             }
 
+            // Ensure the row receives focus on click so keyboard navigation
+            // (ArrowUp/Down, Home/End, Space, Enter) works immediately.
+            if (IsKeyboardNavigable)
+            {
+                try
+                {
+                    navModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>(
+                        "import", "./_content/BlazorBlueprint.Primitives/js/primitives/table-row-nav.js");
+                    await navModule.InvokeVoidAsync("focusRow", elementRef);
+                }
+                catch
+                {
+                    // Ignore JS interop errors during prerendering
+                }
+            }
+
             Context.OnRowClick?.Invoke(Item);
 
             if (IsSelectable)

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/table-row-nav.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/table-row-nav.js
@@ -119,6 +119,14 @@ export function moveFocusToNextRow(element) {
 }
 
 /**
+ * Focuses the given row element.
+ * @param {HTMLElement} element - The row element to focus
+ */
+export function focusRow(element) {
+    element?.focus();
+}
+
+/**
  * Moves focus to the first focusable row in the table body.
  * @param {HTMLElement} element - The current row element
  */


### PR DESCRIPTION
## Summary
- Add Home key support to jump focus to the first row in the DataGrid
- Add End key support to jump focus to the last row in the DataGrid
- Prevent default browser scrolling for Home/End keys when a row is focused

## Test plan
- [ ] Focus a DataGrid row and press Home — verify focus moves to the first row
- [ ] Focus a DataGrid row and press End — verify focus moves to the last row
- [ ] Verify Home/End do not cause the page to scroll while a row is focused
- [ ] Verify ArrowUp/ArrowDown/Space/Enter navigation still works as before