### PR TITLE
docs: add Sortable to README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-03-17
+
+### Added
+
+- **BbSortable Primitive** (`BlazorBlueprint.Primitives.Sortable`) — New headless drag-and-drop sortable primitive powered by SortableJS. Handles all JS interop lifecycle (init, destroy, re-init on parameter changes), ARIA live announcements, `@key`-based Blazor diffing, and `IAsyncDisposable` cleanup. Supports within-list reorder, connected multi-list transfers, drag handles, and configurable group/pull/put/sort/filter options.
+- **BbSortable Component** (`BlazorBlueprint.Components`) — Styled wrapper over the Sortable primitive adding `SortableLayout` enum (`List`/`Grid`) with pre-built Tailwind CSS layout classes and `Class` parameter for customization.
+- **Sortable demo pages** — Component demo at `/components/sortable` (basic list, drag handle, connected lists, grid, Kanban board) and Primitive demo at `/primitives/sortable` (basic, handle, connected lists).
+
+---
+
 ## 2026-03-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Production-ready components for complex data-driven applications:
 | **Rating** | Star/icon rating input |
 | **Select** | Dropdown select with search and keyboard navigation |
 | **Slider** | Range input with drag support |
+| **Sortable** | Drag-and-drop sortable lists and grids powered by SortableJS, with connected multi-list support and Kanban-style boards |
 | **Split Button** | Primary action with dropdown for secondary actions |
 | **Switch** | Toggle switch with customizable thumb |
 | **Tag Input** | Inline tag/chip input for managing string lists with suggestions, validation, and customizable triggers |
@@ -285,7 +286,7 @@ Production-ready components for complex data-driven applications:
 
 ## Primitives
 
-Blazor Blueprint's **25 headless primitives** provide behavior, ARIA attributes, and keyboard support without any styling. They handle all the complex interaction logic — focus trapping, ARIA attributes, keyboard shortcuts, portal rendering — while giving you complete control over appearance.
+Blazor Blueprint's **26 headless primitives** provide behavior, ARIA attributes, and keyboard support without any styling. They handle all the complex interaction logic — focus trapping, ARIA attributes, keyboard shortcuts, portal rendering — while giving you complete control over appearance.
 
 Use primitives when you need full design freedom or are building a custom design system.
 
@@ -310,6 +311,7 @@ Use primitives when you need full design freedom or are building a custom design
 | **Separator** | Semantic or decorative divider with orientation support |
 | **Sheet** | Side panel, focus trapping, scroll locking |
 | **Slider** | Range input with keyboard navigation and pointer drag support |
+| **Sortable** | Drag-and-drop sortable lists with SortableJS interop, ARIA live announcements, and connected multi-list support |
 | **Switch** | Toggle state, keyboard support, ARIA switch role |
 | **Table** | Sorting, pagination, row selection, keyboard row navigation |
 | **Tabs** | Tab selection, arrow key navigation, ARIA tab roles |
@@ -459,3 +461,4 @@ Blazor Blueprint is inspired by [shadcn/ui](https://ui.shadcn.com/) and the desi
 - [Heroicons](https://heroicons.com/) — MIT License, Tailwind Labs
 - [Feather Icons](https://feathericons.com/) — MIT License
 - [Apache ECharts](https://echarts.apache.org/) — Apache License 2.0
+- [SortableJS](https://sortablejs.github.io/Sortable/) — MIT License


### PR DESCRIPTION
## Summary

- Add Sortable component and primitive to README component/primitive tables
- Update headless primitive count from 25 to 26
- Add SortableJS to Acknowledgments section
- Add 2026-03-17 CHANGELOG entry for the new Sortable component

## Test plan
- [x] Documentation-only change, no code modifications