### PR TITLE
fix: address codebase review issues from 2026-03-11

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.JSInterop;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
@@ -329,9 +330,9 @@ public partial class BbCombobox<TValue> : ComponentBase
             await Task.Delay(50);
             await _commandInputRef.FocusAsync();
         }
-        catch
+        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
         {
-            // Ignore focus errors
+            // Expected during circuit disconnect or disposal
         }
     }
 

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
@@ -1548,16 +1548,29 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
 
         if (a is IComparable comparableA)
         {
-            try
+            if (a.GetType() == b.GetType())
             {
-                if (b is string bStr && a is not string)
+                return comparableA.CompareTo(b);
+            }
+
+            if (b is string bStr && a is not string)
+            {
+                try
                 {
                     var converted = Convert.ChangeType(bStr, a.GetType(), System.Globalization.CultureInfo.InvariantCulture);
                     return comparableA.CompareTo(converted);
                 }
+                catch (Exception ex) when (ex is InvalidCastException or FormatException or OverflowException)
+                {
+                    return string.Compare(a.ToString(), b.ToString(), StringComparison.OrdinalIgnoreCase);
+                }
+            }
+
+            try
+            {
                 return comparableA.CompareTo(b);
             }
-            catch
+            catch (Exception ex) when (ex is ArgumentException or InvalidCastException)
             {
                 return string.Compare(a.ToString(), b.ToString(), StringComparison.OrdinalIgnoreCase);
             }

--- a/src/BlazorBlueprint.Components/Components/Input/BbInput.razor
+++ b/src/BlazorBlueprint.Components/Components/Input/BbInput.razor
@@ -15,4 +15,5 @@
     required="@Required"
     aria-label="@AriaLabel"
     aria-describedby="@AriaDescribedBy"
-    aria-invalid="@EffectiveAriaInvalid" />
+    aria-invalid="@EffectiveAriaInvalid"
+    @attributes="AdditionalAttributes" />

--- a/src/BlazorBlueprint.Components/Components/Input/BbInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Input/BbInput.razor.cs
@@ -169,6 +169,12 @@ public partial class BbInput : ComponentBase
     public bool? AriaInvalid { get; set; }
 
     /// <summary>
+    /// Gets or sets additional HTML attributes to apply to the input element.
+    /// </summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    /// <summary>
     /// Gets or sets the HTML name attribute for the input element.
     /// </summary>
     /// <remarks>

--- a/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor.cs
@@ -323,9 +323,19 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
                     $"{Id}-search",
                     $"{Id}-listbox");
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
             {
-                Console.WriteLine($"MultiSelect JS setup failed: {ex.Message}");
+                // Expected during circuit disconnect
+                _jsSetupDone = false;
+                _dotNetRef?.Dispose();
+                _dotNetRef = null;
+            }
+            catch (InvalidOperationException)
+            {
+                // JS interop not available during prerendering
+                _jsSetupDone = false;
+                _dotNetRef?.Dispose();
+                _dotNetRef = null;
             }
         }
         // Cleanup JS when popover closes
@@ -343,9 +353,9 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
             {
                 await _multiSelectModule.InvokeVoidAsync("removeMultiSelectInput", $"{Id}-search");
             }
-            catch
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
-                // Module may already be disposed
+                // Module may already be disposed or circuit disconnected
             }
         }
         _jsSetupDone = false;
@@ -424,9 +434,9 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
             await Task.Delay(50);
             await _searchInputRef.FocusAsync();
         }
-        catch
+        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
         {
-            // Ignore focus errors
+            // Expected during circuit disconnect or disposal
         }
     }
 

--- a/src/BlazorBlueprint.Components/Components/TagInput/BbTagInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/TagInput/BbTagInput.razor.cs
@@ -255,7 +255,7 @@ public partial class BbTagInput : ComponentBase, IAsyncDisposable
             return true;
         }
 
