### PR TITLE
fix: scope component CSS in @layer bb + DataTable / FilterBuilder polish

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataTableDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataTableDemo.razor
@@ -9,7 +9,8 @@
         <div class="space-y-3">
             <h1 class="text-4xl font-bold tracking-tight">Data Table Component</h1>
             <p class="text-xl text-muted-foreground">
-                A powerful and flexible data table component with sorting, filtering, pagination, and row selection.
+                A powerful and flexible data table component with sorting, global search, pagination, and row selection.
+                For per-column filter UIs, use <a href="/components/datagrid" class="text-primary underline underline-offset-4">BbDataGrid</a>.
             </p>
         </div>
     </div>
@@ -417,8 +418,6 @@
             new("Search", "Search...", "Placeholder for the toolbar search input"),
             new("Columns", "Columns", "Label for the column visibility button"),
             new("ToggleColumns", "Toggle columns", "Aria label for column toggle checkboxes"),
-            new("Filter", "Filter", "Label for the filter button"),
-            new("FilterColumns", "Filter columns", "Placeholder in the filter columns search"),
             new("SelectAllRows", "Select all rows", "Aria label for the header checkbox"),
             new("SelectThisRow", "Select this row", "Aria label for row checkboxes"),
             new("ClearSelection", "Clear selection", "Label for the clear selection action"),

--- a/src/BlazorBlueprint.Components/Components/DataTable/BbDataTable.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataTable/BbDataTable.razor.cs
@@ -6,7 +6,7 @@ namespace BlazorBlueprint.Components;
 
 /// <summary>
 /// A styled data table component that wraps the Table Primitive with automatic sorting,
-/// filtering, pagination, and row selection capabilities.
+/// pagination, row selection, and global search.
 /// </summary>
 /// <typeparam name="TData">The type of data items in the table.</typeparam>
 /// <remarks>
@@ -18,12 +18,18 @@ namespace BlazorBlueprint.Components;
 /// <para>
 /// Features:
 /// - Declarative column API via DataTableColumn child components
-/// - Automatic sorting, filtering, and pagination (hybrid mode with overrides)
+/// - Automatic sorting and pagination (hybrid mode with overrides)
+/// - Global search across columns via the toolbar
 /// - Row selection (single/multiple) with checkboxes
-/// - Optional toolbar with global search and column visibility toggle
+/// - Optional toolbar with column visibility toggle
 /// - Empty and loading state templates
 /// - Full shadcn styling with hover states and transitions
 /// - Accessibility support (ARIA attributes, keyboard navigation)
+/// </para>
+/// <para>
+/// For per-column filter UIs (operator + value editor per column, like Excel autofilter),
+/// use <see cref="BbDataGrid{TData}"/> instead. DataTable is intentionally a simpler
+/// surface focused on global search.
 /// </para>
 /// </remarks>
 /// <example>

--- a/src/BlazorBlueprint.Components/Components/DataTable/BbDataTableColumn.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataTable/BbDataTableColumn.razor.cs
@@ -70,9 +70,15 @@ public partial class BbDataTableColumn<TData, TValue> : ComponentBase where TDat
     public bool Sortable { get; set; }
 
     /// <summary>
-    /// Gets or sets whether this column can be filtered.
+    /// Gets or sets whether this column is included in the toolbar's global search.
+    /// When at least one column has <c>Filterable="true"</c>, the global search box
+    /// only probes those columns; otherwise it probes every column.
     /// Default is false.
     /// </summary>
+    /// <remarks>
+    /// For per-column filter UIs (operator + value editor per column),
+    /// use <see cref="BbDataGrid{TData}"/> which ships full column-filter support.
+    /// </remarks>
     [Parameter]
     public bool Filterable { get; set; }
 

--- a/src/BlazorBlueprint.Components/Components/DataTable/BbDataTableToolbar.razor
+++ b/src/BlazorBlueprint.Components/Components/DataTable/BbDataTableToolbar.razor
@@ -9,28 +9,6 @@
                Placeholder="@Localizer["DataTable.Search"]"
                Class="h-8 w-[150px] lg:w-[250px]" />
 
