### PR TITLE
fix: keep spinners animating under bb-no-animate (#330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-05-21
+
+### Fixed
+
+- **bb-no-animate: spinners frozen** — The global `bb-no-animate` switch disabled *all* CSS animations, including loading spinners — freezing them mid-rotation so they no longer conveyed ongoing work. The kill rule now exempts looping status indicators: `.animate-spin` (spinners) and `.animate-pulse` (skeletons) keep animating, while transitions and decorative entrance/exit animations (dropdowns, sheets, modals) are still disabled. Add the new `.bb-animate-keep` class to exempt any other element. ([#330](https://github.com/blazorblueprintui/ui/issues/330))
+
+---
+
 ## 2026-05-14
 
 ### Added

--- a/src/BlazorBlueprint.Components/wwwroot/css/blazorblueprint-input.css
+++ b/src/BlazorBlueprint.Components/wwwroot/css/blazorblueprint-input.css
@@ -765,11 +765,16 @@
   }
 }
 
-/* Global animation disable — add class="bb-no-animate" to <html> to turn off all animations */
+/* Global animation disable — add class="bb-no-animate" to <html> to turn off
+   transitions and decorative animations.
+
+   Looping status indicators are exempt: spinners (.animate-spin) and pulse
+   (.animate-pulse) communicate ongoing work, not decoration, so freezing them
+   would misrepresent state. Add .bb-animate-keep to exempt anything else. */
 @layer utilities {
-  .bb-no-animate *,
-  .bb-no-animate *::before,
-  .bb-no-animate *::after {
+  .bb-no-animate *:not(.animate-spin, .animate-pulse, .bb-animate-keep),
+  .bb-no-animate *:not(.animate-spin, .animate-pulse, .bb-animate-keep)::before,
+  .bb-no-animate *:not(.animate-spin, .animate-pulse, .bb-animate-keep)::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;


### PR DESCRIPTION
## Problem

The global `bb-no-animate` switch disabled **all** CSS animations via a universal-selector kill rule:

```css
.bb-no-animate *, .bb-no-animate *::before, .bb-no-animate *::after {
  animation-duration: 0.01ms !important;
  animation-iteration-count: 1 !important;
  transition-duration: 0.01ms !important;
}
```

This froze loading spinners mid-rotation. A spinner conveys *ongoing work* — freezing it misrepresents state. The rule couldn't distinguish a one-shot decorative entrance animation (dropdown/sheet/modal) from a looping status indicator (spinner/skeleton), so it killed both.

This surfaced in a consuming app whose Blazor Server reconnection modal — a hand-written SVG using `animate-spin` — sat frozen while reconnecting. It reproduces anywhere `bb-no-animate` is on `<html>`; the reconnect modal is just the most visible spot.

Fixes #330.

## Fix

Exempt looping status indicators from the kill rule with `:not()`:

```css
.bb-no-animate *:not(.animate-spin, .animate-pulse, .bb-animate-keep),
.bb-no-animate *:not(.animate-spin, .animate-pulse, .bb-animate-keep)::before,
.bb-no-animate *:not(.animate-spin, .animate-pulse, .bb-animate-keep)::after {
  animation-duration: 0.01ms !important;
  animation-iteration-count: 1 !important;
  transition-duration: 0.01ms !important;
}
```

- `:not()` exclusion (not a re-enable rule) means the spinner is never touched — its own `animation: spin 1s linear infinite` applies naturally, full speed and fully customizable.
- Keys off `animate-spin` / `animate-pulse`, which `BbSpinner` and skeletons already emit — **zero markup changes**, consumers' existing spinners just start working.
- `.bb-animate-keep` is a new generic escape hatch for anything else that should survive `bb-no-animate`.
- Transitions and decorative entrance/exit animations (dropdowns, sheets, modals) are still disabled — behaviour unchanged for everything except spinners/pulse.

## Testing

- `dotnet build` recompiles Tailwind — built `blazorblueprint.css` carries the updated selector.
- 67/67 tests pass; no public API surface change.

## Release note

Components-only fix — warrants a `BlazorBlueprint.Components` patch bump on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)