-        return true; // Allow re-renders triggered by parent parameter changes
+        return false;
     }
 
     // ══════════════════════════════════════════════════════════════════

--- a/src/BlazorBlueprint.Components/Components/Toast/ToastService.cs
+++ b/src/BlazorBlueprint.Components/Components/Toast/ToastService.cs
@@ -7,6 +7,7 @@ namespace BlazorBlueprint.Components;
 public class ToastService
 {
     private readonly List<ToastData> toasts = new();
+    private readonly object sync = new();
 
     /// <summary>
     /// Event fired when the toast collection changes.
@@ -16,7 +17,16 @@ public class ToastService
     /// <summary>
     /// Gets the current list of toasts.
     /// </summary>
-    public IReadOnlyList<ToastData> Toasts => toasts.AsReadOnly();
+    public IReadOnlyList<ToastData> Toasts
+    {
+        get
+        {
+            lock (sync)
+            {
+                return toasts.ToArray();
+            }
+        }
+    }
 
     /// <summary>
     /// Gets or sets the runtime toast position override.
@@ -50,7 +60,10 @@ public class ToastService
     /// <param name="toast">The toast data to display.</param>
     public void Show(ToastData toast)
     {
-        toasts.Add(toast);
+        lock (sync)
+        {
+            toasts.Add(toast);
+        }
         OnChange?.Invoke();
     }
 
@@ -110,10 +123,14 @@ public class ToastService
     /// <param name="id">The toast ID to dismiss.</param>
     public void Dismiss(string id)
     {
-        var toast = toasts.FirstOrDefault(t => t.Id == id);
-        if (toast != null)
+        bool removed;
+        lock (sync)
         {
-            toasts.Remove(toast);
+            var toast = toasts.FirstOrDefault(t => t.Id == id);
+            removed = toast != null && toasts.Remove(toast);
+        }
+        if (removed)
+        {
             OnChange?.Invoke();
         }
     }
@@ -123,7 +140,10 @@ public class ToastService
     /// </summary>
     public void DismissAll()
     {
-        toasts.Clear();
+        lock (sync)
+        {
+            toasts.Clear();
+        }
         OnChange?.Invoke();
     }
 }

--- a/src/BlazorBlueprint.Primitives/Primitives/ContextMenu/BbContextMenuContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/ContextMenu/BbContextMenuContent.razor
@@ -90,9 +90,9 @@
                 await menuKeyboardModule.InvokeVoidAsync("initialize", contentRef, dotNetRef, instanceId,
                     new { mode = "vertical", loop = Loop, initialFocus = "first" });
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
-                // Expected during circuit disconnect
+                // Expected during circuit disconnect or module loading failure
             }
             catch (InvalidOperationException)
             {

--- a/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialogContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialogContent.razor
@@ -122,9 +122,9 @@
                         "import", "./_content/BlazorBlueprint.Primitives/js/primitives/portal.js");
                     _scrollLockCleanup = await _portalModule.InvokeAsync<IJSObjectReference>("lockBodyScroll");
                 }
-                catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+                catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
                 {
-                    // Expected during circuit disconnect in Blazor Server
+                    // Expected during circuit disconnect or module loading failure
                 }
                 catch (InvalidOperationException)
                 {
@@ -140,9 +140,9 @@
                 _dotNetRef = DotNetObjectReference.Create(this);
                 await _escapeModule.InvokeVoidAsync("initialize", _dotNetRef, _instanceId);
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
-                // Expected during circuit disconnect in Blazor Server
+                // Expected during circuit disconnect or module loading failure
             }
             catch (InvalidOperationException)
             {

--- a/src/BlazorBlueprint.Primitives/Primitives/DropdownMenu/BbDropdownMenuContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/DropdownMenu/BbDropdownMenuContent.razor
@@ -210,9 +210,9 @@
             _clickOutsideCleanup = await _clickOutsideModule.InvokeAsync<IJSObjectReference>(
                 "onClickOutside", _contentRef, _dotNetRef, "JsOnClickOutside", Context.State.TriggerElement);
         }