-        @if (Columns.Any(c => c.Filterable))
-        {
-            <BbPopover>
-                <BbPopoverTrigger>
-                    <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" Class="h-8 border-dashed">
-                        <svg class="w-4 h-4 me-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
-                        </svg>
-                        @Localizer["DataTable.Filter"]
-                    </BbButton>
-                </BbPopoverTrigger>
-                <BbPopoverContent Class="w-[200px] p-0" Align="@PopoverAlign.Start">
-                    <div class="p-4 space-y-2">
-                        <div class="text-sm font-medium">@Localizer["DataTable.FilterColumns"]</div>
-                        <div class="text-xs text-muted-foreground">
-                            (Column filtering UI - To be implemented in Phase 2)
-                        </div>
-                    </div>
-                </BbPopoverContent>
-            </BbPopover>
-        }
-
         <BbPopover>
             <BbPopoverTrigger>
                 <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" Class="h-8 ms-auto">

--- a/src/BlazorBlueprint.Components/Components/FilterBuilder/BbFilterCondition.razor
+++ b/src/BlazorBlueprint.Components/Components/FilterBuilder/BbFilterCondition.razor
@@ -31,7 +31,7 @@
                     break;
 
                 case FilterFieldType.Number when FilterOperatorHelper.IsRangeOperator(Condition.Operator):
-                    <div class="flex items-center gap-2">
+                    <div class="flex flex-wrap items-center gap-2">
                         <BbNumericInput TValue="double"
                                         Value="@GetDoubleValue()"
                                         ValueChanged="HandleDoubleValueChanged"
@@ -61,7 +61,7 @@
                     break;
 
                 case FilterFieldType.Date or FilterFieldType.DateTime when Condition.Operator is FilterOperator.InLast or FilterOperator.InNext:
-                    <div class="flex items-center gap-2">
+                    <div class="flex flex-wrap items-center gap-2">
                         <BbNumericInput TValue="int"
                                         Value="@GetInLastAmount()"
                                         ValueChanged="HandleInLastAmountChanged"

--- a/src/BlazorBlueprint.Components/Components/FilterBuilder/BbFilterCondition.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/FilterBuilder/BbFilterCondition.razor.cs
@@ -290,7 +290,7 @@ public partial class BbFilterCondition : ComponentBase
 
     // CSS classes
     private string RowCssClass => ClassNames.cn(
-        "flex items-center gap-2",
+        "flex flex-wrap items-center",
         Context?.Compact == true ? "gap-1" : "gap-2"
     );
 

--- a/src/BlazorBlueprint.Components/Localization/DefaultBbLocalizer.cs
+++ b/src/BlazorBlueprint.Components/Localization/DefaultBbLocalizer.cs
@@ -107,8 +107,6 @@ public class DefaultBbLocalizer : IBbLocalizer
         ["DataTable.Search"] = "Search...",
         ["DataTable.Columns"] = "Columns",
         ["DataTable.ToggleColumns"] = "Toggle columns",
-        ["DataTable.Filter"] = "Filter",
-        ["DataTable.FilterColumns"] = "Filter columns",
 
         // DataView
         ["DataView.SearchPlaceholder"] = "Search...",

--- a/src/BlazorBlueprint.Components/wwwroot/css/blazorblueprint-input.css
+++ b/src/BlazorBlueprint.Components/wwwroot/css/blazorblueprint-input.css
@@ -1,5 +1,16 @@
 /* BlazorBlueprint Components - Pre-built Tailwind CSS */
-@import 'tailwindcss';
+
+/* Cascade-layer order. `bb` is declared last so component utilities
+   (e.g. md:flex on the sidebar) always win at parity regardless of which
+   <link> tag a consumer's app.css loads in relative to ours. Consumers
+   override with !important (which inverts layer priority) or unlayered CSS. */
+@layer properties, theme, base, components, utilities, bb;
+
+@import 'tailwindcss' layer(bb);
+/* tw-animate.css uses @utility (a Tailwind v4 source directive) which cannot
+   be nested inside a layer. Imported unlayered; its utilities land in the
+   default `utilities` layer. Anything in tw-animate that absolutely must win
+   should use the doubled-data-attribute trick or live inside @layer bb below. */
 @import './tw-animate.css';
 
 /* Configure source paths for scanning Razor files */
@@ -195,6 +206,11 @@
   --tracking-wider: calc(var(--tracking-normal) + 0.05em);
   --tracking-widest: calc(var(--tracking-normal) + 0.1em);
 }
