### PR TITLE
fix(combobox): selected label for pre-bound compositional values (#340)

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor
@@ -72,5 +72,19 @@
                 </CascadingValue>
             </BbPopoverContent>
         </BbPopover>
+        @* Hidden registration pass (compositional mode only). The interactive items above live
+           inside the popover portal, which doesn't mount until the first open — so for a pre-bound
+           Value the trigger would show the placeholder until the user opens the dropdown once.
+           Rendering the items again here, invisibly and non-interactively (see RegistrationOnly),
+           lets each one register its display text on initial load so the trigger resolves the
+           selected caption immediately. *@
+        @if (Options is null && ChildContent is not null)
+        {
+            <div style="display:none" aria-hidden="true">
+                <CascadingValue Name="@BbComboboxConstants.RegistrationScopeName" Value="true" IsFixed="true">
+                    @ChildContent
+                </CascadingValue>
+            </div>
+        }
     </div>
 </CascadingValue>

--- a/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor.cs
@@ -66,9 +66,10 @@ public partial class BbCombobox<TValue> : ComponentBase
     private string _lastSearchQuery = string.Empty;
 
     // Bypass for ShouldRender when the trigger needs to pick up a freshly-registered
-    // display text for the current selection. ComboboxItem children live inside the
-    // popover portal and only mount on first open, so their RegisterItem call
-    // arrives well after the surrounding render-skipping state has settled.
+    // display text for the current selection. ComboboxItem children register their text on
+    // initial render via the hidden registration pass, but that happens after the trigger's
+    // first render — so RegisterItem arrives once the render-skipping state has already
+    // settled and must force a follow-up render.
     private bool _triggerTextDirty;
 
     protected override bool ShouldRender()
@@ -153,14 +154,14 @@ public partial class BbCombobox<TValue> : ComponentBase
     /// <c>BbComboboxItem</c> has registered yet.
     /// </summary>
     /// <remarks>
-    /// Items live inside the popover portal and only mount when it opens, so the
-    /// internal text registry is empty on initial render. Set this when you already
-    /// know the display text for the preselected value (typically right after resolving
-    /// it from an API) so the trigger can render the correct caption before the user
-    /// has opened the popover. Options mode does not need this — it resolves the text
-    /// synchronously from the <see cref="Options"/> collection. Ignored once a matching
-    /// item registers, so re-registration (e.g. Text updated by the parent) still
-    /// corrects stale captions.
+    /// Compositional items now register their text on initial render (via a hidden
+    /// registration pass), so the trigger resolves a pre-bound <see cref="Value"/> without
+    /// this in the common case. Set it only when the matching item isn't present in the
+    /// markup at first render — e.g. the selection is loaded asynchronously and added later —
+    /// so the trigger can still show a caption in the meantime. Options mode never needs this;
+    /// it resolves text synchronously from the <see cref="Options"/> collection. A registered
+    /// item always wins over this hint, so re-registration (e.g. Text updated by the parent)
+    /// still corrects stale captions.
     /// </remarks>
     [Parameter]
     public string? SelectedItemText { get; set; }
@@ -331,9 +332,9 @@ public partial class BbCombobox<TValue> : ComponentBase
 
     /// <summary>
     /// Gets the display text for the currently selected item. Resolution order:
-    /// Options (Options mode) → registered items (Compositional mode, after first open) →
-    /// caller-supplied <see cref="SelectedItemText"/> (covers the pre-mount gap) →
-    /// cached text from the last user selection → placeholder.
+    /// Options (Options mode) → registered items (Compositional mode) →
+    /// caller-supplied <see cref="SelectedItemText"/> (fallback when no matching item is in
+    /// the markup yet) → cached text from the last user selection → placeholder.
     /// </summary>
     private string SelectedDisplayText
     {
@@ -358,8 +359,8 @@ public partial class BbCombobox<TValue> : ComponentBase
                 return registryText;
             }
 
-            // Caller-provided initial text — covers the "popover has never opened so
-            // children have not mounted" gap that the registry alone cannot fill.
+            // Caller-provided initial text — fallback when the selected value has no matching
+            // item in the markup yet (e.g. the selection is loaded asynchronously).
             if (!string.IsNullOrEmpty(SelectedItemText))
             {
                 return SelectedItemText;
@@ -506,8 +507,9 @@ public partial class BbCombobox<TValue> : ComponentBase
 
         // If the registered item is the current selection and its display text actually
         // changed (covers first-mount and Text-updates), re-render so the trigger picks
-        // up the new caption. Items mount lazily inside the popover portal, so without
-        // this the trigger would stay on the placeholder until the user interacted.
+        // up the new caption. Registration happens after the trigger's first render (the
+        // hidden registration pass mounts children later in the same initial render cycle),
+        // so without this the trigger would stay on the placeholder.
         if (textChanged && EqualityComparer<TValue>.Default.Equals(value, Value))
         {
             _triggerTextDirty = true;

--- a/src/BlazorBlueprint.Components/Components/Combobox/BbComboboxConstants.cs
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbComboboxConstants.cs
@@ -1,0 +1,16 @@
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// Shared, type-independent constants for the Combobox component family.
+/// </summary>
+internal static class BbComboboxConstants
+{
+    /// <summary>
+    /// Name of the cascading flag the parent uses to mark its hidden, render-nothing
+    /// registration pass so <c>BbComboboxItem</c> children register their display text
+    /// on initial load without producing interactive DOM. Lives on a non-generic type so
+    /// it can be referenced from a <see cref="Microsoft.AspNetCore.Components.CascadingParameterAttribute"/>
+    /// name without involving the parent's type parameter.
+    /// </summary>
+    public const string RegistrationScopeName = "BbComboboxRegistrationOnly";
+}

--- a/src/BlazorBlueprint.Components/Components/Combobox/BbComboboxItem.razor
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbComboboxItem.razor
@@ -1,26 +1,31 @@
 @namespace BlazorBlueprint.Components
 @typeparam TValue
 
-<BbCommandItem Value="@Value?.ToString()" OnSelect="@HandleSelect" SearchText="@Text" Disabled="@Disabled">
-    @if (ChildContent is not null)
-    {
-        @ChildContent
-    }
-    else
-    {
-        @Text
-    }
-    <svg xmlns="http://www.w3.org/2000/svg"
-         width="16"
-         height="16"
-         viewBox="0 0 24 24"
-         fill="none"
-         stroke="currentColor"
-         stroke-width="2"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         class="@($"ml-auto h-4 w-4 shrink-0 {(IsSelected ? "opacity-100" : "opacity-0")}")"
-         aria-label="@(IsSelected ? "Selected" : "")">
-        <path d="M20 6 9 17l-5-5" />
-    </svg>
-</BbCommandItem>
+@* In the parent's hidden registration pass we register text (via lifecycle) but emit no
+   DOM — BbCommandItem needs a CommandContext that only exists inside the popover's BbCommand. *@
+@if (!RegistrationOnly)
+{
+    <BbCommandItem Value="@Value?.ToString()" OnSelect="@HandleSelect" SearchText="@Text" Disabled="@Disabled">
+        @if (ChildContent is not null)
+        {
+            @ChildContent
+        }
+        else
+        {
+            @Text
+        }
+        <svg xmlns="http://www.w3.org/2000/svg"
+             width="16"
+             height="16"
+             viewBox="0 0 24 24"
+             fill="none"
+             stroke="currentColor"
+             stroke-width="2"
+             stroke-linecap="round"
+             stroke-linejoin="round"
+             class="@($"ml-auto h-4 w-4 shrink-0 {(IsSelected ? "opacity-100" : "opacity-0")}")"
+             aria-label="@(IsSelected ? "Selected" : "")">
+            <path d="M20 6 9 17l-5-5" />
+        </svg>
+    </BbCommandItem>
+}

--- a/src/BlazorBlueprint.Components/Components/Combobox/BbComboboxItem.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbComboboxItem.razor.cs
@@ -13,6 +13,15 @@ public partial class BbComboboxItem<TValue> : ComponentBase, IDisposable
     private BbCombobox<TValue>? Parent { get; set; }
 
     /// <summary>
+    /// When true, this item is part of the parent's hidden registration pass: it registers
+    /// its display text with the parent but renders no DOM. The parent renders the items a
+    /// second time, eagerly and invisibly, so their captions are known on initial load —
+    /// before the popover (and therefore the real, interactive items) has ever mounted.
+    /// </summary>
+    [CascadingParameter(Name = BbComboboxConstants.RegistrationScopeName)]
+    private bool RegistrationOnly { get; set; }
+
+    /// <summary>
     /// Gets or sets the value of this item.
     /// </summary>
     [Parameter, EditorRequired]

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -453,6 +453,7 @@
   - Text : String [EditorRequired]
   - Value : TValue [EditorRequired]
   - Parent : BbCombobox<TValue> [CascadingParameter]
+  - RegistrationOnly : Boolean [CascadingParameter]
 
 ### BbCombobox`1 (BlazorBlueprint.Components)
   - ActiveClass : String


### PR DESCRIPTION
## Summary
Fixes #340 — in compositional mode (`<BbComboboxItem>` children) with a pre-bound `Value`, the trigger showed the placeholder instead of the selected label until the dropdown was opened and closed once.

Items only mounted when the popover first opened (`ForceMount=false`), so `RegisterItem` never ran on initial load and the trigger's text lookup fell back to the placeholder. (#337 added re-render-on-register machinery, but it never fired because the items never mounted.)

Adds a hidden, non-interactive **registration pass**: `ChildContent` renders once more inside a `display:none` wrapper carrying a cascaded registration flag, so each `BbComboboxItem` registers its text on initial render (while rendering no DOM) — which makes the #337 machinery fire. The popover lifecycle is left completely untouched.

## Notes
- New internal `BbComboboxConstants` (cascade name) and a private `RegistrationOnly` cascading flag on `BbComboboxItem`. The API-surface snapshot was updated to include the framework-tracked `RegistrationOnly` parameter (reviewed, intentional).
- Alternative considered: force-mounting the popover content only in compositional mode (no API-surface line, but changes the popover mount lifecycle). Chose the lower-risk registration pass.

## Verification
- **Browser:** trigger shows the pre-bound label ("Vue.js") immediately on load; persists through open/close; Options mode unaffected.
- **All 67 tests pass**, including the API-surface snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
