### PR TITLE
Fix sortable.js casing, for linux deployments

### DIFF
--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/sortable.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/sortable.js
@@ -24,7 +24,7 @@ async function loadSortable() {
   if (!sortableLoadPromise) {
     sortableLoadPromise = (async () => {
       // Resolve relative to this module's own URL
-      const libPath = new URL('../../lib/sortable/Sortable.min.js', import.meta.url).href;
+      const libPath = new URL('../../lib/sortable/sortable.min.js', import.meta.url).href;
       const mod = await import(libPath);
       return mod;
     })();


### PR DESCRIPTION
## Description

Corrects the casing when referencing sortable.min.js. The case mismatch causes problems on Linux deployments.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [x] Blazor Server
- [x] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility
- [ ] Dark mode

## Related Issues

