### PR TITLE
feat: add BbComboboxGroup for grouped combobox items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-04-07
+
+### Added
+
+- **BbComboboxGroup: grouped items support** — New `BbComboboxGroup` component for organizing combobox items under labeled sections in compositional mode. Groups automatically hide when search filters out all their items. Label styling is customizable via `LabelClass` parameter.
+
+---
+
+## 2026-04-06
+
+### Fixed
+
+- **README: missing setup code** — Added missing out-of-box setup code to README. (PR [#290](https://github.com/blazorblueprintui/ui/pull/290), community contribution by [@mxmissile](https://github.com/mxmissile))
+
+---
+
 ## 2026-04-03
 
 ### Added

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ComboboxDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ComboboxDemo.razor
@@ -466,6 +466,77 @@
         <CodeBlock Source="Components/Combobox/compositional.txt" />
     </section>
 
+    <!-- Grouped Items -->
+    <section class="space-y-4">
+        <h2 class="text-2xl font-semibold">Grouped Items</h2>
+        <p class="text-sm text-muted-foreground">
+            Use <code class="bg-muted px-1 py-0.5 rounded text-sm">BbComboboxGroup</code> to organize items
+            under labeled sections. Groups automatically hide when their items are filtered out by the search query.
+        </p>
+
+        <div class="flex flex-col gap-2">
+            <BbCombobox TValue="string"
+                     @bind-Value="groupedValue"
+                     Placeholder="Select attribute..."
+                     SearchPlaceholder="Search..."
+                     EmptyMessage="No attribute found."
+                     PopoverWidth="w-[250px]">
+                <BbComboboxGroup Label="Employee">
+                    <BbComboboxItem Value="@("gender")" Text="Gender">Gender</BbComboboxItem>
+                    <BbComboboxItem Value="@("nationality")" Text="Nationality">Nationality</BbComboboxItem>
+                    <BbComboboxItem Value="@("age")" Text="Age">Age</BbComboboxItem>
+                </BbComboboxGroup>
+                <BbComboboxGroup Label="Employment">
+                    <BbComboboxItem Value="@("company")" Text="Company">Company</BbComboboxItem>
+                    <BbComboboxItem Value="@("jobTitle")" Text="Job Title">Job Title</BbComboboxItem>
+                    <BbComboboxItem Value="@("department")" Text="Department">Department</BbComboboxItem>
+                </BbComboboxGroup>
+                <BbComboboxGroup Label="Location">
+                    <BbComboboxItem Value="@("country")" Text="Country">Country</BbComboboxItem>
+                    <BbComboboxItem Value="@("city")" Text="City">City</BbComboboxItem>
+                </BbComboboxGroup>
+            </BbCombobox>
+            <div class="rounded-lg border p-4 bg-muted/50 space-y-1">
+                <p class="text-sm"><span class="font-medium">Selected value:</span> <span class="font-mono">@(string.IsNullOrEmpty(groupedValue) ? "(none)" : groupedValue)</span></p>
+            </div>
+        </div>
+
+        <CodeBlock Source="Components/Combobox/grouped.txt" />
+    </section>
+
+    <!-- Grouped Items with Custom Label -->
+    <section class="space-y-4">
+        <h2 class="text-2xl font-semibold">Grouped Items (Custom Label)</h2>
+        <p class="text-sm text-muted-foreground">
+            Use <code class="bg-muted px-1 py-0.5 rounded text-sm">LabelClass</code> to override the default label styling.
+        </p>
+
+        <div class="flex flex-col gap-2">
+            <BbCombobox TValue="string"
+                     @bind-Value="groupedCustomLabelValue"
+                     Placeholder="Select fruit..."
+                     SearchPlaceholder="Search..."
+                     EmptyMessage="No fruit found."
+                     PopoverWidth="w-[250px]">
+                <BbComboboxGroup Label="Tropical" LabelClass="text-sm font-bold text-primary">
+                    <BbComboboxItem Value="@("mango")" Text="Mango">Mango</BbComboboxItem>
+                    <BbComboboxItem Value="@("pineapple")" Text="Pineapple">Pineapple</BbComboboxItem>
+                    <BbComboboxItem Value="@("papaya")" Text="Papaya">Papaya</BbComboboxItem>
+                </BbComboboxGroup>
+                <BbComboboxGroup Label="Berries" LabelClass="text-sm font-bold text-primary">
+                    <BbComboboxItem Value="@("strawberry")" Text="Strawberry">Strawberry</BbComboboxItem>
+                    <BbComboboxItem Value="@("blueberry")" Text="Blueberry">Blueberry</BbComboboxItem>
+                    <BbComboboxItem Value="@("raspberry")" Text="Raspberry">Raspberry</BbComboboxItem>
+                </BbComboboxGroup>
+            </BbCombobox>
+            <div class="rounded-lg border p-4 bg-muted/50 space-y-1">
+                <p class="text-sm"><span class="font-medium">Selected value:</span> <span class="font-mono">@(string.IsNullOrEmpty(groupedCustomLabelValue) ? "(none)" : groupedCustomLabelValue)</span></p>
+            </div>
+        </div>
+
+        <CodeBlock Source="Components/Combobox/grouped-custom-label.txt" />
+    </section>
+
     <!-- Async Compositional Mode -->
     <section class="space-y-4">
         <h2 class="text-2xl font-semibold">Async Compositional Mode</h2>
@@ -614,6 +685,18 @@
                     Custom content to render. When null, renders Text as plain text.
                 </ApiParameter>
             </ApiReference>
+
+            <ApiReference ComponentName="ComboboxGroup">
+                <ApiParameter Name="Label" Type="string?" Default="null">
+                    Label text displayed above the group items. The entire group hides when its items are filtered out.
+                </ApiParameter>
+                <ApiParameter Name="LabelClass" Type="string?" Default="null">
+                    Additional CSS classes applied to the label element.
+                </ApiParameter>
+                <ApiParameter Name="ChildContent" Type="RenderFragment?">
+                    Content for the group. Typically contains ComboboxItem components.
+                </ApiParameter>
+            </ApiReference>
         </div>
     </section>
 
@@ -735,6 +818,10 @@
 
     // Compositional mode example
     private string? compositionalValue;
+
+    // Grouped examples
+    private string? groupedValue;
+    private string? groupedCustomLabelValue;
 
     private static readonly Dictionary<string, string> compositionalLabels = new()
     {

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldComboboxDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldComboboxDemo.razor
@@ -129,6 +129,43 @@
         <CodeBlock Source="Components/FormFieldCombobox/compositional.txt" />
     </div>
 
+    <!-- Grouped Items -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Grouped Items</h2>
+            <p class="text-sm text-muted-foreground">
+                Use <code class="text-xs bg-muted px-1 py-0.5 rounded">BbComboboxGroup</code> to organize items
+                under labeled sections. Groups automatically hide when their items are filtered out.
+            </p>
+        </div>
+        <div class="max-w-md">
+            <BbFormFieldCombobox TValue="string"
+                               @bind-Value="_groupedValue"
+                               Label="Attribute"
+                               Placeholder="Select attribute..."
+                               SearchPlaceholder="Search..."
+                               EmptyMessage="No attribute found."
+                               HelperText="Choose an attribute to filter by."
+                               MatchTriggerWidth="true"
+                               InputClass="w-full">
+                <BbComboboxGroup Label="Employee">
+                    <BbComboboxItem Value="@("gender")" Text="Gender">Gender</BbComboboxItem>
+                    <BbComboboxItem Value="@("nationality")" Text="Nationality">Nationality</BbComboboxItem>
+                    <BbComboboxItem Value="@("age")" Text="Age">Age</BbComboboxItem>
+                </BbComboboxGroup>
+                <BbComboboxGroup Label="Employment">
+                    <BbComboboxItem Value="@("company")" Text="Company">Company</BbComboboxItem>
+                    <BbComboboxItem Value="@("jobTitle")" Text="Job Title">Job Title</BbComboboxItem>
+                    <BbComboboxItem Value="@("department")" Text="Department">Department</BbComboboxItem>
+                </BbComboboxGroup>
+            </BbFormFieldCombobox>
+        </div>
+        <div class="rounded-lg border p-4 bg-muted/50 space-y-1">
+            <p class="text-sm"><span class="font-medium">Selected value:</span> <span class="font-mono">@(string.IsNullOrEmpty(_groupedValue) ? "(none)" : _groupedValue)</span></p>
+        </div>
+        <CodeBlock Source="Components/FormFieldCombobox/grouped.txt" />
+    </div>
+
     <!-- Non-String Value Types -->
     <div class="space-y-4">
         <div class="space-y-2">
@@ -417,6 +454,7 @@
 @code {
     private string? _selectedFramework;
     private string? _compositionalValue;
+    private string? _groupedValue;
     private int? _selectedPriority;
     private Guid? _selectedProject;
     private bool _formSubmitted;

--- a/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor
@@ -35,9 +35,9 @@
                     <BbCommandInput @ref="_commandInputRef" Placeholder="@EffectiveSearchPlaceholder" />
                     <BbCommandList OnLoadMore="@OnLoadMore" IsLoading="@IsLoading" EndOfListMessage="@EndOfListMessage">
                         <BbCommandEmpty>@EffectiveEmptyMessage</BbCommandEmpty>
-                        <BbCommandGroup>
-                            @if (Options is not null)
-                            {
+                        @if (Options is not null)
+                        {
+                            <BbCommandGroup>
                                 @foreach (var option in Options)
                                 {
                                     var itemValue = option.Value;
@@ -61,12 +61,12 @@
                                         </svg>
                                     </BbCommandItem>
                                 }
-                            }
-                            else if (ChildContent is not null)
-                            {
-                                @ChildContent
-                            }
-                        </BbCommandGroup>
+                            </BbCommandGroup>
+                        }
+                        else if (ChildContent is not null)
+                        {
+                            @ChildContent
+                        }
                     </BbCommandList>
                 </BbCommand>
                 </CascadingValue>

--- a/src/BlazorBlueprint.Components/Components/Combobox/BbComboboxGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbComboboxGroup.razor
@@ -1,0 +1,38 @@
+@namespace BlazorBlueprint.Components
+
+<BbCommandGroup>
+    @if (!string.IsNullOrWhiteSpace(Label))
+    {
+        <div class="@LabelCssClass">
+            @Label
+        </div>
+    }
+    @ChildContent
+</BbCommandGroup>
+
+@code {
+    /// <summary>
+    /// Gets or sets the label text displayed above the group items.
+    /// When the search query filters out all items in this group, the entire group (including the label) is hidden.
+    /// </summary>
+    [Parameter]
+    public string? Label { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional CSS classes to apply to the label element.
+    /// </summary>
+    [Parameter]
+    public string? LabelClass { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content to be rendered inside the group.
+    /// Typically contains <see cref="BbComboboxItem{TValue}"/> components.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private string LabelCssClass => ClassNames.cn(
+        "px-2 py-1.5 text-xs font-semibold text-muted-foreground",
+        LabelClass
+    );
+}

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -442,6 +442,11 @@
   - ValueExpression : Expression<Func<String>>
   - CascadedEditContext : EditContext [CascadingParameter]
 
+### BbComboboxGroup (BlazorBlueprint.Components)
+  - ChildContent : RenderFragment
+  - Label : String
+  - LabelClass : String
+
 ### BbComboboxItem`1 (BlazorBlueprint.Components)
   - ChildContent : RenderFragment
   - Disabled : Boolean


### PR DESCRIPTION
## Summary
- Adds new `BbComboboxGroup` component that wraps `BbCommandGroup` to support labeled, filterable item groups in compositional mode
- Groups automatically hide when search filters out all their items
- Label styling customizable via `LabelClass` parameter
- Updated `BbCombobox.razor` to render ChildContent without a wrapping `BbCommandGroup`, allowing user-defined groups to manage visibility independently
- Added grouped items and custom label demos to Combobox and FormFieldCombobox demo pages
- Updated API surface snapshot and changelog

## Test plan
- [x] All 67 API surface tests pass
- [x] Verify grouped combobox renders group labels correctly
- [x] Verify searching hides groups with no matching items
- [x] Verify `LabelClass` overrides default label styling
- [x] Verify existing compositional mode (without groups) still works
- [x] Verify Options mode is unaffected
- [x] Verify FormFieldCombobox grouped example works