### PR TITLE
fix(primitives): restore focus to trigger on intentional overlay close

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataViewDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataViewDemo.razor
@@ -717,7 +717,7 @@
             : name.Length > 0 ? name[0].ToString() : "?";
     }
 
-    private async ValueTask<DataViewResult<Person>> LoadPeopleAsync(DataViewRequest request)
+    private ValueTask<DataViewResult<Person>> LoadPeopleAsync(DataViewRequest request)
     {
         IEnumerable<Person> query = asyncPeople;
 
@@ -749,10 +749,10 @@
             .Take(request.Count ?? materialized.Count)
             .ToList();
 
-        return new DataViewResult<Person>
+        return ValueTask.FromResult(new DataViewResult<Person>
         {
             Items = items,
             TotalItemCount = materialized.Count
-        };
+        });
     }
 }

--- a/src/BlazorBlueprint.Primitives/Primitives/DropdownMenu/BbDropdownMenuCheckboxItem.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/DropdownMenu/BbDropdownMenuCheckboxItem.razor
@@ -81,7 +81,8 @@
 
         if (CloseOnSelect && Context != null)
         {
-            Context.Close();
+            // Item activation is an intentional close — return focus to the trigger.
+            Context.Close(restoreFocus: true);
         }
     }
 

--- a/src/BlazorBlueprint.Primitives/Primitives/DropdownMenu/BbDropdownMenuContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/DropdownMenu/BbDropdownMenuContent.razor
@@ -3,6 +3,7 @@
 @using BlazorBlueprint.Primitives.Floating
 @using BlazorBlueprint.Primitives.Services
 @inject IJSRuntime JSRuntime
+@inject IFocusManager FocusManager
 @implements IAsyncDisposable
 
 @*
@@ -304,8 +305,21 @@
         {
             if (!Context.IsOpen)
             {
+                // Capture both the trigger ref and the restore flag before teardown.
+                var trigger = Context.State.TriggerElement;
+                var shouldRestoreFocus = Context.State.RestoreFocusOnClose;
+
                 await CleanupAsync();
                 StateHasChanged();
+
+                // Restore focus to the trigger AFTER cleanup so the now-unmounted menu
+                // isn't the active element when the user next presses Tab. Only restore
+                // for intentional closes (Escape, item activation) — click-outside
+                // leaves focus where the user clicked.
+                if (shouldRestoreFocus && trigger.HasValue)
+                {
+                    await FocusManager.RestoreFocus(trigger);
+                }
             }
             else
             {
@@ -331,7 +345,8 @@
 
         if (CloseOnEscape)
         {
-            Context.Close();
+            // Escape is an intentional dismiss — return focus to the trigger.
+            Context.Close(restoreFocus: true);
         }
     }
 

--- a/src/BlazorBlueprint.Primitives/Primitives/DropdownMenu/BbDropdownMenuItem.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/DropdownMenu/BbDropdownMenuItem.razor
@@ -137,7 +137,9 @@ else
 
         if (CloseOnSelect && Context != null)
         {
-            Context.Close();
+            // Item activation is an intentional close — return focus to the trigger
+            // so keyboard navigation (Tab) continues from the right place.
+            Context.Close(restoreFocus: true);
         }
     }
 

--- a/src/BlazorBlueprint.Primitives/Primitives/DropdownMenu/DropdownMenuContext.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DropdownMenu/DropdownMenuContext.cs
@@ -24,6 +24,14 @@ public class DropdownMenuState
     /// Used for keyboard navigation.
     /// </summary>
     public int FocusedIndex { get; set; } = -1;
+
+    /// <summary>
+    /// Gets or sets whether focus should be returned to the trigger element when the
+    /// menu closes. Set to <c>true</c> by intentional close paths (item activation,
+    /// Escape) and left <c>false</c> for external dismissals (click-outside) where
+    /// focus is already where the user wants it.
+    /// </summary>
+    public bool RestoreFocusOnClose { get; set; }
 }
 
 /// <summary>
@@ -76,18 +84,26 @@ public class DropdownMenuContext : PrimitiveContextWithEvents<DropdownMenuState>
             state.IsOpen = true;
             state.TriggerElement = triggerElement;
             state.FocusedIndex = -1; // Reset focus on open
+            state.RestoreFocusOnClose = false; // Cleared so the next Close() decides afresh
         });
     }
 
     /// <summary>
     /// Closes the dropdown menu.
     /// </summary>
-    public void Close()
+    /// <param name="restoreFocus">
+    /// When <c>true</c>, signals that focus should be returned to the trigger element
+    /// after the content tears down. Pass <c>true</c> for intentional close paths
+    /// (Escape, item activation) and leave <c>false</c> for external dismissals
+    /// (click-outside) where focus is already where the user wants it.
+    /// </param>
+    public void Close(bool restoreFocus = false)
     {
         UpdateState(state =>
         {
             state.IsOpen = false;
             state.FocusedIndex = -1;
+            state.RestoreFocusOnClose = restoreFocus;
         });
     }
 