-        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
         {
-            // Expected during circuit disconnect in Blazor Server
+            // Expected during circuit disconnect or module loading failure
         }
         catch (InvalidOperationException)
         {
@@ -232,9 +232,9 @@
             await _menuKeyboardModule.InvokeVoidAsync("initialize", _contentRef, _dotNetRef, Context.ContentId,
                 new { mode = "vertical", loop = Loop });
         }
-        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
         {
-            // Expected during circuit disconnect in Blazor Server
+            // Expected during circuit disconnect or module loading failure
         }
         catch (InvalidOperationException)
         {
@@ -252,9 +252,9 @@
             _matchWidthCleanup = await _matchWidthModule.InvokeAsync<IJSObjectReference>(
                 "matchTriggerWidth", Context.State.TriggerElement, _contentRef);
         }
-        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
         {
-            // Expected during circuit disconnect in Blazor Server
+            // Expected during circuit disconnect or module loading failure
         }
         catch (InvalidOperationException)
         {
@@ -293,21 +293,23 @@
         return attributes.Count > 0 ? attributes : null;
     }
 
-    private async void HandleContextStateChanged()
+    private void HandleContextStateChanged()
+    {
+        _ = InvokeAsync(HandleContextStateChangedAsync);
+    }
+
+    private async Task HandleContextStateChangedAsync()
     {
         try
         {
             if (!Context.IsOpen)
             {
-                await InvokeAsync(async () =>
-                {
-                    await CleanupAsync();
-                    StateHasChanged();
-                });
+                await CleanupAsync();
+                StateHasChanged();
             }
             else
             {
-                await InvokeAsync(StateHasChanged);
+                StateHasChanged();
             }
         }
         catch (Exception ex) when (ex is ObjectDisposedException or TaskCanceledException)

--- a/src/BlazorBlueprint.Primitives/Primitives/Floating/BbFloatingPortal.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Floating/BbFloatingPortal.razor
@@ -297,6 +297,11 @@
                 await OnReady.InvokeAsync();
             }
         }
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
+        {
+            // Expected during circuit disconnect or module loading failure (e.g. offline)
+            _isPositioned = true;
+        }
         catch (Exception ex)
         {
             LogSetupFailed(Logger, PortalId, ex.Message, ex);
@@ -372,6 +377,10 @@
                 AnchorElement.Value,
                 _portalContentRef,
                 options);
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
+        {
+            // Expected during circuit disconnect or module loading failure (e.g. offline)
         }
         catch (Exception ex)
         {

--- a/src/BlazorBlueprint.Primitives/Primitives/Popover/BbPopoverContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Popover/BbPopoverContent.razor
@@ -214,9 +214,9 @@
                 "JsOnClickOutside",
                 Context.TriggerId);     // Trigger ID (not ElementReference)
         }
-        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
         {
-            // Expected during circuit disconnect in Blazor Server
+            // Expected during circuit disconnect or module loading failure
         }
         catch (InvalidOperationException)
         {
@@ -244,21 +244,23 @@
         }
     }
 
