### PR TITLE
feat(datagrid): cascading hierarchy selection and file explorer demo

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGridHierarchy/file-explorer.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGridHierarchy/file-explorer.txt
@@ -1,0 +1,51 @@
+<BbDataGrid TData="FileEntry" Items="@fileTree"
+            ChildrenSelector="@(f => f.Children)"
+            ItemValueSelector="@(f => f.Id)"
+            SelectionMode="DataTableSelectionMode.Multiple"
+            HierarchySelectionMode="HierarchySelectionMode.Cascade"
+            SelectedItemsChanged="@((IReadOnlyCollection<FileEntry> items) => { selectedFiles = items; })"
+            DefaultExpandDepth="1"
+            ShowExpandAll="true"
+            ShowPagination="false"
+            Reorderable="true"
+            Resizable="true">
+    <Columns>
+        <BbDataGridSelectColumn TData="FileEntry" />
+        <BbDataGridHierarchyColumn TData="FileEntry" TProp="string"
+                                   Property="@(f => f.Name)" Title="Name" Sortable>
+            <CellTemplate>
+                <div class="flex items-center gap-2">
+                    <LucideIcon Name="@GetFileIcon(context.Item)"
+                               Class="@(context.Item.IsFolder ? "w-4 h-4 text-blue-500" : "w-4 h-4 text-muted-foreground")" />
+                    <span class="truncate">@context.Value</span>
+                </div>
+            </CellTemplate>
+        </BbDataGridHierarchyColumn>
+        <BbDataGridTemplateColumn TData="FileEntry" Title="Size"
+                                 Sortable SortBy="@(f => (object)(f.Size ?? 0L))">
+            <ChildContent>
+                <span class="text-muted-foreground tabular-nums">@FormatFileSize(context.Size)</span>
+            </ChildContent>
+        </BbDataGridTemplateColumn>
+        <BbDataGridPropertyColumn TData="FileEntry" TProp="string"
+                                 Property="@(f => f.Extension ?? "")" Title="Type" Sortable />
+        <BbDataGridPropertyColumn TData="FileEntry" TProp="DateTime"
+                                 Property="@(f => f.Modified)" Title="Modified"
+                                 Format="yyyy-MM-dd" Sortable />
+    </Columns>
+</BbDataGrid>
+
+@code {
+    private IReadOnlyCollection<FileEntry>? selectedFiles;
+
+    private sealed class FileEntry
+    {
+        public string Id { get; init; } = "";
+        public string Name { get; init; } = "";
+        public bool IsFolder { get; init; }
+        public long? Size { get; init; }
+        public string? Extension { get; init; }
+        public DateTime Modified { get; init; }
+        public List<FileEntry>? Children { get; init; }
+    }
+}

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridHierarchyDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridHierarchyDemo.razor
@@ -120,6 +120,58 @@
         <CodeBlock Source="Components/DataGridHierarchy/lazy-loading.txt" />
     </div>
 
