### PR TITLE
fix(slider): slider style was affected by culture info

### DIFF
--- a/src/BlazorBlueprint.Components/Components/RangeSlider/BbRangeSlider.razor
+++ b/src/BlazorBlueprint.Components/Components/RangeSlider/BbRangeSlider.razor
@@ -1,5 +1,6 @@
 @namespace BlazorBlueprint.Components
 @using Microsoft.JSInterop
+@using System.Globalization
 @inject IJSRuntime JS
 @implements IAsyncDisposable
 
@@ -10,7 +11,7 @@
     <div class="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
         @* Active range track *@
         <div class="absolute h-full bg-primary"
-             style="left: @(StartPercentage)%; width: @(EndPercentage - StartPercentage)%;">
+             style="left: @(StartPercentageValue); width: @(RangePercentageValue);">
         </div>
     </div>
 
@@ -24,7 +25,7 @@
          aria-disabled="@Disabled"
          tabindex="@(Disabled ? -1 : 0)"
          class="@StartThumbClass"
-         style="left: @(StartPercentage)%;"
+         style="left: @(StartPercentageValue);"
          @onpointerdown="@(e => StartThumbDrag(e))"
          @onkeydown="@(e => HandleStartKeyDown(e))">
         @if (ShowTooltips)
@@ -43,7 +44,7 @@
          aria-disabled="@Disabled"
          tabindex="@(Disabled ? -1 : 0)"
          class="@EndThumbClass"
-         style="left: @(EndPercentage)%;"
+         style="left: @(EndPercentageValue);"
          @onpointerdown="@(e => EndThumbDrag(e))"
          @onkeydown="@(e => HandleEndKeyDown(e))">
         @if (ShowTooltips)
@@ -182,6 +183,10 @@
     private double EndValue => IsControlled ? Value.End : _internalEnd;
     private double StartPercentage => ((StartValue - Min) / (Max - Min)) * 100;
     private double EndPercentage => ((EndValue - Min) / (Max - Min)) * 100;
+
+    private string StartPercentageValue => $"{StartPercentage.ToString(CultureInfo.InvariantCulture)}%";
+    private string EndPercentageValue => $"{EndPercentage.ToString(CultureInfo.InvariantCulture)}%";
+    private string RangePercentageValue => $"{(EndPercentage - StartPercentage).ToString(CultureInfo.InvariantCulture)}%";
 
     protected override void OnInitialized()
     {

--- a/src/BlazorBlueprint.Components/Components/Slider/BbSlider.razor
+++ b/src/BlazorBlueprint.Components/Components/Slider/BbSlider.razor
@@ -1,5 +1,6 @@
 @namespace BlazorBlueprint.Components
 @using Microsoft.JSInterop
+@using System.Globalization
 @inject IJSRuntime JS
 @implements IAsyncDisposable
 
@@ -14,11 +15,11 @@
      @onkeydown="HandleKeyDown">
     <div class="@ComputedTrackClass">
         <div class="@ComputedIndicatorClass"
-             style="width: @(Percentage)%;">
+             style="width: @PercentageValue;">
         </div>
     </div>
     <div class="@ComputedThumbClass"
-         style="left: @(Percentage)%;">
+         style="left: @PercentageValue;">
     </div>
 </div>
 
@@ -73,6 +74,8 @@
     private bool IsControlled => ValueChanged.HasDelegate;
     private double CurrentValue => IsControlled ? Value : _internalValue;
     private double Percentage => ((CurrentValue - Min) / (Max - Min)) * 100;
+
+    private string PercentageValue => $"{Percentage.ToString(CultureInfo.InvariantCulture)}%";
 
     protected override void OnInitialized()
     {


### PR DESCRIPTION
## Fix culture-dependent formatting in slider styles and improve step rounding

### Description

This PR fixes an issue where the slider could behave incorrectly in cultures that use a comma (`,`) as the decimal separator (e.g. `it-IT`, `fr-FR`)

### Problem

The slider thumb position and track indicator width are rendered using inline CSS styles derived from a `double` value:

```
style="width: @(Percentage)%"
style="left: @(Percentage)%"
```

Blazor formats numbers using the current thread culture. In cultures that use `,` as the decimal separator, this produces values such as:

```
width: 12,5%;
left: 12,5%;
```

However, CSS numeric values must use a dot (`.`) as the decimal separator. When rendered with commas, browsers may interpret the values incorrectly, causing the slider thumb and indicator to render in the wrong position.

### Solution

Percentages are now formatted using `CultureInfo.InvariantCulture` before being inserted into CSS styles:

```
private string PercentageValue =>
    $"{Percentage.ToString(CultureInfo.InvariantCulture)}%";
```

This guarantees that the generated CSS always uses the correct decimal separator:

```
width: 12.5%;
left: 12.5%;
```

This makes the component culture-safe and ensures consistent behavior across all locales.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [X] Blazor Server
- [X] Blazor WebAssembly
- [X] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility
- [ ] Dark mode