-    private async void HandleContextStateChanged()
+    private void HandleContextStateChanged()
+    {
+        _ = InvokeAsync(HandleContextStateChangedAsync);
+    }
+
+    private async Task HandleContextStateChangedAsync()
     {
         try
         {
             if (!Context.IsOpen)
             {
-                await InvokeAsync(async () =>
-                {
-                    await CleanupAsync();
-                    StateHasChanged();
-                });
+                await CleanupAsync();
+                StateHasChanged();
             }
             else
             {
-                await InvokeAsync(StateHasChanged);
+                StateHasChanged();
             }
         }
         catch (Exception ex) when (ex is ObjectDisposedException or TaskCanceledException)

--- a/src/BlazorBlueprint.Primitives/Primitives/Select/BbSelectContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Select/BbSelectContent.razor
@@ -42,6 +42,7 @@
     private IJSObjectReference? _clickOutsideCleanup;
     private DotNetObjectReference<BbSelectContent<TValue>>? _dotNetRef;
     private bool _isKeyboardSetup = false;
+    private bool _disposed = false;
     private string _portalId = "";
 
     /// <summary>
@@ -161,7 +162,7 @@
         // Set up JavaScript-based keyboard navigation
         if (!_isKeyboardSetup)
         {
-            _dotNetRef = DotNetObjectReference.Create(this);
+            _dotNetRef ??= DotNetObjectReference.Create(this);
             await _jsModule.InvokeVoidAsync("setupKeyboardNavigation", _context.ContentId, _dotNetRef);
             _isKeyboardSetup = true;
         }
@@ -189,24 +190,30 @@
                 "JsOnClickOutside",
                 _context.TriggerId);     // Trigger ID (not ElementReference)
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
         {
-            Console.WriteLine($"Failed to set up click-outside: {ex.Message}");
+            // Expected during circuit disconnect or module loading failure
+        }
+        catch (InvalidOperationException)
+        {
+            // JS interop not available during prerendering
         }
     }
 
-    private async void HandleContextStateChanged()
+    private void HandleContextStateChanged()
+    {
+        _ = InvokeAsync(HandleContextStateChangedAsync);
+    }
+
+    private async Task HandleContextStateChangedAsync()
     {
         try
         {
             // When context closes, clean up
             if (_context?.IsOpen == false && _isKeyboardSetup)
             {
-                await InvokeAsync(async () =>
-                {
-                    await CleanupAsync();
-                    StateHasChanged();
-                });
+                await CleanupAsync();
+                StateHasChanged();
             }
         }
         catch (Exception ex) when (ex is ObjectDisposedException or TaskCanceledException)
@@ -267,6 +274,7 @@
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void JsOnClickOutside()
     {
+        if (_disposed) { return; }
         _context?.Close();
     }
 
@@ -277,6 +285,7 @@
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void JsOnEscapeKey()
     {
+        if (_disposed) { return; }
         _context?.Close();
     }
 
@@ -287,11 +296,14 @@
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void JsOnTabKey()
     {
+        if (_disposed) { return; }
         _context?.Close();
     }
 
     public async ValueTask DisposeAsync()
     {
+        _disposed = true;
+
         if (_context != null)
         {
             _context.OnStateChanged -= HandleContextStateChanged;

--- a/src/BlazorBlueprint.Primitives/Primitives/Sheet/BbSheetContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Sheet/BbSheetContent.razor
@@ -123,9 +123,9 @@
                         "import", "./_content/BlazorBlueprint.Primitives/js/primitives/portal.js");
                     _scrollLockCleanup = await _portalModule.InvokeAsync<IJSObjectReference>("lockBodyScroll");
                 }
-                catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+                catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
                 {
-                    // Expected during circuit disconnect in Blazor Server
+                    // Expected during circuit disconnect or module loading failure
                 }
                 catch (InvalidOperationException)
                 {
@@ -141,9 +141,9 @@
                 _dotNetRef = DotNetObjectReference.Create(this);
                 await _escapeModule.InvokeVoidAsync("initialize", _dotNetRef, _instanceId);
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
-                // Expected during circuit disconnect in Blazor Server
+                // Expected during circuit disconnect or module loading failure
             }
             catch (InvalidOperationException)
             {

--- a/src/BlazorBlueprint.Primitives/Primitives/Tabs/BbTabsList.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Tabs/BbTabsList.razor
@@ -188,9 +188,9 @@
                 _keyboardNavCleanup = await _keyboardNavModule.InvokeAsync<IJSObjectReference>(
                     "setupKeyboardNav", _elementRef);
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
-                // Circuit disconnected, ignore
+                // Circuit disconnected or module loading failure, ignore
             }
         }
     }

