### PR TITLE
fix(primitives): reference-count body scroll lock for nested overlays (#329)

### DIFF
--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/portal.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/portal.js
@@ -87,26 +87,59 @@ export function getComputedZIndex(element) {
     return isNaN(zIndex) ? 0 : zIndex;
 }
 
+// ============================================================================
+// Body scroll lock (reference counted)
+// Stacked/nested overlays (e.g. a Dialog opening an AlertDialog) each acquire a
+// lock. We must only restore the body's original scroll state once the LAST lock
+// is released — otherwise a nested overlay's cleanup, capturing the already-locked
+// "hidden" state, would clobber the outer overlay's restore and leave the page
+// permanently frozen regardless of disposal order.
+// ============================================================================
+
+let scrollLockCount = 0;
+let savedScrollState = null;
+
 /**
- * Locks body scroll (useful for modals).
- * @returns {Object} Object with cleanup method to restore scroll
+ * Locks body scroll (useful for modals). Reference counted so nested overlays
+ * share a single underlying lock.
+ * @returns {Object} Object with an apply() method that releases this lock
  */
 export function lockBodyScroll() {
-    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
-    const originalOverflow = document.body.style.overflow;
-    const originalPaddingRight = document.body.style.paddingRight;
+    if (scrollLockCount === 0) {
+        // First lock: capture the true original state before mutating it.
+        const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+        savedScrollState = {
+            overflow: document.body.style.overflow,
+            paddingRight: document.body.style.paddingRight
+        };
 
-    document.body.style.overflow = 'hidden';
+        document.body.style.overflow = 'hidden';
 
-    // Prevent layout shift by adding padding for scrollbar
-    if (scrollbarWidth > 0) {
-        document.body.style.paddingRight = `${scrollbarWidth}px`;
+        // Prevent layout shift by adding padding for scrollbar
+        if (scrollbarWidth > 0) {
+            document.body.style.paddingRight = `${scrollbarWidth}px`;
+        }
     }
+
+    scrollLockCount++;
+
+    // Guard against this handle being released more than once (e.g. close + dispose).
+    let released = false;
 
     // Return cleanup function wrapped in object for C# interop
     const cleanup = () => {
-        document.body.style.overflow = originalOverflow;
-        document.body.style.paddingRight = originalPaddingRight;
+        if (released) {
+            return;
+        }
+        released = true;
+        scrollLockCount = Math.max(0, scrollLockCount - 1);
+
+        // Only restore once every lock has been released.
+        if (scrollLockCount === 0 && savedScrollState) {
+            document.body.style.overflow = savedScrollState.overflow;
+            document.body.style.paddingRight = savedScrollState.paddingRight;
+            savedScrollState = null;
+        }
     };
 
     return {


### PR DESCRIPTION
## Summary
Fixes #329 — nested dialogs froze the page (no scrolling) until a refresh.

`lockBodyScroll` in `portal.js` used a per-call closure that captured the **current** `body.style.overflow`, with no reference counting. With stacked overlays, whichever cleanup ran **last** won — and if a nested overlay's cleanup (which captured `hidden`) ran last, it re-applied `hidden` and left the page frozen. Disposal order for nested overlays isn't guaranteed, so this tripped easily (e.g. a confirm action that closes both dialogs).

Rewrites it as a module-level **reference-counted** lock: the true original body state is saved once on the first lock and restored only when the **last** lock releases, with a per-handle idempotency guard against double-release. Shared by Dialog, Sheet, Drawer, and the imperative DialogProvider.

## Verification
- **Direct module test (real browser):** in the previously-fatal release order (outer released first, inner last) and on double-release, `body.style.overflow` restores to `""`.
- **Real nested-dialog flow** (button-close *and* Escape paths): page stays scrollable after closing; `overflow` restored; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
