### PR TITLE
fix: set data-active on sidebar menu links during navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **BbSidebarMenuButton: active item not highlighted on navigation** — When a sidebar menu button or sub-button used `Href` for routing, its `data-active` attribute stayed bound to the static `IsActive` parameter and never updated on navigation, so the active item received only `aria-current="page"` and not the accent background. `BbSidebarMenuButton` and `BbSidebarMenuSubButton` now detect the active route themselves — using the same matching rules as the `Match` parameter always implied — and drive `data-active`, `aria-current`, and styling from a single resolved state. ([#331](https://github.com/blazorblueprintui/ui/issues/331))
 - **bb-no-animate: spinners frozen** — The global `bb-no-animate` switch disabled *all* CSS animations, including loading spinners — freezing them mid-rotation so they no longer conveyed ongoing work. The kill rule now exempts looping status indicators: `.animate-spin` (spinners) and `.animate-pulse` (skeletons) keep animating, while transitions and decorative entrance/exit animations (dropdowns, sheets, modals) are still disabled. Add the new `.bb-animate-keep` class to exempt any other element. ([#330](https://github.com/blazorblueprintui/ui/issues/330))
 
 ---

--- a/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarMenuButton.razor
+++ b/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarMenuButton.razor
@@ -1,5 +1,6 @@
 @namespace BlazorBlueprint.Components
 @using Microsoft.AspNetCore.Components.Routing
+@implements IDisposable
 
 @*
     SidebarMenuButton component for clickable menu items with tooltip support.
@@ -27,6 +28,9 @@ else
 
     [CascadingParameter]
     private BlazorBlueprint.Primitives.Collapsible.CollapsibleContext? CollapsibleContext { get; set; }
+
+    [Inject]
+    private NavigationManager NavigationManager { get; set; } = default!;
 
     /// <summary>
     /// The button content.
@@ -99,6 +103,39 @@ else
         return !string.IsNullOrEmpty(Tooltip) && Context != null && !Context.Open;
     }
 
+    private bool isActiveByLocation;
+
+    /// <summary>
+    /// Whether the button should render as active — either explicitly via <see cref="IsActive"/>
+    /// or because its <see cref="Href"/> matches the current location.
+    /// </summary>
+    private bool ResolvedActive => IsActive || isActiveByLocation;
+
+    protected override void OnInitialized()
+    {
+        NavigationManager.LocationChanged += OnLocationChanged;
+    }
+
+    protected override void OnParametersSet()
+    {
+        isActiveByLocation = NavLinkMatcher.IsMatch(NavigationManager, NavigationManager.Uri, Href, Match);
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        var nowActive = NavLinkMatcher.IsMatch(NavigationManager, e.Location, Href, Match);
+        if (nowActive != isActiveByLocation)
+        {
+            isActiveByLocation = nowActive;
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public void Dispose()
+    {
+        NavigationManager.LocationChanged -= OnLocationChanged;
+    }
+
     private RenderFragment RenderButton() => __builder =>
     {
         // Auto-detect: if Href is provided and AsChild wasn't explicitly set to Button, render as Anchor
@@ -107,19 +144,17 @@ else
 
         if (shouldRenderAsAnchor)
         {
-            <NavLink href="@Href"
-                     class="@GetClasses()"
-                     data-sidebar="menu-button"
-                     data-size="@Size.ToValue()"
-                     data-active="@(IsActive ? "true" : "false")"
-                     data-state="@(CollapsibleContext?.Open ?? false ? "open" : "closed")"
-                     aria-current="@(IsActive ? "page" : null)"
-                     aria-expanded="@(CollapsibleContext?.Open ?? false)"
-                     Match="@Match"
-                     ActiveClass="data-[active=true]:bg-sidebar-accent"
-                     @attributes="AdditionalAttributes">
+            <a href="@Href"
+               class="@GetClasses()"
+               data-sidebar="menu-button"
+               data-size="@Size.ToValue()"
+               data-active="@(ResolvedActive ? "true" : "false")"
+               data-state="@(CollapsibleContext?.Open ?? false ? "open" : "closed")"
+               aria-current="@(ResolvedActive ? "page" : null)"
+               aria-expanded="@(CollapsibleContext?.Open ?? false)"
+               @attributes="AdditionalAttributes">
                 @ChildContent
-            </NavLink>
+            </a>
         }
         else
         {
@@ -127,9 +162,9 @@ else
                     class="@GetClasses()"
                     data-sidebar="menu-button"
                     data-size="@Size.ToValue()"
-                    data-active="@(IsActive ? "true" : "false")"
+                    data-active="@(ResolvedActive ? "true" : "false")"
                     data-state="@(CollapsibleContext?.Open ?? false ? "open" : "closed")"
-                    aria-current="@(IsActive ? "page" : null)"
+                    aria-current="@(ResolvedActive ? "page" : null)"
                     aria-expanded="@(CollapsibleContext?.Open ?? false)"
                     @onclick="HandleClick"
                     @attributes="AdditionalAttributes">
@@ -153,7 +188,7 @@ else
 
     private string GetClasses()
     {
-        var baseClasses = "group peer/menu-button flex w-full items-center overflow-hidden text-left outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:[&>span]:hidden [&>span:last-child]:truncate [&>svg]:shrink-0";
+        var baseClasses = "group peer/menu-button flex w-full items-center overflow-hidden text-left outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:[&>span]:hidden [&>span:last-child]:truncate [&>svg]:shrink-0";
 
         var variantClasses = Variant.ToValue() switch
         {

--- a/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarMenuSubButton.razor
+++ b/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarMenuSubButton.razor
@@ -1,5 +1,6 @@
 @namespace BlazorBlueprint.Components
 @using Microsoft.AspNetCore.Components.Routing
+@implements IDisposable
 
 @*
     SidebarMenuSubButton component for clickable submenu items.
@@ -13,13 +14,13 @@
 
 @if (shouldRenderAsAnchor)
 {
-    <NavLink href="@Href" class="@GetClasses()" data-sidebar="menu-sub-button" data-size="@Size.ToValue()" data-active="@(IsActive ? "true" : "false")" aria-current="@(IsActive ? "page" : null)" Match="@Match" ActiveClass="data-[active=true]:bg-sidebar-accent" @attributes="AdditionalAttributes">
+    <a href="@Href" class="@GetClasses()" data-sidebar="menu-sub-button" data-size="@Size.ToValue()" data-active="@(ResolvedActive ? "true" : "false")" aria-current="@(ResolvedActive ? "page" : null)" @attributes="AdditionalAttributes">
         @ChildContent
-    </NavLink>
+    </a>
 }
 else
 {
-    <button type="button" class="@GetClasses()" data-sidebar="menu-sub-button" data-size="@Size.ToValue()" data-active="@(IsActive ? "true" : "false")" aria-current="@(IsActive ? "page" : null)" @attributes="AdditionalAttributes">
+    <button type="button" class="@GetClasses()" data-sidebar="menu-sub-button" data-size="@Size.ToValue()" data-active="@(ResolvedActive ? "true" : "false")" aria-current="@(ResolvedActive ? "page" : null)" @attributes="AdditionalAttributes">
         @ChildContent
     </button>
 }
@@ -72,6 +73,42 @@ else
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Inject]
+    private NavigationManager NavigationManager { get; set; } = default!;
+
+    private bool isActiveByLocation;
+
+    /// <summary>
+    /// Whether the button should render as active — either explicitly via <see cref="IsActive"/>
+    /// or because its <see cref="Href"/> matches the current location.
+    /// </summary>
+    private bool ResolvedActive => IsActive || isActiveByLocation;
+
+    protected override void OnInitialized()
+    {
+        NavigationManager.LocationChanged += OnLocationChanged;
+    }
+
+    protected override void OnParametersSet()
+    {
+        isActiveByLocation = NavLinkMatcher.IsMatch(NavigationManager, NavigationManager.Uri, Href, Match);
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        var nowActive = NavLinkMatcher.IsMatch(NavigationManager, e.Location, Href, Match);
+        if (nowActive != isActiveByLocation)
+        {
+            isActiveByLocation = nowActive;
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public void Dispose()
+    {
+        NavigationManager.LocationChanged -= OnLocationChanged;
+    }
 
     private string GetClasses()
     {

--- a/src/BlazorBlueprint.Components/Components/Sidebar/NavLinkMatcher.cs
+++ b/src/BlazorBlueprint.Components/Components/Sidebar/NavLinkMatcher.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// Replicates the active-route matching used by <see cref="NavLink"/> so that sidebar
+/// menu buttons can compute their own active state and expose it through a reliable
+/// <c>data-active</c> attribute. The algorithm is intentionally identical to
+/// <see cref="NavLink"/> so the <c>Match</c> parameter behaves exactly as users expect.
+/// </summary>
+internal static class NavLinkMatcher
+{
+    /// <summary>
+    /// Determines whether <paramref name="href"/> matches the current location, using the
+    /// same rules as <see cref="NavLink"/>.
+    /// </summary>
+    /// <param name="navigationManager">Used to resolve <paramref name="href"/> to an absolute URI.</param>
+    /// <param name="currentUriAbsolute">The current absolute URI to match against.</param>
+    /// <param name="href">The link target. A null or empty value never matches.</param>
+    /// <param name="match">How the URL should be matched.</param>
+    public static bool IsMatch(
+        NavigationManager navigationManager,
+        string currentUriAbsolute,
+        string? href,
+        NavLinkMatch match)
+    {
+        if (string.IsNullOrEmpty(href))
+        {
+            return false;
+        }
+
+        var hrefAbsolute = navigationManager.ToAbsoluteUri(href).AbsoluteUri;
+
+        if (EqualsHrefExactlyOrIfTrailingSlashAdded(currentUriAbsolute, hrefAbsolute))
+        {
+            return true;
+        }
+
+        return match == NavLinkMatch.Prefix
+            && IsStrictlyPrefixWithSeparator(currentUriAbsolute, hrefAbsolute);
+    }
+
+    private static bool EqualsHrefExactlyOrIfTrailingSlashAdded(string currentUriAbsolute, string hrefAbsolute)
+    {
+        if (string.Equals(currentUriAbsolute, hrefAbsolute, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // Special case: a link to "/path/" is also active at "/path" (with no trailing
+        // slash), because servers commonly serve the same page for both.
+        if (currentUriAbsolute.Length == hrefAbsolute.Length - 1
+            && hrefAbsolute[^1] == '/'
+            && hrefAbsolute.StartsWith(currentUriAbsolute, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsStrictlyPrefixWithSeparator(string value, string prefix)
+    {
+        var prefixLength = prefix.Length;
+
+        if (value.Length <= prefixLength)
+        {
+            return false;
+        }
+
+        // Only match when there is a separator character at the end of the prefix or
+        // right after it: "/abc" is a prefix of "/abc/def" but not "/abcdef".
+        return value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            && (prefixLength == 0
+                || !IsUnreservedCharacter(prefix[prefixLength - 1])
+                || !IsUnreservedCharacter(value[prefixLength]));
+    }
+
+    private static bool IsUnreservedCharacter(char c)
+        => char.IsLetterOrDigit(c) || c is '-' or '.' or '_' or '~';
+}


### PR DESCRIPTION
## Summary

Fixes #331 — `BbSidebarMenuButton` / `BbSidebarMenuSubButton` with an `Href` did not get `data-active="true"` on navigation, so the active sidebar item was never highlighted (only `aria-current="page"` flipped).

## Root cause

When given an `Href`, both components rendered a Blazor `<NavLink>` and delegated active-route *detection* to it. But `data-active` was hard-bound to the static `IsActive` parameter — `NavLink` never writes `data-active`. The styling bridge was circular: the `ActiveClass` they passed (`data-[active=true]:bg-sidebar-accent`) is a Tailwind variant gated on `data-active="true"`, which never became true. So `NavLink` correctly detected the route (and set `aria-current="page"`) but the item was never styled active.

## Fix

Both components now own active detection instead of half-delegating to `NavLink`:

- Inject `NavigationManager`, subscribe to `LocationChanged`, implement `IDisposable`.
- New internal `NavLinkMatcher` — a faithful copy of `NavLink`'s matching algorithm, so the `Match` parameter behaves exactly as before.
- `data-active`, `aria-current` and styling all derive from a single `ResolvedActive` value (`IsActive || isActiveByLocation`), preserving the explicit-`IsActive` escape hatch.
- The anchor branch renders a plain `<a>` instead of `<NavLink>` (Blazor's router still intercepts internal links).
- `BbSidebarMenuButton` gains the `data-[active=true]:*` base styling it was previously missing (`BbSidebarMenuSubButton` already had it).

## Testing

- Full solution build: succeeds, 0 warnings / 0 errors.
- API surface tests: 67/67 pass (no public surface change).
- Verified in a browser against a dedicated reproduction page: navigating Home → Counter → Weather, the active link now flips `data-active` to `"true"` and gets the accent background on every navigation — matching an explicit-`IsActive` control group exactly. Before the fix `data-active` stayed `"false"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)