### PR TITLE
fix: ComboBox value change detection in nested rendering contexts

### DIFF
--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
@@ -48,6 +48,7 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     private Func<TData, object>? _lastItemKey;
 
     // ShouldRender tracking
+    private bool _parametersChanged;
     private IEnumerable<TData>? _lastItems;
     private bool _lastIsLoading;
     private int _columnsVersion;
@@ -292,6 +293,8 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
 
     protected override async Task OnParametersSetAsync()
     {
+        _parametersChanged = true;
+
         if (State != null)
         {
             _gridState = State;
@@ -1257,6 +1260,17 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
 
     protected override bool ShouldRender()
     {
+        if (_parametersChanged)
+        {
+            _parametersChanged = false;
+            _lastItems = Items;
+            _lastIsLoading = IsLoading;
+            _lastColumnsVersion = _columnsVersion;
+            _lastStateVersion = _stateVersion;
+            _lastGridStateVersion = _gridState.Version;
+            return true;
+        }
+
         var itemsChanged = !ReferenceEquals(_lastItems, Items);
         var loadingChanged = _lastIsLoading != IsLoading;
         var columnsChanged = _lastColumnsVersion != _columnsVersion;

--- a/src/BlazorBlueprint.Components/Components/DataTable/BbDataTable.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataTable/BbDataTable.razor.cs
@@ -68,6 +68,7 @@ public partial class BbDataTable<TData> : ComponentBase where TData : class
     private bool _selectAllDropdownOpen;
 
     // ShouldRender tracking fields
+    private bool _parametersChanged;
     private IEnumerable<TData>? _lastData;
     private DataTableSelectionMode _lastSelectionMode;
     private bool _lastIsLoading;
@@ -259,6 +260,8 @@ public partial class BbDataTable<TData> : ComponentBase where TData : class
 
     protected override async Task OnParametersSetAsync()
     {
+        _parametersChanged = true;
+
         // Keep selection mode in sync with parameter
         _tableState.Selection.Mode = GetPrimitiveSelectionMode();
 
@@ -700,6 +703,21 @@ public partial class BbDataTable<TData> : ComponentBase where TData : class
     /// </summary>
     protected override bool ShouldRender()
     {
+        if (_parametersChanged)
+        {
+            _parametersChanged = false;
+            _lastData = Data;
+            _lastSelectionMode = SelectionMode;
+            _lastIsLoading = IsLoading;
+            _lastColumnsVersion = _columnsVersion;
+            _lastGlobalSearchValue = _globalSearchValue;
+            _lastSelectionVersion = _selectionVersion;
+            _lastPaginationVersion = _paginationVersion;
+            _lastFilter = Filter;
+            _lastFilterVersion = Filter?.Version ?? 0;
+            return true;
+        }
+
         var dataChanged = !ReferenceEquals(_lastData, Data);
         var selectionModeChanged = _lastSelectionMode != SelectionMode;
         var loadingChanged = _lastIsLoading != IsLoading;

--- a/src/BlazorBlueprint.Components/Components/DataView/BbDataView.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataView/BbDataView.razor.cs
@@ -74,6 +74,7 @@ public partial class BbDataView<TItem> : ComponentBase, IAsyncDisposable where T
     private int _sortingVersion;
 
     // ShouldRender tracking fields
+    private bool _parametersChanged;
     private IEnumerable<TItem>? _lastData;
     private DataViewLayout _lastLayout;
     private bool _lastIsLoading;
@@ -344,6 +345,8 @@ public partial class BbDataView<TItem> : ComponentBase, IAsyncDisposable where T
 
     protected override async Task OnParametersSetAsync()
     {
+        _parametersChanged = true;
+
         // Sync the backing field when the Layout parameter changes externally.
         currentLayout = Layout;
 
@@ -654,6 +657,21 @@ public partial class BbDataView<TItem> : ComponentBase, IAsyncDisposable where T
 
     protected override bool ShouldRender()
     {
+        if (_parametersChanged)
+        {
+            _parametersChanged = false;
+            _lastData = Data;
+            _lastLayout = currentLayout;
+            _lastIsLoading = IsLoading;
+            _lastFieldsVersion = _fieldsVersion;
+            _lastSearchValue = _searchValue;
+            _lastPaginationVersion = _paginationVersion;
+            _lastSlotVersion = _slotVersion;
+            _lastInfiniteScrollVersion = _infiniteScrollVersion;
+            _lastSortingVersion = _sortingVersion;
+            return true;
+        }
+
         var dataChanged = !ReferenceEquals(_lastData, Data);
         var layoutChanged = _lastLayout != currentLayout;
         var loadingChanged = _lastIsLoading != IsLoading;

--- a/src/BlazorBlueprint.Primitives/Primitives/Collapsible/BbCollapsible.razor.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/Collapsible/BbCollapsible.razor.cs
@@ -68,6 +68,7 @@ namespace BlazorBlueprint.Primitives.Collapsible;
 public partial class BbCollapsible : ComponentBase
 {
     private CollapsibleContext context = new();
+    private bool _parametersChanged;
     private bool _lastOpen;
     private bool _lastDisabled;
 
@@ -138,6 +139,7 @@ public partial class BbCollapsible : ComponentBase
     /// </summary>
     protected override void OnParametersSet()
     {
+        _parametersChanged = true;
         context.Open = Open;
         context.Disabled = Disabled;
     }
@@ -148,6 +150,14 @@ public partial class BbCollapsible : ComponentBase
     /// </summary>
     protected override bool ShouldRender()
     {
+        if (_parametersChanged)
+        {
+            _parametersChanged = false;
+            _lastOpen = Open;
+            _lastDisabled = Disabled;
+            return true;
+        }
+
         if (Open != _lastOpen || Disabled != _lastDisabled)
         {
             _lastOpen = Open;

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/BbDataGrid.razor.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/BbDataGrid.razor.cs
@@ -18,6 +18,7 @@ public partial class BbDataGrid<TData> : ComponentBase, IDisposable where TData 
     private CancellationTokenSource? loadCts;
 
     // ShouldRender tracking
+    private bool parametersChanged;
     private int lastRenderVersion;
     private object? lastItems;
     private SelectionMode lastSelectionMode;
@@ -182,6 +183,8 @@ public partial class BbDataGrid<TData> : ComponentBase, IDisposable where TData 
 
     protected override async Task OnParametersSetAsync()
     {
+        parametersChanged = true;
+
         context.SelectionMode = SelectionMode;
         context.EnableKeyboardNavigation = EnableKeyboardNavigation;
         EffectiveState.Selection.Mode = SelectionMode;
@@ -610,6 +613,16 @@ public partial class BbDataGrid<TData> : ComponentBase, IDisposable where TData 
     {
         if (IsControlled)
         {
+            return true;
+        }
+
+        if (parametersChanged)
+        {
+            parametersChanged = false;
+            lastItems = Items;
+            lastSelectionMode = SelectionMode;
+            lastManualPagination = ManualPagination;
+            lastRenderVersion = stateVersion;
             return true;
         }
 

--- a/src/BlazorBlueprint.Primitives/Primitives/Table/BbTable.razor.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/Table/BbTable.razor.cs
@@ -16,6 +16,7 @@ public partial class BbTable<TData> : ComponentBase, IDisposable where TData : c
     private readonly List<Task> _pendingTasks = new();
 
     // ShouldRender tracking fields
+    private bool _parametersChanged;
     private int _lastRenderVersion;
     private IEnumerable<TData>? _lastData;
     private SelectionMode _lastSelectionMode;
@@ -279,6 +280,8 @@ public partial class BbTable<TData> : ComponentBase, IDisposable where TData : c
     /// </summary>
     protected override void OnParametersSet()
     {
+        _parametersChanged = true;
+
         // Update context with new parameters
         _context.SelectionMode = SelectionMode;
         _context.EnableKeyboardNavigation = EnableKeyboardNavigation;
@@ -366,6 +369,17 @@ public partial class BbTable<TData> : ComponentBase, IDisposable where TData : c
         // For controlled mode, always allow re-render since state may be modified in-place
         if (IsControlled)
         {
+            return true;
+        }
+
+        // Allow re-render when parent re-rendered us (parameters were set)
+        if (_parametersChanged)
+        {
+            _parametersChanged = false;
+            _lastData = Data;
+            _lastSelectionMode = SelectionMode;
+            _lastManualPagination = ManualPagination;
+            _lastRenderVersion = _stateVersion;
             return true;
         }
 


### PR DESCRIPTION
## Summary

- Fixes #203 — labels bound to ComboBox selected value not updating when ComboBox is nested inside container components (e.g., DataTable CellTemplate inside a Dialog)
- Adds a `_parametersChanged` flag to 6 container components so that parent-triggered re-renders cascade through to user-provided template content (CellTemplate, ChildContent)
- Affected components: `BbDataTable`, `BbDataGrid` (Components + Primitives), `BbDataView`, `BbTable`, `BbCollapsible`

## Test plan

- [x] Run `dotnet build` — passes with 0 warnings/errors
- [x] Run `dotnet test` — all API surface snapshot tests pass
- [x] Manual: DataTable demo → Dialog with ComboBox in CellTemplate → select a new value → label updates immediately without reopening dialog
- [x] Manual: Verify existing DataTable/DataGrid sorting, pagination, and selection still work correctly
- [x] Manual: Verify Collapsible toggle behavior unchanged