### PR TITLE
fix(combobox): resolve trigger display text for pre-bound values in compositional mode

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor.cs
@@ -65,11 +65,18 @@ public partial class BbCombobox<TValue> : ComponentBase
     private bool _lastDisabled;
     private string _lastSearchQuery = string.Empty;
 
+    // Bypass for ShouldRender when the trigger needs to pick up a freshly-registered
+    // display text for the current selection. ComboboxItem children live inside the
+    // popover portal and only mount on first open, so their RegisterItem call
+    // arrives well after the surrounding render-skipping state has settled.
+    private bool _triggerTextDirty;
+
     protected override bool ShouldRender()
     {
-        if (_parametersChanged)
+        if (_parametersChanged || _triggerTextDirty)
         {
             _parametersChanged = false;
+            _triggerTextDirty = false;
             _lastIsOpen = _isOpen;
             _lastValue = Value;
             _lastDisabled = Disabled;
@@ -139,6 +146,24 @@ public partial class BbCombobox<TValue> : ComponentBase
     /// </summary>
     [Parameter]
     public string? Placeholder { get; set; }
+
+    /// <summary>
+    /// Gets or sets the display text shown in the trigger when a value is preselected
+    /// via <see cref="Value"/> in compositional mode and no matching
+    /// <c>BbComboboxItem</c> has registered yet.
+    /// </summary>
+    /// <remarks>
+    /// Items live inside the popover portal and only mount when it opens, so the
+    /// internal text registry is empty on initial render. Set this when you already
+    /// know the display text for the preselected value (typically right after resolving
+    /// it from an API) so the trigger can render the correct caption before the user
+    /// has opened the popover. Options mode does not need this — it resolves the text
+    /// synchronously from the <see cref="Options"/> collection. Ignored once a matching
+    /// item registers, so re-registration (e.g. Text updated by the parent) still
+    /// corrects stale captions.
+    /// </remarks>
+    [Parameter]
+    public string? SelectedItemText { get; set; }
 
     /// <summary>
     /// Gets or sets the placeholder text shown in the search input.
@@ -305,9 +330,10 @@ public partial class BbCombobox<TValue> : ComponentBase
     }
 
     /// <summary>
-    /// Gets the display text for the currently selected item.
-    /// Checks Options first (Options mode), then the item text registry (Compositional mode),
-    /// then falls back to the cached display text from the last selection.
+    /// Gets the display text for the currently selected item. Resolution order:
+    /// Options (Options mode) → registered items (Compositional mode, after first open) →
+    /// caller-supplied <see cref="SelectedItemText"/> (covers the pre-mount gap) →
+    /// cached text from the last user selection → placeholder.
     /// </summary>
     private string SelectedDisplayText
     {
@@ -318,21 +344,30 @@ public partial class BbCombobox<TValue> : ComponentBase
                 return EffectivePlaceholder;
             }
 
-            // Options mode: look up from Options collection
+            // Options mode: synchronous lookup from the Options collection.
             var selectedOption = Options?.FirstOrDefault(o => EqualityComparer<TValue>.Default.Equals(o.Value, Value));
             if (selectedOption is not null)
             {
                 return selectedOption.Text;
             }
 
-            // Compositional mode: look up from registered items
+            // Compositional mode: a registered item wins over the caller-provided hint so
+            // that re-registration (e.g. Text updated by the parent) corrects stale captions.
             if (_itemTextRegistry.GetValueOrDefault(Value) is { } registryText)
             {
                 return registryText;
             }
 
-            // Fallback: cached display text from last selection survives Options array changes
-            // during async filtering (e.g. selected option filtered out of current results).
+            // Caller-provided initial text — covers the "popover has never opened so
+            // children have not mounted" gap that the registry alone cannot fill.
+            if (!string.IsNullOrEmpty(SelectedItemText))
+            {
+                return SelectedItemText;
+            }
+
+            // Last-resort: cached text from a previous user selection, which survives
+            // Options array changes during async filtering (e.g. selected option filtered
+            // out of current results).
             return _selectedDisplayTextCache ?? EffectivePlaceholder;
         }
     }
@@ -452,13 +487,31 @@ public partial class BbCombobox<TValue> : ComponentBase
 
     /// <summary>
     /// Registers an item's value and display text for trigger display text lookup.