--- a/src/BlazorBlueprint.Primitives/Primitives/Tooltip/BbTooltipTrigger.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Tooltip/BbTooltipTrigger.razor
@@ -82,11 +82,16 @@ else
     private ElementReference? _asChildTriggerRef;
 
     /// <summary>
+    /// Cached trigger context to avoid creating new instances on every render.
+    /// </summary>
+    private TriggerContext? _cachedTriggerContext;
+
+    /// <summary>
     /// Context passed to child components when AsChild is true.
     /// When a parent TriggerContext exists (e.g., from DialogTrigger), merges parent click/aria
     /// behavior with tooltip hover/focus behavior so nested triggers work correctly.
     /// </summary>
-    private TriggerContext TriggerContext => new()
+    private TriggerContext TriggerContext => _cachedTriggerContext ??= new()
     {
         TriggerId = ParentTriggerContext?.TriggerId ?? Context.TriggerId,
         IsOpen = ParentTriggerContext?.IsOpen ?? Context.IsOpen,

--- a/src/BlazorBlueprint.Primitives/Primitives/TreeView/BbTreeView.razor.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/TreeView/BbTreeView.razor.cs
@@ -281,9 +281,9 @@ public partial class BbTreeView : IAsyncDisposable
 
                 await keyboardModule.InvokeVoidAsync("initialize", elementRef, dotNetRef, context.Id);
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
-                // Circuit disconnected, ignore
+                // Circuit disconnected or module loading failure, ignore
             }
         }
     }
@@ -407,7 +407,10 @@ public partial class BbTreeView : IAsyncDisposable
         context.ExpandSiblings(value);
     }
 
