### PR TITLE
fix(Textarea): correct UpdateTiming.OnChange docs to not mention Enter

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Input/UpdateTiming.cs
+++ b/src/BlazorBlueprint.Components/Components/Input/UpdateTiming.cs
@@ -11,7 +11,8 @@ public enum UpdateTiming
     Immediate,
 
     /// <summary>
-    /// Fires <c>ValueChanged</c> only when the input loses focus or the user presses Enter (default).
+    /// Fires <c>ValueChanged</c> only when the element loses focus (default).
+    /// For single-line inputs, also fires when the user presses Enter.
     /// Zero C# interop calls during typing.
     /// </summary>
     OnChange,

--- a/src/BlazorBlueprint.Components/Components/InputGroup/BbInputGroupTextarea.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/InputGroup/BbInputGroupTextarea.razor.cs
@@ -252,7 +252,7 @@ public partial class BbInputGroupTextarea : ComponentBase
     }
 
     /// <summary>
-    /// Called from JavaScript on blur/Enter (all modes).
+    /// Called from JavaScript on blur (all modes).
     /// </summary>
     [JSInvokable]
     public async Task JsOnChange(string? value)

--- a/src/BlazorBlueprint.Components/Components/Textarea/BbTextarea.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Textarea/BbTextarea.razor.cs
@@ -70,7 +70,7 @@ public partial class BbTextarea : ComponentBase
     /// </summary>
     /// <remarks>
     /// When <see cref="UpdateTiming"/> is <see cref="UpdateTiming.OnChange"/> (default),
-    /// fires only on blur or Enter. Use <see cref="UpdateTiming.Immediate"/> for per-keystroke updates.
+    /// fires only on blur. Use <see cref="UpdateTiming.Immediate"/> for per-keystroke updates.
     /// </remarks>
     [Parameter]
     public EventCallback<string?> ValueChanged { get; set; }
@@ -200,7 +200,7 @@ public partial class BbTextarea : ComponentBase
     /// <remarks>
     /// <list type="bullet">
     /// <item><see cref="UpdateTiming.Immediate"/> — every keystroke (batched via requestAnimationFrame).</item>
-    /// <item><see cref="UpdateTiming.OnChange"/> — only on blur / Enter (default).</item>
+    /// <item><see cref="UpdateTiming.OnChange"/> — only on blur (default).</item>
     /// <item><see cref="UpdateTiming.Debounced"/> — after typing pauses for <see cref="DebounceInterval"/> ms.</item>
     /// </list>
     /// </remarks>
@@ -339,7 +339,7 @@ public partial class BbTextarea : ComponentBase
     }
 
     /// <summary>
-    /// Called from JavaScript on blur/Enter (all modes).
+    /// Called from JavaScript on blur (all modes).
     /// </summary>
     [JSInvokable]
     public async Task JsOnChange(string? value)

--- a/src/BlazorBlueprint.Components/wwwroot/js/text-input.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/text-input.js
@@ -3,7 +3,8 @@
  * Handles input/change events in JS to minimize C# interop calls.
  *
  * Modes:
- *   - onchange:  JS only calls C# on blur/Enter (zero interop during typing).
+ *   - onchange:  JS only calls C# on the native change event (zero interop during typing).
+ *                For inputs this fires on blur and Enter; for textareas it fires on blur only.
  *   - immediate: JS batches calls via requestAnimationFrame.
  *   - debounced: JS debounces calls via setTimeout.
  */


### PR DESCRIPTION
Closes #229

## Summary
- The `UpdateTiming.OnChange` XML docs incorrectly stated that `ValueChanged` fires on Enter for all elements, but the HTML `change` event only fires on Enter for `<input>` — for `<textarea>`, Enter simply adds a newline
- Updated `UpdateTiming` enum docs to clarify Enter only applies to single-line inputs
- Fixed XML docs in `BbTextarea`, `BbInputGroupTextarea`, and JS module comments to say "blur" instead of "blur/Enter"

## Test plan
- [x] Build succeeds with zero warnings
- [x] All 48 tests pass (including API surface snapshots)