+    <!-- ── File Explorer ────────────────────────────────────────────── -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">File Explorer</h2>
+            <p class="text-sm text-muted-foreground">
+                A file-explorer-style tree with icons, file sizes, and dates.
+                Uses <code class="bg-muted px-1 py-0.5 rounded">HierarchySelectionMode.Cascade</code>
+                to cascade selection to children — selecting a folder selects all its contents.
+                Parents show an indeterminate state when partially selected.
+                All columns are sortable, <code class="bg-muted px-1 py-0.5 rounded">Reorderable</code>, and <code class="bg-muted px-1 py-0.5 rounded">Resizable</code>.
+            </p>
+        </div>
+        <BbDataGrid TData="FileEntry" Items="@fileTree"
+                    ChildrenSelector="@(f => f.Children)"
+                    ItemValueSelector="@(f => f.Id)"
+                    SelectionMode="DataTableSelectionMode.Multiple"
+                    HierarchySelectionMode="HierarchySelectionMode.Cascade"
+                    SelectedItemsChanged="@((IReadOnlyCollection<FileEntry> items) => { selectedFiles = items; })"
+                    DefaultExpandDepth="1"
+                    ShowExpandAll="true"
+                    ShowPagination="false"
+                    Reorderable="true"
+                    Resizable="true">
+            <Columns>
+                <BbDataGridSelectColumn TData="FileEntry" />
+                <BbDataGridHierarchyColumn TData="FileEntry" TProp="string" Property="@(f => f.Name)" Title="Name" Sortable>
+                    <CellTemplate>
+                        <div class="flex items-center gap-2">
+                            <LucideIcon Name="@GetFileIcon(context.Item)"
+                                       Class="@ClassNames.cn("w-4 h-4 shrink-0", context.Item.IsFolder ? "text-blue-500" : "text-muted-foreground")" />
+                            <span class="truncate">@context.Value</span>
+                        </div>
+                    </CellTemplate>
+                </BbDataGridHierarchyColumn>
+                <BbDataGridTemplateColumn TData="FileEntry" Title="Size" Sortable SortBy="@(f => (object)(f.Size ?? 0L))">
+                    <ChildContent>
+                        <span class="text-muted-foreground tabular-nums">@FormatFileSize(context.Size)</span>
+                    </ChildContent>
+                </BbDataGridTemplateColumn>
+                <BbDataGridPropertyColumn TData="FileEntry" TProp="string" Property="@(f => f.Extension ?? "")" Title="Type" Sortable />
+                <BbDataGridPropertyColumn TData="FileEntry" TProp="DateTime" Property="@(f => f.Modified)" Title="Modified" Format="yyyy-MM-dd" Sortable />
+            </Columns>
+        </BbDataGrid>
+        @if (selectedFiles?.Count > 0)
+        {
+            <p class="text-sm text-muted-foreground">
+                @selectedFiles.Count item(s) selected
+            </p>
+        }
+        <CodeBlock Source="Components/DataGridHierarchy/file-explorer.txt" />
+    </div>
+
     <!-- ── Large Dataset (World Geography) ────────────────────────── -->
     <div class="space-y-4">
         <div class="space-y-2">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridHierarchyDemo.razor.cs
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridHierarchyDemo.razor.cs
@@ -310,6 +310,144 @@ public partial class DataGridHierarchyDemo : ComponentBase
         public List<Place>? Children { get; init; }
     }
 