--- a/src/BlazorBlueprint.Primitives/Primitives/Popover/BbPopoverContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Popover/BbPopoverContent.razor
@@ -3,6 +3,7 @@
 @using BlazorBlueprint.Primitives.Floating
 @using BlazorBlueprint.Primitives.Services
 @inject IJSRuntime JSRuntime
+@inject IFocusManager FocusManager
 @implements IAsyncDisposable
 
 @*
@@ -255,8 +256,21 @@
         {
             if (!Context.IsOpen)
             {
+                // Capture both the trigger ref and the restore flag before teardown.
+                var trigger = Context.State.TriggerElement;
+                var shouldRestoreFocus = Context.State.RestoreFocusOnClose;
+
                 await CleanupAsync();
                 StateHasChanged();
+
+                // Restore focus to the trigger AFTER cleanup so the now-unmounted popover
+                // isn't the active element when the user next presses Tab. Only restore
+                // for intentional closes (Escape) — click-outside leaves focus where the
+                // user clicked.
+                if (shouldRestoreFocus && trigger.HasValue)
+                {
+                    await FocusManager.RestoreFocus(trigger);
+                }
             }
             else
             {
@@ -282,7 +296,8 @@
             // Close popover if configured
             if (CloseOnEscape)
             {
-                Context.Close();
+                // Escape is an intentional dismiss — return focus to the trigger.
+                Context.Close(restoreFocus: true);
             }
         }
     }

--- a/src/BlazorBlueprint.Primitives/Primitives/Popover/PopoverContext.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/Popover/PopoverContext.cs
@@ -18,6 +18,14 @@ public class PopoverState
     /// Used for positioning and focus management.
     /// </summary>
     public ElementReference? TriggerElement { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether focus should be returned to the trigger element when the
+    /// popover closes. Set to <c>true</c> by intentional close paths (Escape) and left
+    /// <c>false</c> for external dismissals (click-outside) where focus is already
+    /// where the user wants it.
+    /// </summary>
+    public bool RestoreFocusOnClose { get; set; }
 }
 
 /// <summary>
@@ -58,14 +66,25 @@ public class PopoverContext : PrimitiveContextWithEvents<PopoverState>
         {
             state.IsOpen = true;
             state.TriggerElement = triggerElement;
+            state.RestoreFocusOnClose = false; // Cleared so the next Close() decides afresh
         });
     }
 
     /// <summary>
     /// Closes the popover.
     /// </summary>
-    public void Close() =>
-        UpdateState(state => state.IsOpen = false);
+    /// <param name="restoreFocus">
+    /// When <c>true</c>, signals that focus should be returned to the trigger element
+    /// after the content tears down. Pass <c>true</c> for intentional close paths
+    /// (Escape) and leave <c>false</c> for external dismissals (click-outside) where
+    /// focus is already where the user wants it.
+    /// </param>
+    public void Close(bool restoreFocus = false) =>
+        UpdateState(state =>
+        {
+            state.IsOpen = false;
+            state.RestoreFocusOnClose = restoreFocus;
+        });
 
     /// <summary>
     /// Toggles the popover open/closed state.

--- a/src/BlazorBlueprint.Primitives/Primitives/Select/BbSelectContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Select/BbSelectContent.razor
@@ -5,6 +5,7 @@
 @using BlazorBlueprint.Primitives.Services
 @using Microsoft.JSInterop
 @inject IJSRuntime JS
+@inject IFocusManager FocusManager
 @implements IAsyncDisposable
 
 @*
@@ -212,8 +213,23 @@
             // When context closes, clean up
             if (_context?.IsOpen == false && _isKeyboardSetup)
             {
+                // Capture both the trigger ref and the restore flag before teardown.
+                // State.TriggerElement is still populated at this point (Close() doesn't
+                // clear it), but we read it eagerly in case anything else mutates state.
+                var trigger = _context.State.TriggerElement;
+                var shouldRestoreFocus = _context.State.RestoreFocusOnClose;
+
                 await CleanupAsync();
                 StateHasChanged();
+
+                // Restore focus to the trigger AFTER cleanup so the now-unmounted listbox
+                // isn't the active element when the user next presses Tab. Only restore
+                // for intentional closes (Escape, selection) — click-outside and Tab
+                // leave focus where the user intentionally moved it.
+                if (shouldRestoreFocus && trigger.HasValue)
+                {
+                    await FocusManager.RestoreFocus(trigger);
+                }
             }
         }
         catch (Exception ex) when (ex is ObjectDisposedException or TaskCanceledException)
@@ -286,7 +302,8 @@
     public void JsOnEscapeKey()
     {
         if (_disposed) { return; }
-        _context?.Close();
+        // Escape is an intentional dismiss — return focus to the trigger.
+        _context?.Close(restoreFocus: true);
     }
 
     /// <summary>

