### PR TITLE
feat(Tabs): responsive mode collapses to Select on overflow

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Tabs/responsive.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Tabs/responsive.txt
@@ -1,0 +1,21 @@
+<BbTabs DefaultValue="overview">
+    <BbTabsList Responsive>
+        <BbTabsTrigger Value="overview" Label="Overview">Overview</BbTabsTrigger>
+        <BbTabsTrigger Value="analytics" Label="Analytics">Analytics</BbTabsTrigger>
+        <BbTabsTrigger Value="reports" Label="Reports">Reports</BbTabsTrigger>
+        <BbTabsTrigger Value="notifications" Label="Notifications">Notifications</BbTabsTrigger>
+        <BbTabsTrigger Value="settings" Label="Settings">Settings</BbTabsTrigger>
+        <BbTabsTrigger Value="billing" Label="Billing">Billing</BbTabsTrigger>
+        <BbTabsTrigger Value="integrations" Label="Integrations">Integrations</BbTabsTrigger>
+        <BbTabsTrigger Value="security" Label="Security">Security</BbTabsTrigger>
+    </BbTabsList>
+
+    <BbTabsContent Value="overview">...</BbTabsContent>
+    <BbTabsContent Value="analytics">...</BbTabsContent>
+    <BbTabsContent Value="reports">...</BbTabsContent>
+    <BbTabsContent Value="notifications">...</BbTabsContent>
+    <BbTabsContent Value="settings">...</BbTabsContent>
+    <BbTabsContent Value="billing">...</BbTabsContent>
+    <BbTabsContent Value="integrations">...</BbTabsContent>
+    <BbTabsContent Value="security">...</BbTabsContent>
+</BbTabs>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TabsDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TabsDemo.razor
@@ -209,6 +209,101 @@
         <CodeBlock Source="Components/Tabs/controlled.txt" />
     </div>
 
+    <div class="space-y-4">
+        <h2 class="text-2xl font-semibold">Responsive</h2>
+        <p class="text-sm text-muted-foreground">
+            When <code>Responsive</code> is enabled, the tabs list automatically collapses into a Select dropdown
+            when the tabs overflow their container. Resize the browser to see it in action.
+        </p>
+
+        <BbTabs DefaultValue="overview">
+            <BbTabsList Responsive>
+                <BbTabsTrigger Value="overview" Label="Overview">Overview</BbTabsTrigger>
+                <BbTabsTrigger Value="analytics" Label="Analytics">Analytics</BbTabsTrigger>
+                <BbTabsTrigger Value="reports" Label="Reports">Reports</BbTabsTrigger>
+                <BbTabsTrigger Value="notifications" Label="Notifications">Notifications</BbTabsTrigger>
+                <BbTabsTrigger Value="settings" Label="Settings">Settings</BbTabsTrigger>
+                <BbTabsTrigger Value="billing" Label="Billing">Billing</BbTabsTrigger>
+                <BbTabsTrigger Value="integrations" Label="Integrations">Integrations</BbTabsTrigger>
+                <BbTabsTrigger Value="security" Label="Security">Security</BbTabsTrigger>
+            </BbTabsList>
+
+            <BbTabsContent Value="overview">
+                <div class="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
+                    <h3 class="text-lg font-semibold mb-2">Overview</h3>
+                    <p class="text-sm text-muted-foreground">
+                        View a summary of your account activity and statistics.
+                    </p>
+                </div>
+            </BbTabsContent>
+
+            <BbTabsContent Value="analytics">
+                <div class="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
+                    <h3 class="text-lg font-semibold mb-2">Analytics</h3>
+                    <p class="text-sm text-muted-foreground">
+                        Detailed analytics and metrics about your usage patterns.
+                    </p>
+                </div>
+            </BbTabsContent>
+
+            <BbTabsContent Value="reports">
+                <div class="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
+                    <h3 class="text-lg font-semibold mb-2">Reports</h3>
+                    <p class="text-sm text-muted-foreground">
+                        Generate and download detailed reports for your team.
+                    </p>
+                </div>
+            </BbTabsContent>
+
+            <BbTabsContent Value="notifications">
+                <div class="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
+                    <h3 class="text-lg font-semibold mb-2">Notifications</h3>
+                    <p class="text-sm text-muted-foreground">
+                        Manage your notification preferences and channels.
+                    </p>
+                </div>
+            </BbTabsContent>
+
+            <BbTabsContent Value="settings">
+                <div class="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
+                    <h3 class="text-lg font-semibold mb-2">Settings</h3>
+                    <p class="text-sm text-muted-foreground">
+                        Configure your account settings and preferences.
+                    </p>
+                </div>
+            </BbTabsContent>
+
+            <BbTabsContent Value="billing">
+                <div class="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
+                    <h3 class="text-lg font-semibold mb-2">Billing</h3>
+                    <p class="text-sm text-muted-foreground">
+                        Manage your subscription, payment methods, and invoices.
+                    </p>
+                </div>
+            </BbTabsContent>
+
+            <BbTabsContent Value="integrations">
+                <div class="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
+                    <h3 class="text-lg font-semibold mb-2">Integrations</h3>
+                    <p class="text-sm text-muted-foreground">
+                        Connect third-party services and manage API keys.
+                    </p>
+                </div>
+            </BbTabsContent>
+
+            <BbTabsContent Value="security">
+                <div class="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
+                    <h3 class="text-lg font-semibold mb-2">Security</h3>
+                    <p class="text-sm text-muted-foreground">
+                        Two-factor authentication, sessions, and audit log.
+                    </p>
+                </div>
+            </BbTabsContent>
+        </BbTabs>
+
+        <CodeBlock Source="Components/Tabs/responsive.txt" />
+    </div>
+
     <AccessibilityList>
         <AriaAttributes>
             <AccessibilityItem>Uses <code>role="tablist"</code>, <code>role="tab"</code>, and <code>role="tabpanel"</code> for proper semantics</AccessibilityItem>
