### PR TITLE
feat(filtering): add Hours, Minutes, Seconds to date/time filters

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
@@ -106,6 +106,8 @@
                     FilterType="FilterFieldType.Enum"
                     FilterOptions="@(new[] { "Active", "Inactive", "Pending", "Suspended" }.Select(s => new SelectOption<string>(s, s)))"
                     Width="120px" />
+                <BbDataGridPropertyColumn TData="Person" TProp="DateTime" Property="@(p => p.JoinDate)" Title="Join Date" Sortable Filterable Format="d" Width="130px" />
+                <BbDataGridPropertyColumn TData="Person" TProp="DateTime" Property="@(p => p.LastActivity)" Title="Last Activity" Sortable Filterable Format="g" Width="170px" />
                 <BbDataGridPropertyColumn TData="Person" TProp="bool" Property="@(p => p.IsActive)" Title="Active" Sortable Filterable Width="100px" />
             </Columns>
         </BbDataGrid>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Recipes/FilterableDataGridRecipe.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Recipes/FilterableDataGridRecipe.razor
@@ -39,6 +39,7 @@
             <BbBadge Variant="BadgeVariant.Outline">Role (Enum)</BbBadge>
             <BbBadge Variant="BadgeVariant.Outline">Status (Enum)</BbBadge>
             <BbBadge Variant="BadgeVariant.Outline">Join Date (Date)</BbBadge>
+            <BbBadge Variant="BadgeVariant.Outline">Last Activity (DateTime)</BbBadge>
             <BbBadge Variant="BadgeVariant.Outline">Last Promotion (Date)</BbBadge>
             <BbBadge Variant="BadgeVariant.Outline">Active (Boolean)</BbBadge>
         </div>
@@ -100,6 +101,7 @@
             <BbDataGridPropertyColumn Property="@(e => e.Age)" Title="Age" Sortable="true" Width="80px" />
             <BbDataGridPropertyColumn Property="@(e => e.Salary)" Title="Salary" Sortable="true" Format="C0" Width="120px" />
             <BbDataGridPropertyColumn Property="@(e => e.JoinDate)" Title="Join Date" Sortable="true" Format="d" Width="130px" />
+            <BbDataGridPropertyColumn Property="@(e => e.LastActivity)" Title="Last Activity" Sortable="true" Format="g" Width="170px" />
             <BbDataGridTemplateColumn Title="Last Promotion" Sortable="true" SortBy="@(e => e.LastPromotionDate)" Width="150px">
                 @{
                     var emp = context;
@@ -169,6 +171,7 @@
             Options = Statuses.Select(s => new SelectOption<string>(s, s)).ToArray()
         },
         new FilterField { Name = "JoinDate", Label = "Join Date", Type = FilterFieldType.Date },
+        new FilterField { Name = "LastActivity", Label = "Last Activity", Type = FilterFieldType.DateTime },
         new FilterField { Name = "LastPromotionDate", Label = "Last Promotion", Type = FilterFieldType.Date },
         new FilterField { Name = "IsActive", Label = "Active", Type = FilterFieldType.Boolean }
     };
@@ -258,6 +261,7 @@
                 Status = Statuses[Rng.Next(Statuses.Length)],
                 Salary = RoundToNearest500(Rng.Next(35000, 200000)),
                 JoinDate = joinDate,
+                LastActivity = GenerateLastActivity(i, count),
                 LastPromotionDate = hasPromotion ? joinDate.AddDays(Rng.Next(90, 1500)) : null,
                 IsActive = Rng.Next(100) > 15
             });
@@ -267,6 +271,21 @@
     }
 
     private static int RoundToNearest500(int value) => (int)(Math.Round(value / 500.0) * 500);
+
+    private static DateTime GenerateLastActivity(int index, int count)
+    {
+        var now = DateTime.Now;
+        var bucket = (index * 6) / count;
+        return bucket switch
+        {
+            0 => now.AddSeconds(-Rng.Next(1, 60)),
+            1 => now.AddMinutes(-Rng.Next(1, 60)),
+            2 => now.AddHours(-Rng.Next(1, 24)),
+            3 => now.AddDays(-Rng.Next(1, 7)),
+            4 => now.AddDays(-Rng.Next(7, 28)),
+            _ => now.AddDays(-Rng.Next(28, 365))
+        };
+    }
 
     public class Employee
     {
@@ -279,6 +298,7 @@
         public string Status { get; set; } = string.Empty;
         public int Salary { get; set; }
         public DateTime JoinDate { get; set; }
+        public DateTime LastActivity { get; set; }
         public DateTime? LastPromotionDate { get; set; }
         public bool IsActive { get; set; }
     }

