### PR TITLE
fix(toast): stop empty toast container from blocking clicks (#316)

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Toast/BbToastProvider.razor
+++ b/src/BlazorBlueprint.Components/Components/Toast/BbToastProvider.razor
@@ -218,7 +218,10 @@
     }
 
     private string GetContainerCssClass(ToastPosition position) => ClassNames.cn(
-        "fixed z-[100] flex max-h-screen w-full flex-col-reverse gap-2 p-4 sm:flex-col md:max-w-[420px]",
+        // pointer-events-none lets clicks pass through the fixed-position container
+        // (which always renders, even with zero toasts) so it doesn't block the UI
+        // behind it. Each BbToast re-enables pointer-events-auto on its own root.
+        "pointer-events-none fixed z-[100] flex max-h-screen w-full flex-col-reverse gap-2 p-4 sm:flex-col md:max-w-[420px]",
         position switch
         {
             ToastPosition.TopRight => "top-0 right-0",


### PR DESCRIPTION
## Summary

`BbToastProvider` always renders its toast container `<div>` — even when there are zero toasts. That container is `position: fixed`, pinned `bottom-0 right-0`, up to 420px wide, with `z-[100]` and `p-4` padding. With no `pointer-events-none`, the empty box sat over the bottom-right corner of every page and swallowed all clicks there (reported in #316 as eating the bottom half of the "Send" button in the chat app demo).

## Fix

Add `pointer-events-none` to the container's class list so clicks pass straight through it. `BbToast` already carries `pointer-events-auto` on its own root (`BbToast.razor:146`), so individual toasts remain fully interactive — the container half of that standard pattern was simply missing.

One-line change, and because the main toast stack and the per-toast position containers share `GetContainerCssClass`, it fixes both.

## Test plan

- [x] Reproduced in a local IssueTester page: a `fixed bottom-4 right-4` button inside the toast container's footprint was unclickable before the fix, clickable after (verified via Playwright — click counter incremented).
- [x] Regression check: triggered a toast and confirmed it still renders bottom-right with a working close button — `pointer-events-auto` on the toast root works through the `pointer-events-none` container.
- [x] Reviewer: hard-refresh any page with `BbToastProvider` in the layout and confirm bottom-right elements are clickable; trigger a toast and confirm close button + hover-to-pause still work.

_Reproduction page lives in the local-only `devkit/` IssueTester project (gitignored), so it's not included in this PR._