+    // ── FileEntry (file explorer) ──
+
+    private IReadOnlyCollection<FileEntry>? selectedFiles;
+
+    private sealed class FileEntry
+    {
+        public string Id { get; init; } = "";
+        public string Name { get; init; } = "";
+        public bool IsFolder { get; init; }
+        public long? Size { get; init; }
+        public string? Extension { get; init; }
+        public DateTime Modified { get; init; }
+        public List<FileEntry>? Children { get; init; }
+    }
+
+    private static string GetFileIcon(FileEntry entry)
+    {
+        if (entry.IsFolder)
+        {
+            return "folder";
+        }
+
+        return entry.Extension switch
+        {
+            ".cs" or ".js" or ".ts" or ".razor" or ".html" or ".css" => "file-code",
+            ".json" or ".xml" or ".yaml" or ".yml" => "file-json-2",
+            ".png" or ".jpg" or ".svg" or ".gif" or ".ico" => "file-image",
+            ".md" or ".txt" => "file-text",
+            ".sln" or ".csproj" => "file-cog",
+            _ => "file"
+        };
+    }
+
+    private static string FormatFileSize(long? bytes)
+    {
+        if (bytes == null)
+        {
+            return "--";
+        }
+
+        double b = bytes.Value;
+        string[] units = { "B", "KB", "MB", "GB" };
+        var i = 0;
+        while (b >= 1024 && i < units.Length - 1)
+        {
+            b /= 1024;
+            i++;
+        }
+
+        return $"{b:0.#} {units[i]}";
+    }
+
+    private static readonly List<FileEntry> fileTree = new()
+    {
+        new()
+        {
+            Id = "f1", Name = "src", IsFolder = true, Modified = new(2025, 12, 5),
+            Children = new()
+            {
+                new()
+                {
+                    Id = "f2", Name = "Components", IsFolder = true, Modified = new(2025, 12, 1),
+                    Children = new()
+                    {
+                        new() { Id = "f3", Name = "Button.razor", Extension = ".razor", Size = 2_150, Modified = new(2025, 12, 1) },
+                        new() { Id = "f4", Name = "Button.razor.cs", Extension = ".cs", Size = 1_840, Modified = new(2025, 12, 1) },
+                        new() { Id = "f5", Name = "Dialog.razor", Extension = ".razor", Size = 3_420, Modified = new(2025, 11, 28) },
+                        new() { Id = "f6", Name = "Dialog.razor.cs", Extension = ".cs", Size = 4_200, Modified = new(2025, 11, 28) },
+                        new() { Id = "f7", Name = "DataGrid.razor", Extension = ".razor", Size = 8_960, Modified = new(2025, 12, 1) },
+                        new() { Id = "f8", Name = "DataGrid.razor.cs", Extension = ".cs", Size = 15_300, Modified = new(2025, 12, 1) }
+                    }
+                },
+                new()
+                {
+                    Id = "f9", Name = "Pages", IsFolder = true, Modified = new(2025, 12, 5),
+                    Children = new()
+                    {
+                        new() { Id = "f10", Name = "Home.razor", Extension = ".razor", Size = 1_200, Modified = new(2025, 12, 5) },
+                        new() { Id = "f11", Name = "Settings.razor", Extension = ".razor", Size = 2_800, Modified = new(2025, 11, 30) },
+                        new() { Id = "f12", Name = "Dashboard.razor", Extension = ".razor", Size = 5_100, Modified = new(2025, 12, 3) }
+                    }
+                },
+                new()
+                {
+                    Id = "f13", Name = "wwwroot", IsFolder = true, Modified = new(2025, 11, 15),
+                    Children = new()
+                    {
+                        new()
+                        {
+                            Id = "f14", Name = "css", IsFolder = true, Modified = new(2025, 11, 15),
+                            Children = new()
+                            {
+                                new() { Id = "f15", Name = "app.css", Extension = ".css", Size = 920, Modified = new(2025, 11, 15) },
+                                new() { Id = "f16", Name = "tailwind.css", Extension = ".css", Size = 48_200, Modified = new(2025, 11, 15) }
+                            }
+                        },
+                        new()
+                        {
+                            Id = "f17", Name = "images", IsFolder = true, Modified = new(2025, 10, 20),
+                            Children = new()
+                            {
+                                new() { Id = "f18", Name = "logo.svg", Extension = ".svg", Size = 4_500, Modified = new(2025, 10, 20) },
+                                new() { Id = "f19", Name = "hero.png", Extension = ".png", Size = 131_400, Modified = new(2025, 10, 20) },
+                                new() { Id = "f20", Name = "og-image.jpg", Extension = ".jpg", Size = 89_600, Modified = new(2025, 10, 20) }
+                            }
+                        },
+                        new() { Id = "f21", Name = "favicon.ico", Extension = ".ico", Size = 1_100, Modified = new(2025, 10, 1) }
+                    }
+                },
+                new() { Id = "f22", Name = "App.razor", Extension = ".razor", Size = 520, Modified = new(2025, 12, 5) },
+                new() { Id = "f23", Name = "Program.cs", Extension = ".cs", Size = 1_300, Modified = new(2025, 12, 3) }
+            }
+        },
+        new()
+        {
+            Id = "f24", Name = "tests", IsFolder = true, Modified = new(2025, 12, 4),
+            Children = new()
+            {
+                new() { Id = "f25", Name = "ComponentTests.cs", Extension = ".cs", Size = 3_200, Modified = new(2025, 12, 4) },
+                new() { Id = "f26", Name = "PageTests.cs", Extension = ".cs", Size = 2_100, Modified = new(2025, 12, 2) },
+                new() { Id = "f27", Name = "IntegrationTests.cs", Extension = ".cs", Size = 4_800, Modified = new(2025, 12, 4) }
+            }
+        },
+        new()
+        {
+            Id = "f28", Name = "docs", IsFolder = true, Modified = new(2025, 12, 6),
+            Children = new()
+            {
+                new() { Id = "f29", Name = "README.md", Extension = ".md", Size = 4_800, Modified = new(2025, 12, 6) },
+                new() { Id = "f30", Name = "CHANGELOG.md", Extension = ".md", Size = 12_400, Modified = new(2025, 12, 5) },
+                new() { Id = "f31", Name = "architecture.md", Extension = ".md", Size = 6_200, Modified = new(2025, 11, 20) }
+            }
+        },
+        new() { Id = "f32", Name = ".gitignore", Size = 310, Modified = new(2025, 10, 1) },
+        new() { Id = "f33", Name = "BlazorApp.sln", Extension = ".sln", Size = 1_200, Modified = new(2025, 10, 1) },
+        new() { Id = "f34", Name = "global.json", Extension = ".json", Size = 85, Modified = new(2025, 10, 1) }
+    };
+
     private static List<Place> worldData = AssignIds(BuildWorldData());
 
     private static List<Place> AssignIds(List<Place> places)

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor
@@ -566,6 +566,7 @@
                     {
                         <div @onclick:stopPropagation="true">
                             <BbCheckbox Checked="@_gridState.Selection.IsSelected(item)"
+                                      Indeterminate="@IsHierarchyItemIndeterminate(item)"
                                       CheckedChanged="@((bool isChecked) => HandleRowSelectionChanged(item, isChecked))"
                                       AriaLabel="Select this row" />
                         </div>

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
@@ -489,6 +489,17 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     [Parameter]
     public int? ChildPageSize { get; set; }
 
+    /// <summary>
+    /// Controls how row selection interacts with the hierarchy.
+    /// <see cref="HierarchySelectionMode.Independent"/> (default) treats each row independently.
+    /// <see cref="HierarchySelectionMode.Cascade"/> cascades selection to descendants and shows
+    /// an indeterminate state on parents with partially selected children.
+    /// Only applies when <see cref="SelectionMode"/> is <see cref="DataTableSelectionMode.Multiple"/>
+    /// and hierarchy mode is active.
+    /// </summary>
+    [Parameter]
+    public HierarchySelectionMode HierarchySelectionMode { get; set; } = HierarchySelectionMode.Independent;
+
     internal DataGridState<TData> EffectiveState => State ?? _gridState;
 
     protected override void OnInitialized()
@@ -2162,6 +2173,14 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
             _gridState.Selection.Deselect(item);
         }
 