--- a/src/BlazorBlueprint.Primitives/Primitives/Select/BbSelectTrigger.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Select/BbSelectTrigger.razor
@@ -103,7 +103,8 @@
                 _shouldPreventDefault = true;
                 if (_context.IsOpen)
                 {
-                    _context.Close();
+                    // Escape is an intentional dismiss — return focus to the trigger.
+                    _context.Close(restoreFocus: true);
                 }
                 break;
             default:

--- a/src/BlazorBlueprint.Primitives/Primitives/Select/SelectContext.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/Select/SelectContext.cs
@@ -62,6 +62,14 @@ public class SelectState<TValue>
     /// Gets or sets whether the select is required.
     /// </summary>
     public bool Required { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether focus should be returned to the trigger element when the
+    /// dropdown closes. Set to <c>true</c> by intentional close paths (item selection,
+    /// Escape) and left <c>false</c> for external dismissals (click-outside, Tab) where
+    /// focus is already on whatever the user moved to.
+    /// </summary>
+    public bool RestoreFocusOnClose { get; set; }
 }
 
 /// <summary>
@@ -172,18 +180,26 @@ public class SelectContext<TValue> : PrimitiveContextWithEvents<SelectState<TVal
             state.IsOpen = true;
             state.TriggerElement = triggerElement;
             state.FocusedIndex = -1; // Reset focus on open
+            state.RestoreFocusOnClose = false; // Cleared so the next Close() decides afresh
         });
     }
 
     /// <summary>
     /// Closes the select dropdown.
     /// </summary>
-    public void Close()
+    /// <param name="restoreFocus">
+    /// When <c>true</c>, signals that focus should be returned to the trigger element
+    /// after the content tears down. Pass <c>true</c> for intentional close paths
+    /// (Escape, keyboard activation) and leave <c>false</c> for external dismissals
+    /// (click-outside, Tab) where focus is already where the user wants it.
+    /// </param>
+    public void Close(bool restoreFocus = false)
     {
         UpdateState(state =>
         {
             state.IsOpen = false;
             state.FocusedIndex = -1;
+            state.RestoreFocusOnClose = restoreFocus;
         });
     }
 
@@ -221,6 +237,9 @@ public class SelectContext<TValue> : PrimitiveContextWithEvents<SelectState<TVal
             state.DisplayText = displayText;
             state.IsOpen = false; // Close after selection
             state.FocusedIndex = -1;
+            // Selection is an intentional close — return focus to the trigger so
+            // keyboard navigation (Tab) continues from the right place.
+            state.RestoreFocusOnClose = true;
         });
 
         // Invoke value change callback


### PR DESCRIPTION
## Problem

Closes #336.

When a Select or DropdownMenu was closed by an **intentional** action — pressing Escape, or selecting an item — keyboard focus was not returned to the trigger. As the overlay content unmounted, `document.activeElement` fell back to `<body>`, so a subsequent Tab resumed from the top of the page instead of from the control the user had just been operating. Popover had the same gap on Escape when focus was inside its content.

## Fix

Focus is now restored to the trigger **only** on intentional closes. External dismissals (click-outside, Tab) are deliberately left alone, so focus stays wherever the user moved it.

- Added `Close(bool restoreFocus = false)` plus a `RestoreFocusOnClose` state flag to the Select, DropdownMenu, and Popover contexts. The flag is reset on `Open()`, so each close decides afresh.
- Content components capture the trigger reference **before** teardown and call `IFocusManager.RestoreFocus` **after** `CleanupAsync()`, so the now-unmounted overlay is never the active element when Tab is next pressed.
- The Select selection path sets the flag directly, since it closes via state mutation rather than `Close()`.
- `Close()` keeps its previous parameterless behaviour via the default argument, so existing callers are unaffected.

## Verification

These paths aren't reachable by the API-surface snapshot tests — they need a real browser and real focus — so this was verified manually in the Server demo via Playwright, asserting `document.activeElement` after each close path:

| Component | Close path | Expected | Result |
|---|---|---|---|
| Select | Escape | focus → trigger | ✅ |
| Select | keyboard selection (↓ Enter) | focus → trigger | ✅ |
| Select | click-outside | focus stays off trigger | ✅ |
| DropdownMenu | Escape | focus → trigger | ✅ |
| DropdownMenu | item activation | focus → trigger | ✅ |
| DropdownMenu | click-outside | focus stays off trigger | ✅ |
| Popover | Escape (focus inside content) | focus → trigger | ✅ |
| Popover | click-outside | focus stays off trigger | ✅ |

Full solution builds clean; Primitives snapshot tests 67/67; no console errors during the run.

## Also included

Folds in an unrelated one-line fix for a `CS1998` build error in `DataViewDemo.razor` (an async items-provider with no `await`) that was breaking the demo host build under `TreatWarningsAsErrors`. It's what unblocked running the demo for the verification above; bundled here per maintainer request.

## Follow-up (not in this PR)

While testing I noticed a popover with no focusable content does **not** close on Escape when focus is left on the trigger — the Escape handler is scoped to the content element. This is pre-existing and unrelated to this change, but may be worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
