### PR TITLE
fix: BbTabs forwards AdditionalAttributes to primitive root (#293)

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Tabs/BbTabs.razor
+++ b/src/BlazorBlueprint.Components/Components/Tabs/BbTabs.razor
@@ -5,16 +5,16 @@
     Wraps the Tabs primitive with shadcn/ui styling.
 *@
 
-<div class="@CssClass" @attributes="AdditionalAttributes">
-    <BlazorBlueprint.Primitives.Tabs.BbTabs Value="@Value"
-                                   ValueChanged="@ValueChanged"
-                                   DefaultValue="@DefaultValue"
-                                   OnValueChange="@OnValueChange"
-                                   Orientation="@Orientation"
-                                   ActivationMode="@ActivationMode">
-        @ChildContent
-    </BlazorBlueprint.Primitives.Tabs.BbTabs>
-</div>
+<BlazorBlueprint.Primitives.Tabs.BbTabs Value="@Value"
+                                ValueChanged="@ValueChanged"
+                                DefaultValue="@DefaultValue"
+                                OnValueChange="@OnValueChange"
+                                Orientation="@Orientation"
+                                ActivationMode="@ActivationMode"
+                                class="@CssClass"
+                                @attributes="AdditionalAttributes">
+    @ChildContent
+</BlazorBlueprint.Primitives.Tabs.BbTabs>
 
 @code {
     /// <summary>


### PR DESCRIPTION
## Summary
- Removed the redundant outer wrapper `<div>` from the Components-layer `BbTabs` and forwarded `class` + `AdditionalAttributes` directly to the `BlazorBlueprint.Primitives.Tabs.BbTabs` primitive, matching the pattern already used by `BbAccordion` and `BbDialogTitle`.
- Previously, attributes like `id`, `data-*`, and ARIA attributes set on `<BbTabs ...>` never reached the primitive's root element because the wrapper div captured them and the primitive received nothing.

## Note on DOM structure
The rendered DOM now has one fewer wrapper div. Public C# API is unchanged. Consumers relying on two levels of nested divs in custom CSS/JS would need to adjust — acceptable under the v3 breaking-changes branch.

Closes #293

## Test plan
- [x] `dotnet build` on Components project succeeds with no warnings
- [x] Verify `AdditionalAttributes` (e.g. `id`, `data-testid`) land on the rendered tabs root in the demo apps
- [x] Confirm existing Tabs demos on server/wasm/auto demo hosts still render and behave correctly
- [x] API surface snapshots unchanged (public API is identical)