-    /// Called by ComboboxItem on initialization.
+    /// Called by ComboboxItem on initialization and on parameter cascade.
     /// </summary>
     internal void RegisterItem(TValue value, string text)
     {
-        if (value is not null)
+        if (value is null)
         {
-            _itemTextRegistry[value] = text;
+            return;
+        }
+
+        // Only mark dirty when the text genuinely changed — without this guard the
+        // OnParametersSet-side RegisterItem call would queue a render on every parent
+        // cascade because identical text is re-registered each cycle.
+        var textChanged = !_itemTextRegistry.TryGetValue(value, out var existing)
+            || !string.Equals(existing, text, StringComparison.Ordinal);
+
+        _itemTextRegistry[value] = text;
+
+        // If the registered item is the current selection and its display text actually
+        // changed (covers first-mount and Text-updates), re-render so the trigger picks
+        // up the new caption. Items mount lazily inside the popover portal, so without
+        // this the trigger would stay on the placeholder until the user interacted.
+        if (textChanged && EqualityComparer<TValue>.Default.Equals(value, Value))
+        {
+            _triggerTextDirty = true;
+            StateHasChanged();
         }
     }
 

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -472,6 +472,7 @@
   - SearchPlaceholder : String
   - SearchQuery : String
   - SearchQueryChanged : EventCallback<String>
+  - SelectedItemText : String
   - Value : TValue
   - ValueChanged : EventCallback<TValue>
   - ValueExpression : Expression<Func<TValue>>


### PR DESCRIPTION
## Problem

In compositional mode (`<BbComboboxItem>` children, not `Options`), the trigger resolves its caption from an internal text registry that's only populated when items mount. Items live inside `BbPopoverContent` which — since commit `8ea4a8c4` (the WASM perf fix that flipped `ForceMount` to `false`) — does not mount until the popover first opens.

The consequence: any `BbCombobox` with a pre-bound `Value` in compositional mode renders the placeholder instead of the selected item's text on initial paint. Worse, even after the popover opens once and items register, the trigger still doesn't update because `RegisterItem` was a silent dictionary mutation — no `StateHasChanged`. The placeholder only got replaced when *something else* triggered a render (e.g. the user actually selected an item).

Options mode is immune: it resolves text synchronously against the `Options` collection on every render.

## Fix

Three coordinated changes in `BbCombobox.razor.cs`, no popover-default changes, perf fix preserved:

### 1. Caller-provided `SelectedItemText` parameter

```csharp
[Parameter]
public string? SelectedItemText { get; set; }
```

Callers that already know the display text for a pre-bound value (typical: the value came from an API alongside its label) can now render it on initial paint without waiting for items to mount.

### 2. `SelectedDisplayText` resolution chain (new step in **bold**)

Options → registered items → **`SelectedItemText`** → `_selectedDisplayTextCache` → placeholder

A registered item still wins over the caller hint so re-registration (e.g. `Text` updated by the parent) corrects stale captions.

### 3. `RegisterItem` triggers a guarded re-render

```csharp
internal void RegisterItem(TValue value, string text)
{
    if (value is null) return;

    var textChanged = !_itemTextRegistry.TryGetValue(value, out var existing)
        || !string.Equals(existing, text, StringComparison.Ordinal);

    _itemTextRegistry[value] = text;

    if (textChanged && EqualityComparer<TValue>.Default.Equals(value, Value))
    {
        _triggerTextDirty = true;
        StateHasChanged();
    }
}
```

The new `_triggerTextDirty` flag is consulted by `ShouldRender` so the render isn't swallowed by the existing parameter-tracking guard. The `textChanged` comparison is essential — without it the `OnParametersSet`-side `RegisterItem` call (which runs every parent cascade) would queue a render on every cycle.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| Compositional, `Value` pre-bound, caller passes `SelectedItemText` | Placeholder forever | Correct text on initial paint |
| Compositional, `Value` pre-bound, no `SelectedItemText` | Placeholder forever | Placeholder until first popover open, then snaps to correct text |
| Compositional, item `Text` updated dynamically | Trigger stuck on first-mount caption | Trigger updates on next re-registration |
| Options mode | ✓ | ✓ (no change) |

## Alternatives considered

- **`ForceMount="true"` on `BbCombobox`'s popover** — fixes everything with no caller change, but reverts the `8ea4a8c4` perf win. Rejected for that reason.
- **`KeepItemsMounted` opt-out parameter** (default `true`, force-mount items) — same trade-off as above, with an escape hatch. Held in reserve if the "no `SelectedItemText` provided" case turns out to bite in practice.
- **`Func<TValue, string?> DisplayTextSelector`** — over-engineered; callers already have the string by the time they pass `Value`.
- **Pre-render `ChildContent` outside the popover** — breaks portal isolation and `BbCommandGroup` layout assumptions.

## Verification

- Components build clean.
- 67/67 API surface snapshot tests pass after baselining the new parameter (single-line addition: `- SelectedItemText : String`).
- No changes to `BbComboboxItem`, `BbPopover*`, or any primitive — only one new optional parameter on `BbCombobox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