+        if (HierarchySelectionMode == HierarchySelectionMode.Cascade
+            && IsHierarchyMode && _hierarchyManager != null && ItemValueSelector != null)
+        {
+            var value = ItemValueSelector(item);
+            CascadeSelectionToDescendants(value, isChecked);
+            UpdateAncestorSelection(value);
+        }
+
         _stateVersion++;
 
         if (SelectedItemsChanged.HasDelegate)
@@ -2171,6 +2190,92 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
 
         await NotifyStateChangedAsync();
         StateHasChanged();
+    }
+
+    private void CascadeSelectionToDescendants(string value, bool select)
+    {
+        if (_hierarchyManager == null)
+        {
+            return;
+        }
+
+        var descendantValues = _hierarchyManager.GetAllDescendantValues(value);
+        foreach (var dv in descendantValues)
+        {
+            var descendant = _hierarchyManager.GetItemByValue(dv);
+            if (descendant != null)
+            {
+                if (select)
+                {
+                    _gridState.Selection.Select(descendant);
+                }
+                else
+                {
+                    _gridState.Selection.Deselect(descendant);
+                }
+            }
+        }
+    }
+
+    private void UpdateAncestorSelection(string value)
+    {
+        if (_hierarchyManager == null)
+        {
+            return;
+        }
+
+        var ancestors = _hierarchyManager.GetAncestorValues(value);
+        foreach (var ancestorValue in ancestors)
+        {
+            var ancestor = _hierarchyManager.GetItemByValue(ancestorValue);
+            if (ancestor == null)
+            {
+                continue;
+            }
+
+            var childValues = _hierarchyManager.GetDirectChildValues(ancestorValue);
+            var allSelected = childValues.Count > 0 && childValues.All(cv =>
+            {
+                var child = _hierarchyManager.GetItemByValue(cv);
+                return child != null && _gridState.Selection.IsSelected(child);
+            });
+
+            if (allSelected)
+            {
+                _gridState.Selection.Select(ancestor);
+            }
+            else
+            {
+                _gridState.Selection.Deselect(ancestor);
+            }
+        }
+    }
+
+    private bool IsHierarchyItemIndeterminate(TData item)
+    {
+        if (HierarchySelectionMode != HierarchySelectionMode.Cascade
+            || _hierarchyManager == null || ItemValueSelector == null)
+        {
+            return false;
+        }
+
+        var value = ItemValueSelector(item);
+        if (!_hierarchyManager.HasChildren(value))
+        {
+            return false;
+        }
+
+        if (_gridState.Selection.IsSelected(item))
+        {
+            return false;
+        }
+
+        var descendantValues = _hierarchyManager.GetAllDescendantValues(value);
+        return descendantValues.Any(dv =>
+        {
+            var desc = _hierarchyManager.GetItemByValue(dv);
+            return desc != null && _gridState.Selection.IsSelected(desc);
+        });
     }
 
     internal async Task HandleGroupToggle(DataGridGroupRow<TData> groupRow)