--- a/demos/BlazorBlueprint.Demo.Shared/Services/MockDataService.cs
+++ b/demos/BlazorBlueprint.Demo.Shared/Services/MockDataService.cs
@@ -121,6 +121,7 @@ public class MockDataService
                 LastPromotionDate = GeneratePromotionDate(),
                 Salary = _random.Next(40000, 150000),
                 JoinDate = DateTime.Now.AddDays(-_random.Next(1, 3650)), // Random date within last 10 years
+                LastActivity = GenerateLastActivity(i, count),
                 IsActive = _random.Next(100) > 20 // 80% chance of being active
             });
         }
@@ -152,6 +153,26 @@ public class MockDataService
 
     private static DateTimeOffset? GeneratePromotionDate() =>
         DateTimeOffset.UtcNow - TimeSpan.FromDays(_random.Next(365, 730));
+
+    private static DateTime GenerateLastActivity(int index, int count)
+    {
+        var now = DateTime.Now;
+
+        // Distribute records across time ranges so every filter unit is testable:
+        // ~10% within last 60 seconds, ~10% within last 60 minutes,
+        // ~15% within last 24 hours, ~20% within last 7 days,
+        // ~20% within last 4 weeks, ~25% within last 12 months
+        var bucket = index * 6 / count;
+        return bucket switch
+        {
+            0 => now.AddSeconds(-_random.Next(1, 60)),
+            1 => now.AddMinutes(-_random.Next(1, 60)),
+            2 => now.AddHours(-_random.Next(1, 24)),
+            3 => now.AddDays(-_random.Next(1, 7)),
+            4 => now.AddDays(-_random.Next(7, 28)),
+            _ => now.AddDays(-_random.Next(28, 365))
+        };
+    }
 
     /// <summary>
     /// Generates a list of mock product records.
@@ -201,6 +222,7 @@ public class Person
     public DateTimeOffset? LastPromotionDate { get; set; }
     public int Salary { get; set; }
     public DateTime JoinDate { get; set; }
+    public DateTime LastActivity { get; set; }
     public bool IsActive { get; set; }
 }
 

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridColumnFilter.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridColumnFilter.razor.cs
@@ -18,7 +18,10 @@ public partial class BbDataGridColumnFilter : ComponentBase
     {
         new SelectOption<InLastPeriod>(InLastPeriod.Days, "days"),
         new SelectOption<InLastPeriod>(InLastPeriod.Weeks, "weeks"),
-        new SelectOption<InLastPeriod>(InLastPeriod.Months, "months")
+        new SelectOption<InLastPeriod>(InLastPeriod.Months, "months"),
+        new SelectOption<InLastPeriod>(InLastPeriod.Hours, "hours"),
+        new SelectOption<InLastPeriod>(InLastPeriod.Minutes, "minutes"),
+        new SelectOption<InLastPeriod>(InLastPeriod.Seconds, "seconds")
     };
 
     private static readonly IEnumerable<SelectOption<DatePreset>> datePresetOptions = new[]

--- a/src/BlazorBlueprint.Components/Components/FilterBuilder/BbFilterCondition.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/FilterBuilder/BbFilterCondition.razor.cs
@@ -15,7 +15,10 @@ public partial class BbFilterCondition : ComponentBase
     {
         new SelectOption<InLastPeriod>(InLastPeriod.Days, "days"),
         new SelectOption<InLastPeriod>(InLastPeriod.Weeks, "weeks"),
-        new SelectOption<InLastPeriod>(InLastPeriod.Months, "months")
+        new SelectOption<InLastPeriod>(InLastPeriod.Months, "months"),
+        new SelectOption<InLastPeriod>(InLastPeriod.Hours, "hours"),
+        new SelectOption<InLastPeriod>(InLastPeriod.Minutes, "minutes"),
+        new SelectOption<InLastPeriod>(InLastPeriod.Seconds, "seconds")
     };
 
     private static readonly IEnumerable<SelectOption<DatePreset>> datePresetOptions = new[]

