### PR TITLE
fix: align border-radius calc with shadcn/ui docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **BbFormFieldSelect: label click opening dropdown** — The `For` attribute on the field label created a native HTML `<label for>` → `<button id>` association that forwarded clicks to the select trigger, causing the dropdown to open on label click and select-all on a second click. Removed the association to match `BbFormFieldCombobox` and `BbFormFieldMultiSelect` behavior.
 - **BbSelect: dropdown not scrolling to active item** — `scrollIntoContainerView` was setting `scrollTop` on the listbox container (`overflow-hidden`) instead of the actual scrollable inner div (`overflow-auto`). Added scroll parent resolution so scroll operations target the correct element. Affects all components using Select: Calendar month/year pickers, FormFieldSelect, DataGridColumnFilter, FilterBuilder, PaginationPageSizeSelector, and TabsList.
+- **Border-radius: calculation inconsistency with shadcn/ui docs** — Switched `--radius-md` and `--radius-sm` from subtraction-based (`- 2px` / `- 4px`) to factor-based (`* 0.8` / `* 0.6`) calculation, matching the official shadcn/ui Tailwind v4 documentation. ([#275](https://github.com/blazorblueprintui/ui/issues/275))
 
 ---
 

--- a/src/BlazorBlueprint.Components/wwwroot/css/blazorblueprint-input.css
+++ b/src/BlazorBlueprint.Components/wwwroot/css/blazorblueprint-input.css
@@ -184,8 +184,8 @@
 
   /* Border Radius */
   --radius-lg: var(--radius);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-sm: calc(var(--radius) * 0.6);
 
   /* Tracking (letter-spacing) — relative to --tracking-normal from the user's theme */
   --tracking-tighter: calc(var(--tracking-normal) - 0.05em);


### PR DESCRIPTION
## Summary
- Switched `--radius-md` and `--radius-sm` from subtraction-based (`- 2px` / `- 4px`) to factor-based (`* 0.8` / `* 0.6`) calculation, matching the official shadcn/ui Tailwind v4 manual installation docs.

Closes #275

## Test plan
- [x] Verify border radii render correctly across components (Button, Card, Input, Dialog, etc.)
- [x] Confirm factor-based scaling produces visually consistent results at different `--radius` values (e.g., `0.25rem`, `0.5rem`, `0.75rem`)