@@ -263,11 +358,20 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the tabs list container.
                 </ApiParameter>
+                <ApiParameter Name="Responsive" Type="bool" Default="false">
+                    When true, collapses tabs into a Select dropdown when they overflow their container.
+                </ApiParameter>
+                <ApiParameter Name="SelectClass" Type="string?" Default="null">
+                    Additional CSS classes for the responsive Select fallback.
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="TabsTrigger">
                 <ApiParameter Name="Value" Type="string">
                     The value that identifies this tab. Must match a TabsContent Value.
+                </ApiParameter>
+                <ApiParameter Name="Label" Type="string?" Default="null">
+                    Display text for this tab in the responsive Select dropdown. Falls back to Value if not provided.
                 </ApiParameter>
                 <ApiParameter Name="Disabled" Type="bool" Default="false">
                     Whether this tab trigger is disabled.

--- a/src/BlazorBlueprint.Components/Components/Tabs/BbTabsList.razor
+++ b/src/BlazorBlueprint.Components/Components/Tabs/BbTabsList.razor
@@ -1,30 +1,40 @@
 @namespace BlazorBlueprint.Components
+@implements IAsyncDisposable
 
 @*
     Styled TabsList component.
     Wraps the TabsList primitive with shadcn/ui styling.
+    Supports responsive mode that collapses to a Select on overflow.
 *@
 