+
+/* All component utility/component layer blocks live inside `@layer bb` so they win
+   the cascade-layer parity against consumer Tailwind output. The inner @layer
+   declarations (base/components/utilities) become sublayers of bb. */
+@layer bb {
 
 /* Required for keyboard navigation visual feedback in Select/Combobox/DropdownMenu */
 @layer components {
@@ -745,7 +761,10 @@
   }
 }
 
-/* Accessibility — respect user's reduced-motion preference */
+} /* end @layer bb */
+
+/* Accessibility — respect user's reduced-motion preference.
+   Left UNLAYERED on purpose so it cannot be defeated by any layered rule. */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -755,6 +774,8 @@
     transition-duration: 0.01ms !important;
   }
 }
+
+@layer bb {
 
 /* DynamicForm - Horizontal layout label width via CSS variable */
 @layer components {
@@ -818,7 +839,10 @@
   }
 }
 
-/* Alert countdown bar animation */
+} /* end @layer bb */
+
+/* Alert countdown bar animation. Keyframes are not subject to cascade
+   layers, so left at top level. */
 @keyframes bb-alert-countdown {
   from { width: 100%; }
   to { width: 0%; }


### PR DESCRIPTION
## Description

Three independent fixes bundled together — the headline change is the new `@layer bb` cascade layer, which fixes the underlying class of bug behind #308.

### 1. `@layer bb` cascade layer (closes #308)

Wraps the Tailwind utility output and authored component styles inside a dedicated `bb` cascade layer declared as the strongest top-level layer:

```css
@layer properties, theme, base, components, utilities, bb;
@import 'tailwindcss' layer(bb);
```

Component utilities like `.md:flex` on the sidebar now win the cascade regardless of which `<link>` tag a consumer's `app.css` loads in relative to ours.

**The original bug:** the recommended NuGet stylesheet setup loaded `blazorblueprint.css` *before* the consumer's compiled `app.css`. Both files emitted into Tailwind v4's `@layer utilities` bucket, so the consumer's `.hidden { display: none }` won the source-order parity over the library's `.md:flex { display: flex }`, hiding the sidebar on desktop in templated apps.

With the `bb` layer the entire class of bug is gone — link order is irrelevant, and any future utility-name collision between the library and a consumer's Tailwind output resolves in the library's favour by design.

Notes:
- `@media (prefers-reduced-motion)` and `@keyframes` stay at top level so accessibility rules remain authoritative.
- `tw-animate.css` is imported unlayered because it uses `@utility` (a Tailwind v4 source directive that cannot be nested inside a `layer()` import). Its animation utilities land in the standard `utilities` layer.
- Consumer override path: `!important` (which inverts layer priority) or authored unlayered CSS.

### 2. Remove DataTable Phase 2 column-filter placeholder (closes #309)

`BbDataTableToolbar` shipped a Filter button with a popover containing the literal text *"Column filtering UI - To be implemented in Phase 2"*. Consumers had no way to disable it.

- Removed the placeholder popover from the toolbar.
- `BbDataTableColumn.Filterable` XML doc rewritten to honestly describe what it does today (scopes the global search) and to point users at `BbDataGrid<TData>` for proper per-column filter UIs.
- `BbDataTable<TData>` XML doc and demo header redirect users wanting per-column filtering to `BbDataGrid`.
- Dropped now-unused `DataTable.Filter` and `DataTable.FilterColumns` localization keys.

### 3. Filter Builder mobile overflow (closes #311)

`BbFilterCondition` rows used `flex items-center gap-2` (no wrap) with fixed-width selects/inputs (`w-[160px]` / `w-[180px]`). Total minimum width ~540px overflowed mobile cards. Added `flex-wrap` to the row and to the inner range/InLast sub-rows; fixed widths preserved so desktop layout is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [x] Blazor Server (#311 mobile overflow verified by issue author)
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility
- [ ] Dark mode

`dotnet test`: 67/67 pass; no API-surface snapshot diffs.

## Related Issues

- Closes #308 — Sidebar component hidden by default
- Closes #309 — BbDataTable renders filter UI placeholder with no way to disable it
- Closes #311 — Content overflow happening for Filter Builder

Companion changes (separate repos):
- `blazorblueprintui/website` — `Installation.razor` updated to explain the `bb` cascade layer and that stylesheet link order no longer matters; `@source` path typo fixed (`../` → `../../`).
- `blazorblueprintui/blazorblueprint-dotnet-template` — link-order workaround reverted now that the layer makes it unnecessary.