-    private async void HandleContextStateChanged()
+    private void HandleContextStateChanged() =>
+        _ = InvokeAsync(HandleContextStateChangedAsync);
+
+    private async Task HandleContextStateChangedAsync()
     {
         // Propagate context state changes to bound parameters via EventCallbacks.
         // Do NOT call StateHasChanged() here — BbTreeItem instances re-render via their
@@ -436,10 +439,9 @@ public partial class BbTreeView : IAsyncDisposable
                 await CheckedValuesChanged.InvokeAsync(new HashSet<string>(context.State.CheckedValues));
             }
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is ObjectDisposedException or TaskCanceledException)
         {
-            // Consumer callback exception — prevent unobserved task exceptions
-            // from crashing the application.
+            // Component may be disposed during async operation
         }
     }
 

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/click-outside.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/click-outside.js
@@ -372,12 +372,17 @@ export function onClickOutsideByIds(elementId, dotNetRef, methodName = 'JsOnClic
     document.addEventListener('pointerup', handlePointerUp, true);
 
     // Enable after current event loop to avoid triggering on opening click
-    setTimeout(() => {
-        isEnabled = true;
+    let disposed = false;
+    const enableTimeout = setTimeout(() => {
+        if (!disposed) {
+            isEnabled = true;
+        }
     }, 0);
 
     const cleanupFunc = () => {
+        disposed = true;
         isEnabled = false;
+        clearTimeout(enableTimeout);
         document.removeEventListener('pointerdown', handlePointerDown, true);
         document.removeEventListener('pointerup', handlePointerUp, true);
     };

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/keyboard-shortcuts.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/keyboard-shortcuts.js
@@ -74,6 +74,7 @@ function handleKeyDown(event) {
  */
 function shouldSkipEvent(event) {
     const target = event.target;
+    if (!target) return false;
 
     // Skip if typing in input elements
     if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/positioning.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/positioning.js
@@ -166,9 +166,6 @@ export function applyPosition(floating, position, makeVisible = false) {
             floating.style.setProperty('visibility', 'visible', 'important');
             floating.style.setProperty('opacity', '1', 'important');
             floating.style.setProperty('pointer-events', 'auto', 'important');
-            // Also ensure position is not being reset by CSS
-            floating.style.setProperty('top', floating.style.top, 'important');
-            floating.style.setProperty('left', floating.style.left, 'important');
 
             // Dispatch event to signal element is now visible and positioned
             floating.dispatchEvent(new CustomEvent('blazorblueprint:visible', { bubbles: true }));

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/select.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/select.js
@@ -47,14 +47,13 @@ function getFocusedIndex(container) {
 function scrollIntoContainerView(element, container, center = false) {
     if (!element || !container) return;
 
-    const containerRect = container.getBoundingClientRect();
-    const elementRect = element.getBoundingClientRect();
-
     // Calculate the element's position relative to the container's scroll position
     const elementTop = element.offsetTop;
     const elementHeight = element.offsetHeight;
     const containerScrollTop = container.scrollTop;
     const containerHeight = container.clientHeight;
+
+    if (containerHeight <= 0 || elementHeight <= 0) return;
 
     if (center) {
         // Center the element in the container

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/tree-keyboard.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/tree-keyboard.js
@@ -149,7 +149,7 @@ export function initialize(containerElement, dotNetRef, instanceId) {
 
         if (hasChildren && !isExpanded) {
           // Expand the node
-          dotNetRef.invokeMethodAsync('JsOnNodeExpand', value);
+          dotNetRef.invokeMethodAsync('JsOnNodeExpand', value).catch(() => {});
         } else if (hasChildren && isExpanded) {
           // Move to first child
           const group = currentItem.querySelector('[role="group"]');
@@ -169,7 +169,7 @@ export function initialize(containerElement, dotNetRef, instanceId) {
 
         if (isExpanded) {
           // Collapse the node
-          dotNetRef.invokeMethodAsync('JsOnNodeCollapse', value);
+          dotNetRef.invokeMethodAsync('JsOnNodeCollapse', value).catch(() => {});
         } else {
           // Move to parent
           const group = currentItem.parentElement;
@@ -187,7 +187,7 @@ export function initialize(containerElement, dotNetRef, instanceId) {
         e.preventDefault();
         if (!isDisabled(currentItem)) {
           const hasChildren = currentItem.getAttribute('data-has-children') === 'true';
-          dotNetRef.invokeMethodAsync('JsOnNodeActivate', value, hasChildren);
+          dotNetRef.invokeMethodAsync('JsOnNodeActivate', value, hasChildren).catch(() => {});
         }
         break;
       }
@@ -198,10 +198,10 @@ export function initialize(containerElement, dotNetRef, instanceId) {
           // If checkable, toggle checkbox; otherwise, activate/select
           const isCheckable = currentItem.getAttribute('aria-checked') !== null;
           if (isCheckable) {
-            dotNetRef.invokeMethodAsync('JsOnNodeCheck', value);
+            dotNetRef.invokeMethodAsync('JsOnNodeCheck', value).catch(() => {});
           } else {
             const hasChildren = currentItem.getAttribute('data-has-children') === 'true';
-            dotNetRef.invokeMethodAsync('JsOnNodeActivate', value, hasChildren);
+            dotNetRef.invokeMethodAsync('JsOnNodeActivate', value, hasChildren).catch(() => {});
           }
         }
         break;
@@ -234,7 +234,7 @@ export function initialize(containerElement, dotNetRef, instanceId) {
       case '*': {
         e.preventDefault();
         // Expand all siblings of the focused node
-        dotNetRef.invokeMethodAsync('JsOnExpandSiblings', value);
+        dotNetRef.invokeMethodAsync('JsOnExpandSiblings', value).catch(() => {});
         break;
       }
 
@@ -259,9 +259,9 @@ export function initialize(containerElement, dotNetRef, instanceId) {
     if (toggle) {
       const isExpanded = treeItem.getAttribute('aria-expanded') === 'true';
       if (isExpanded) {
-        dotNetRef.invokeMethodAsync('JsOnNodeCollapse', value);
+        dotNetRef.invokeMethodAsync('JsOnNodeCollapse', value).catch(() => {});
       } else {
-        dotNetRef.invokeMethodAsync('JsOnNodeExpand', value);
+        dotNetRef.invokeMethodAsync('JsOnNodeExpand', value).catch(() => {});
       }
       return;
     }
@@ -269,7 +269,7 @@ export function initialize(containerElement, dotNetRef, instanceId) {
     // Check if click was on a checkbox
     const checkbox = clickTarget ? clickTarget.closest('[data-tree-checkbox]') : null;
     if (checkbox) {
-      dotNetRef.invokeMethodAsync('JsOnNodeCheck', value);
+      dotNetRef.invokeMethodAsync('JsOnNodeCheck', value).catch(() => {});
       return;
     }
 
@@ -278,7 +278,7 @@ export function initialize(containerElement, dotNetRef, instanceId) {
 
     // Otherwise, select the node
     const hasChildren = treeItem.getAttribute('data-has-children') === 'true';
-    dotNetRef.invokeMethodAsync('JsOnNodeActivate', value, hasChildren);
+    dotNetRef.invokeMethodAsync('JsOnNodeActivate', value, hasChildren).catch(() => {});
 
     // Make sure the clicked item gets focus and update roving tabindex
     focusTreeItem(treeItem);

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -1545,6 +1545,7 @@
   - Class : String
 
 ### BbInput (BlazorBlueprint.Components)
+  - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
   - AriaDescribedBy : String
   - AriaInvalid : Boolean?
   - AriaLabel : String


### PR DESCRIPTION
## Summary

Fixes issues identified in the [2026-03-11 codebase review](docs/reviews/2026-03-11.md) — 3 critical, 8 major, and 7 minor issues across 23 files.

### Critical
- **BbSelectContent DotNetObjectReference leak** — use `??=` to prevent orphaning references on repeated opens
- **async void event handlers** — replace `async void HandleContextStateChanged` with sync wrapper + `async Task` in BbPopoverContent, BbDropdownMenuContent, BbSelectContent, BbTreeView
- **BbTagInput.ShouldRender()** — fix always-true optimization to actually return `false` when unchanged

### Major
- **tree-keyboard.js** — add `.catch(() => {})` to all `invokeMethodAsync` calls
- **BbMultiSelect JS setup** — reset `_jsSetupDone` and dispose `_dotNetRef` on failure; replace bare catch
- **DataGrid.CompareValues** — type-check before comparison to avoid exception-based control flow
- **BbSelectContent JSInvokable** — add `_disposed` guard to `JsOnClickOutside`, `JsOnEscapeKey`, `JsOnTabKey`
- **Console.WriteLine** — replace with specific exception filters in BbSelectContent and BbMultiSelect
- **BbInput AdditionalAttributes** — add `[Parameter(CaptureUnmatchedValues = true)]` for parity with BbTextarea/BbInputGroupInput
- **ToastService** — add `lock` around all list mutations for thread safety

### Minor
- Specific exception filters in Combobox/MultiSelect focus operations
- Cache `TriggerContext` in BbTooltipTrigger to prevent new instance per render
- Fix `setTimeout` race in click-outside.js cleanup
- Null guard for `event.target` in keyboard-shortcuts.js
- Bounds validation in select.js `scrollIntoContainerView`
- Remove unnecessary `!important` on top/left in positioning.js

### JS interop resilience
- Add `JSException` to catch filters across all overlay content components (Select, Popover, DropdownMenu, Dialog, Sheet, ContextMenu, Tabs, TreeView) for graceful handling of module loading failures during offline/disconnect
- Silently handle `JSException` in BbFloatingPortal positioning and setup to suppress noisy warnings when offline

## Test plan
- [x] Build passes (`dotnet build` — 0 warnings, 0 errors)
- [x] All 48 API surface tests pass (snapshot updated for BbInput AdditionalAttributes)
- [x] Manual: Server demo overlay components open/close correctly
- [x] Manual: Offline mode — no warnings from overlay components or FloatingPortal