-<BlazorBlueprint.Primitives.Tabs.BbTabsList class="@CssClass">
-    @ChildContent
-</BlazorBlueprint.Primitives.Tabs.BbTabsList>
+@if (Responsive)
+{
+    <div @ref="_containerRef" class="relative w-full">
+        @* Tab buttons — use visibility:hidden (not display:none) when overflowing
+           so the element retains its measured width for the ResizeObserver. *@
+        <BlazorBlueprint.Primitives.Tabs.BbTabsList class="@ClassNames.cn(CssClass, TabListVisibilityClass)">
+            <CascadingValue Value="this" IsFixed="true">
+                @ChildContent
+            </CascadingValue>
+        </BlazorBlueprint.Primitives.Tabs.BbTabsList>
 
-@code {
-    /// <summary>
-    /// The child content to render within the tabs list.
-    /// Should contain TabsTrigger components.
-    /// </summary>
-    [Parameter]
-    public RenderFragment? ChildContent { get; set; }
-
-    /// <summary>
-    /// Additional CSS classes to apply to the tabs list.
-    /// </summary>
-    [Parameter]
-    public string? Class { get; set; }
-
-    private string CssClass => ClassNames.cn(
-        "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
-        Class
-    );
+        @* Select fallback — positioned absolute so it doesn't affect tablist measurement.
+           When not overflowing it is invisible and non-interactive. *@
+        @if (_responsiveTriggers.Count > 0)
+        {
+            <div class="@SelectWrapperClass">
+                <BbSelect TValue="string"
+                          Value="@Context.ActiveValue"
+                          ValueChanged="@HandleSelectChange"
+                          Options="@SelectOptions"
+                          Class="@SelectCssClass" />
+            </div>
+        }
+    </div>
+}
+else
+{
+    <BlazorBlueprint.Primitives.Tabs.BbTabsList class="@CssClass">
+        @ChildContent
+    </BlazorBlueprint.Primitives.Tabs.BbTabsList>
 }

--- a/src/BlazorBlueprint.Components/Components/Tabs/BbTabsList.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Tabs/BbTabsList.razor.cs
@@ -1,0 +1,147 @@
+using BlazorBlueprint.Primitives;
+using BlazorBlueprint.Primitives.Tabs;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace BlazorBlueprint.Components;
+
+public partial class BbTabsList : IAsyncDisposable
+{
+    private ElementReference _containerRef;
+    private IJSObjectReference? _jsModule;
+    private DotNetObjectReference<BbTabsList>? _dotNetRef;
+    private bool _isOverflowing;
+    private bool _disposed;
+    private readonly List<(string Value, string Label)> _responsiveTriggers = new();
+    private string _componentId = Guid.NewGuid().ToString("N")[..8];
+
+    [Inject]
+    private IJSRuntime JSRuntime { get; set; } = null!;
+
+    /// <summary>
+    /// The child content to render within the tabs list.
+    /// Should contain TabsTrigger components.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Additional CSS classes to apply to the tabs list.
+    /// </summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    /// <summary>
+    /// When true, collapses tabs into a Select dropdown when they overflow their container.
+    /// </summary>
+    [Parameter]
+    public bool Responsive { get; set; }
+
+    /// <summary>
+    /// Additional CSS classes to apply to the responsive Select fallback.
+    /// </summary>
+    [Parameter]
+    public string? SelectClass { get; set; }
+
+    /// <summary>
+    /// Cascading parameter to receive the tabs context from the Primitives layer.
+    /// </summary>
+    [CascadingParameter]
+    public TabsContext Context { get; set; } = null!;
+
+    private string CssClass => ClassNames.cn(
+        "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+        Class
+    );
+
+    // Use invisible (not hidden/display:none) so the tablist keeps its measured width
+    // for the ResizeObserver. pointer-events-none prevents interaction while invisible.
+    private string TabListVisibilityClass => _isOverflowing ? "invisible pointer-events-none" : "";
+
+    // The select is absolutely positioned over the tablist area to avoid affecting layout.
+    // When not overflowing, it's hidden entirely.
+    private string SelectWrapperClass => _isOverflowing
+        ? "absolute inset-x-0 top-0"
+        : "hidden";
+
+    private string SelectCssClass => ClassNames.cn(
+        "w-full",
+        SelectClass
+    );
+
+    private SelectOption<string>[] SelectOptions =>
+        _responsiveTriggers.Select(t => new SelectOption<string>(t.Value, t.Label)).ToArray();
+
+    internal void RegisterResponsiveTrigger(string value, string label)
+    {
+        if (!_responsiveTriggers.Any(t => t.Value == value))
+        {
+            _responsiveTriggers.Add((value, label));
+        }
+    }
+
+    internal void UnregisterResponsiveTrigger(string value) =>
+        _responsiveTriggers.RemoveAll(t => t.Value == value);
+
+    private void HandleSelectChange(string? value)
+    {
+        if (value is not null)
+        {
+            Context.SetActiveTab(value);
+        }
+    }
+
+    [JSInvokable]
+    public void OnOverflowChange(bool isOverflowing)
+    {
+        if (_isOverflowing != isOverflowing)
+        {
+            _isOverflowing = isOverflowing;
+            StateHasChanged();
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && Responsive)
+        {
+            try
+            {
+                _dotNetRef = DotNetObjectReference.Create(this);
+                _jsModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import", "./_content/BlazorBlueprint.Components/js/responsive-tabs.js");
+                await _jsModule.InvokeVoidAsync("initialize", _dotNetRef, _componentId, _containerRef);
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            {
+                // Circuit disconnected, ignore
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        GC.SuppressFinalize(this);
+
+        if (_jsModule is not null)
+        {
+            try
+            {
+                await _jsModule.InvokeVoidAsync("dispose", _componentId);
+                await _jsModule.DisposeAsync();
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            {
+                // Circuit disconnected, ignore
+            }
+        }
+
+        _dotNetRef?.Dispose();
+    }
+}

--- a/src/BlazorBlueprint.Components/Components/Tabs/BbTabsTrigger.razor
+++ b/src/BlazorBlueprint.Components/Components/Tabs/BbTabsTrigger.razor
@@ -1,4 +1,5 @@
 @namespace BlazorBlueprint.Components
+@implements IDisposable
 
 @*
     Styled TabsTrigger component.
@@ -20,6 +21,13 @@
     public string Value { get; set; } = string.Empty;
 
     /// <summary>
+    /// Display text for this tab in the responsive Select dropdown.
+    /// Falls back to Value if not provided.
+    /// </summary>
+    [Parameter]
+    public string? Label { get; set; }
+
+    /// <summary>
     /// Whether this tab trigger is disabled.
     /// </summary>
     [Parameter]
@@ -37,6 +45,17 @@
     [Parameter]
     public string? Class { get; set; }
 
+    /// <summary>
+    /// The parent Components-layer BbTabsList, if responsive mode is enabled.
+    /// </summary>
+    [CascadingParameter]
+    public BbTabsList? ComponentsList { get; set; }
+
+    protected override void OnInitialized()
+    {
+        ComponentsList?.RegisterResponsiveTrigger(Value, Label ?? Value);
+    }
+
     private string CssClass => ClassNames.cn(
         "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5",
         "text-sm font-medium ring-offset-background transition-all",
@@ -45,4 +64,9 @@
         "data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
         Class
     );
+
+    public void Dispose()
+    {
+        ComponentsList?.UnregisterResponsiveTrigger(Value);
+    }
 }

--- a/src/BlazorBlueprint.Components/wwwroot/js/responsive-tabs.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/responsive-tabs.js
@@ -1,0 +1,75 @@
+// Responsive tabs overflow detection
+// Uses ResizeObserver to detect when tab buttons overflow their container
+
+const states = new Map();
+
+/**
+ * Initializes overflow detection for a responsive tabs container.
+ * @param {DotNetObject} dotNetRef - Reference to the Blazor component
+ * @param {string} componentId - Unique identifier for this instance
+ * @param {HTMLElement} containerElement - The wrapper element containing the tablist
+ */
+export function initialize(dotNetRef, componentId, containerElement) {
+  if (!dotNetRef || !containerElement) {
+    return;
+  }
+
+  const tablist = containerElement.querySelector('[role="tablist"]');
+  if (!tablist) {
+    return;
+  }
+
+  // Measure the natural width of all tabs once, before any hiding occurs.
+  // This avoids the feedback loop where hiding tabs changes scrollWidth.
+  let tabsNaturalWidth = tablist.scrollWidth;
+  let lastOverflowing = null;
+
+  const check = () => {
+    const availableWidth = containerElement.clientWidth;
+    const isOverflowing = tabsNaturalWidth > availableWidth;
+    if (isOverflowing !== lastOverflowing) {
+      lastOverflowing = isOverflowing;
+      dotNetRef.invokeMethodAsync('OnOverflowChange', isOverflowing).catch(() => {});
+    }
+  };
+
+  const observer = new ResizeObserver(() => check());
+  observer.observe(containerElement);
+
+  states.set(componentId, { observer, dotNetRef, tablist, remeasure });
+
+  // Initial check
+  check();
+
+  /**
+   * Re-measures the natural tab width. Called when tabs are added/removed.
+   */
+  function remeasure() {
+    tabsNaturalWidth = tablist.scrollWidth;
+    lastOverflowing = null;
+    check();
+  }
+}
+
+/**
+ * Triggers a re-measurement of the natural tab width.
+ * @param {string} componentId - Unique identifier for the instance
+ */
+export function remeasure(componentId) {
+  const state = states.get(componentId);
+  if (state) {
+    state.remeasure();
+  }
+}
+
+/**
+ * Disposes overflow detection for a responsive tabs instance.
+ * @param {string} componentId - Unique identifier for the instance
+ */
+export function dispose(componentId) {
+  const state = states.get(componentId);
+  if (state) {
+    state.observer.disconnect();
+    states.delete(componentId);
+  }
+}

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -2547,12 +2547,17 @@
 ### BbTabsList (BlazorBlueprint.Components)
   - ChildContent : RenderFragment
   - Class : String
+  - Responsive : Boolean
+  - SelectClass : String
+  - Context : TabsContext [CascadingParameter]
 
 ### BbTabsTrigger (BlazorBlueprint.Components)
   - ChildContent : RenderFragment
   - Class : String
   - Disabled : Boolean
+  - Label : String
   - Value : String [EditorRequired]
+  - ComponentsList : BbTabsList [CascadingParameter]
 
 ### BbTagInput (BlazorBlueprint.Components)
   - AddTrigger : TagInputTrigger


### PR DESCRIPTION
## Summary
- Add opt-in `Responsive` parameter to `BbTabsList` that detects tab overflow via ResizeObserver and switches to a `BbSelect` dropdown
- Add `Label` parameter to `BbTabsTrigger` for display text in the responsive Select (falls back to `Value`)
- New JS module (`responsive-tabs.js`) caches the natural tab width to avoid measurement feedback loops

## Test plan
- [x] Run demo app and navigate to `/components/tabs`
- [x] Resize browser to trigger overflow on the Responsive example — verify Select appears
- [x] Widen browser — verify tabs reappear without flickering
- [x] Select a tab via the dropdown — verify correct content panel activates
- [x] Verify non-responsive tab examples remain unchanged