--- a/src/BlazorBlueprint.Primitives/Primitives/Filtering/FilterDefinitionExtensions.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/Filtering/FilterDefinitionExtensions.cs
@@ -299,6 +299,9 @@ public static class FilterDefinitionExtensions
             InLastPeriod.Days => now.AddDays(-amount),
             InLastPeriod.Weeks => now.AddDays(-amount * 7),
             InLastPeriod.Months => now.AddMonths(-amount),
+            InLastPeriod.Hours => now.AddHours(-amount),
+            InLastPeriod.Minutes => now.AddMinutes(-amount),
+            InLastPeriod.Seconds => now.AddSeconds(-amount),
             _ => now
         };
 
@@ -332,6 +335,9 @@ public static class FilterDefinitionExtensions
             InLastPeriod.Days => DateTime.Now.AddDays(amount),
             InLastPeriod.Weeks => DateTime.Now.AddDays(amount * 7),
             InLastPeriod.Months => DateTime.Now.AddMonths(amount),
+            InLastPeriod.Hours => DateTime.Now.AddHours(amount),
+            InLastPeriod.Minutes => DateTime.Now.AddMinutes(amount),
+            InLastPeriod.Seconds => DateTime.Now.AddSeconds(amount),
             _ => DateTime.Now
         };
 
@@ -672,6 +678,9 @@ public static class FilterDefinitionExtensions
             InLastPeriod.Days => DateTime.Now.AddDays(-amount),
             InLastPeriod.Weeks => DateTime.Now.AddDays(-amount * 7),
             InLastPeriod.Months => DateTime.Now.AddMonths(-amount),
+            InLastPeriod.Hours => DateTime.Now.AddHours(-amount),
+            InLastPeriod.Minutes => DateTime.Now.AddMinutes(-amount),
+            InLastPeriod.Seconds => DateTime.Now.AddSeconds(-amount),
             _ => DateTime.Now
         };
 
@@ -719,6 +728,9 @@ public static class FilterDefinitionExtensions
             InLastPeriod.Days => now.AddDays(amount),
             InLastPeriod.Weeks => now.AddDays(amount * 7),
             InLastPeriod.Months => now.AddMonths(amount),
+            InLastPeriod.Hours => now.AddHours(amount),
+            InLastPeriod.Minutes => now.AddMinutes(amount),
+            InLastPeriod.Seconds => now.AddSeconds(amount),
             _ => now
         };
 

--- a/src/BlazorBlueprint.Primitives/Primitives/Filtering/InLastPeriod.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/Filtering/InLastPeriod.cs
@@ -18,5 +18,20 @@ public enum InLastPeriod
     /// <summary>
     /// Number of months.
     /// </summary>
-    Months
+    Months,
+
+    /// <summary>
+    /// Number of hours.
+    /// </summary>
+    Hours,
+
+    /// <summary>
+    /// Number of minutes.
+    /// </summary>
+    Minutes,
+
+    /// <summary>
+    /// Number of seconds.
+    /// </summary>
+    Seconds
 }

--- a/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
@@ -869,6 +869,9 @@
   - Days = 0
   - Weeks = 1
   - Months = 2
+  - Hours = 3
+  - Minutes = 4
+  - Seconds = 5
 
 ### LogicalOperator (BlazorBlueprint.Primitives.Filtering)
   - And = 0


### PR DESCRIPTION
## Summary
- Adds `Hours`, `Minutes`, and `Seconds` values to the `InLastPeriod` enum, enabling finer-grained time filtering with the `InLast` and `InNext` operators
- Updates all filter evaluation logic (both `ToFunc` and `ToExpression` paths) to handle the new time units
- Adds the new options to the FilterBuilder (`BbFilterCondition`) and DataGrid column filter (`BbDataGridColumnFilter`) dropdowns
- Adds a `LastActivity` DateTime column to the DataGrid demo and Filterable DataGrid recipe with time-distributed sample data (seconds, minutes, hours, days, weeks, months ago) for testing all filter units