### PR TITLE
fix: cascade ShouldRender for remaining optimized components

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Calendar/BbCalendar.razor
+++ b/src/BlazorBlueprint.Components/Components/Calendar/BbCalendar.razor
@@ -129,6 +129,7 @@
     private List<List<DateTime?>>? _cachedWeeks;
 
     // ShouldRender tracking fields
+    private bool _parametersChanged;
     private DateTime? _lastSelected;
     private DateTime _lastDisplayDate;
     private DateTime? _lastMinDate;
@@ -245,6 +246,8 @@
 
     protected override void OnParametersSet()
     {
+        _parametersChanged = true;
+
         // Only sync display date when Selected actually changes from external source
         // This prevents overwriting user's month/year navigation
         if (Selected != _previousSelected)
@@ -678,6 +681,19 @@
     /// </summary>
     protected override bool ShouldRender()
     {
+        if (_parametersChanged)
+        {
+            _parametersChanged = false;
+            _lastSelected = Selected;
+            _lastDisplayDate = _displayDate;
+            _lastMinDate = MinDate;
+            _lastMaxDate = MaxDate;
+            _lastShowMonthYearDropdowns = ShowMonthYearDropdowns;
+            _lastFocusedDate = _focusedDate;
+            _lastIsKeyboardNavigating = _isKeyboardNavigating;
+            return true;
+        }
+
         var selectedChanged = _lastSelected != Selected;
         var displayDateChanged = _lastDisplayDate != _displayDate;
         var minDateChanged = _lastMinDate != MinDate;

--- a/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor.cs
@@ -55,6 +55,7 @@ public partial class BbCombobox<TValue> : ComponentBase
     private string? _selectedDisplayTextCache;
 
     // ShouldRender tracking fields
+    private bool _parametersChanged;
     private bool _lastIsOpen;
     private IEnumerable<SelectOption<TValue>>? _lastOptions;
     private TValue? _lastValue;
@@ -63,6 +64,17 @@ public partial class BbCombobox<TValue> : ComponentBase
 
     protected override bool ShouldRender()
     {
+        if (_parametersChanged)
+        {
+            _parametersChanged = false;
+            _lastIsOpen = _isOpen;
+            _lastValue = Value;
+            _lastDisabled = Disabled;
+            _lastSearchQuery = SearchQuery;
+            _lastOptions = Options;
+            return true;
+        }
+
         if (_isOpen != _lastIsOpen
             || !EqualityComparer<TValue>.Default.Equals(Value, _lastValue)
             || Disabled != _lastDisabled
@@ -236,6 +248,7 @@ public partial class BbCombobox<TValue> : ComponentBase
     /// </summary>
     protected override void OnParametersSet()
     {
+        _parametersChanged = true;
         base.OnParametersSet();
 
         // Filter out null options for safety (Options mode only)

--- a/src/BlazorBlueprint.Components/Components/DateRangePicker/BbDateRangePicker.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DateRangePicker/BbDateRangePicker.razor.cs
@@ -24,6 +24,7 @@ public partial class BbDateRangePicker : ComponentBase
     private List<List<DateTime?>>? _cachedWeeksMonth2;
 
     // ShouldRender tracking fields
+    private bool _parametersChanged;
     private bool _lastIsOpen;
     private DateTime _lastDisplayMonth1;
     private DateTime _lastDisplayMonth2;
@@ -167,6 +168,8 @@ public partial class BbDateRangePicker : ComponentBase
 
     protected override void OnParametersSet()
     {
+        _parametersChanged = true;
+
         // Only sync when Value actually changes from external source
         if (Value != _previousValue)
         {
@@ -548,6 +551,23 @@ public partial class BbDateRangePicker : ComponentBase
     /// </summary>
     protected override bool ShouldRender()
     {
+        if (_parametersChanged)
+        {
+            _parametersChanged = false;
+            _lastIsOpen = _isOpen;
+            _lastDisplayMonth1 = _displayMonth1;
+            _lastDisplayMonth2 = _displayMonth2;
+            _lastSelectionStart = _selectionStart;
+            _lastSelectionEnd = _selectionEnd;
+            _lastValue = Value;
+            _lastMinDate = MinDate;
+            _lastMaxDate = MaxDate;
+            _lastShowTwoMonths = ShowTwoMonths;
+            _lastShowPresets = ShowPresets;
+            _lastDisabled = Disabled;
+            return true;
+        }
+
         var changed = _lastIsOpen != _isOpen
             || _lastDisplayMonth1 != _displayMonth1
             || _lastDisplayMonth2 != _displayMonth2

--- a/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor.cs
@@ -24,6 +24,7 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
     private bool _focusDone;
 
     // ShouldRender tracking fields
+    private bool _parametersChanged;
     private IEnumerable<SelectOption<TValue>>? _lastOptions;
     private IEnumerable<TValue>? _lastValues;
     private bool _lastIsOpen;
@@ -271,6 +272,7 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
     /// </summary>
     protected override void OnParametersSet()
     {
+        _parametersChanged = true;
         base.OnParametersSet();
 
         // Filter out null options for safety (Options mode only)
@@ -618,6 +620,17 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
     /// </summary>
     protected override bool ShouldRender()
     {
+        if (_parametersChanged)
+        {
+            _parametersChanged = false;
+            _lastOptions = Options;
+            _lastValues = Values;
+            _lastIsOpen = _isOpen;
+            _lastSearchQuery = _searchQuery;
+            _lastDisabled = Disabled;
+            return true;
+        }
+
         var optionsChanged = !ReferenceEquals(_lastOptions, Options);
         var valuesChanged = !ReferenceEquals(_lastValues, Values);
         var openChanged = _lastIsOpen != _isOpen;

--- a/src/BlazorBlueprint.Components/Components/RichTextEditor/BbRichTextEditor.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/RichTextEditor/BbRichTextEditor.razor.cs
@@ -38,6 +38,7 @@ public partial class BbRichTextEditor : ComponentBase, IAsyncDisposable
     private EditorRange? _savedSelection;
 
     // === ShouldRender Tracking ===
+    private bool _parametersChanged;
     private string? _lastValue;
     private bool _lastDisabled;
     private bool _lastReadOnly;
@@ -199,6 +200,8 @@ public partial class BbRichTextEditor : ComponentBase, IAsyncDisposable
 
     protected override async Task OnParametersSetAsync()
     {
+        _parametersChanged = true;
+
         // If Value changed externally, update the editor
         if (_jsInitialized && Value != _lastKnownValue && !_pendingValueUpdate)
         {
@@ -402,6 +405,17 @@ public partial class BbRichTextEditor : ComponentBase, IAsyncDisposable
     /// </summary>
     protected override bool ShouldRender()
     {
+        if (_parametersChanged)
+        {
+            _parametersChanged = false;
+            _lastValue = Value;
+            _lastDisabled = Disabled;
+            _lastReadOnly = ReadOnly;
+            _lastLinkDialogOpen = _linkDialogOpen;
+            _formatStateChanged = false;
+            return true;
+        }
+
         var valueChanged = _lastValue != Value;
         var disabledChanged = _lastDisabled != Disabled;
         var readOnlyChanged = _lastReadOnly != ReadOnly;

--- a/src/BlazorBlueprint.Components/Components/TimePicker/BbTimePicker.razor
+++ b/src/BlazorBlueprint.Components/Components/TimePicker/BbTimePicker.razor
@@ -159,12 +159,22 @@
     private EditContext? _editContext;
 
     // ShouldRender tracking fields
+    private bool _parametersChanged;
     private TimeSpan? _lastValue;
     private bool _lastIsOpen;
     private bool _lastDisabled;
 
     protected override bool ShouldRender()
     {
+        if (_parametersChanged)
+        {
+            _parametersChanged = false;
+            _lastIsOpen = _isOpen;
+            _lastValue = Value;
+            _lastDisabled = Disabled;
+            return true;
+        }
+
         if (_isOpen != _lastIsOpen
             || Value != _lastValue
             || Disabled != _lastDisabled)
@@ -267,6 +277,8 @@
 
     protected override void OnParametersSet()
     {
+        _parametersChanged = true;
+
         if (Value.HasValue)
         {
             _internalHour = Value.Value.Hours;


### PR DESCRIPTION
## Summary
- Extends the `_parametersChanged` pattern from #206 to six additional components whose `ShouldRender()` optimization could block cascading re-renders from parent components
- Affected components: `BbCombobox`, `BbMultiSelect`, `BbDateRangePicker`, `BbRichTextEditor`, `BbTimePicker`, `BbCalendar`
- `BbTagInput` was not changed as it already returns `true` as its fallback path

## Context
PR #206 fixed this issue for container components (`BbDataGrid`, `BbDataTable`, `BbDataView`, `BbCollapsible`, `BbTable`), but missed these six components that have the same `ShouldRender()` tracking pattern and are equally susceptible to blocking parent re-render cascades.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — all 48 tests pass (API surface snapshots unchanged since `_parametersChanged` is private)
- [x] Manual: nest a Combobox/MultiSelect inside a parent that re-renders and confirm the child updates