--- a/src/BlazorBlueprint.Components/Components/DataGrid/HierarchySelectionMode.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/HierarchySelectionMode.cs
@@ -1,0 +1,21 @@
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// Controls how row selection interacts with hierarchy in a <see cref="BbDataGrid{TData}"/>.
+/// </summary>
+public enum HierarchySelectionMode
+{
+    /// <summary>
+    /// Selection is independent per row. Selecting a parent does not affect children.
+    /// This is the default behavior.
+    /// </summary>
+    Independent = 0,
+
+    /// <summary>
+    /// Selecting a parent cascades to all descendants. Deselecting a parent deselects all descendants.
+    /// When some (but not all) descendants are selected, the parent checkbox shows an indeterminate state.
+    /// Only applies when <see cref="BbDataGrid{TData}.SelectionMode"/> is <see cref="DataTableSelectionMode.Multiple"/>
+    /// and hierarchy mode is active.
+    /// </summary>
+    Cascade = 1
+}

--- a/src/BlazorBlueprint.Primitives/Utilities/HierarchyManager.cs
+++ b/src/BlazorBlueprint.Primitives/Utilities/HierarchyManager.cs
@@ -282,6 +282,17 @@ public partial class HierarchyManager<TItem>
     /// </summary>
     public bool IsRegistered(string value) => itemsByValue.ContainsKey(value);
 
+    /// <summary>
+    /// Gets the direct child values of a parent. Pass null for root items.
+    /// </summary>
+    public IReadOnlyList<string> GetDirectChildValues(string? parentValue)
+    {
+        var key = parentValue ?? RootParentKey;
+        return childrenByParent.TryGetValue(key, out var children)
+            ? children
+            : Array.Empty<string>();
+    }
+
     // --- Traversal ---
 
     /// <summary>

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -784,6 +784,8 @@
   - GroupedItemsProvider : DataGridGroupedItemsProvider<TData>
   - GroupsCollapsedByDefault : Boolean
   - HasChildrenPredicate : Func<TData, Boolean>
+  - HierarchyFilterMode : HierarchyFilterMode
+  - HierarchySelectionMode : HierarchySelectionMode
   - InitialPageSize : Int32
   - IsLoading : Boolean
   - ItemFilter : Func<TData, Boolean>
@@ -3309,6 +3311,10 @@
 ### GradientDirection (BlazorBlueprint.Components)
   - Vertical = 0
   - Horizontal = 1
+
+### HierarchySelectionMode (BlazorBlueprint.Components)
+  - Independent = 0
+  - Cascade = 1
 
 ### IconPosition (BlazorBlueprint.Components)
   - Start = 0

--- a/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
@@ -985,6 +985,10 @@
   - Horizontal = 0
   - Vertical = 1
 
+### HierarchyFilterMode (BlazorBlueprint.Primitives.Utilities)
+  - ShowMatchedSubtree = 0
+  - ShowMatchedOnly = 1
+
 ### Orientation (BlazorBlueprint.Primitives.Utilities)
   - Horizontal = 0
   - Vertical = 1


### PR DESCRIPTION
## Summary
- Add `HierarchySelectionMode` enum (`Independent` / `Cascade`) and corresponding parameter on `BbDataGrid` to support parent-child cascading selection in hierarchy mode
- When `Cascade` is active: selecting a parent selects all descendants, deselecting deselects all descendants, and partially-selected parents show an indeterminate checkbox state
- Add `GetDirectChildValues` method to `HierarchyManager<T>` for efficient ancestor state calculation
- Add file-explorer-style demo to the hierarchy demo page with file/folder icons, type-aware Lucide icons, file size formatting, sortable/reorderable/resizable columns, and cascade selection