### PR TITLE
feat(command): ItemsProvider for server-side lazy loading (#338)

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Command/items-provider.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Command/items-provider.txt
@@ -1,0 +1,47 @@
+<BbCommand OnValueChange="@HandleSelect">
+    <BbCommandInput Placeholder="Search 25,000 records..." />
+    <BbCommandList Class="max-h-[300px]">
+        <BbCommandEmpty>No records found.</BbCommandEmpty>
+        <BbCommandVirtualizedGroup TItem="(string Name, int Index)"
+            Heading="Records"
+            ItemsProvider="@LoadRecordsAsync"
+            ItemValue="@(r => r.Name)"
+            EnableLazyLoading="true">
+            <ItemTemplate Context="record">
+                <span class="flex-1">@record.Name</span>
+                <span class="text-xs text-muted-foreground ml-2">#@record.Index</span>
+            </ItemTemplate>
+        </BbCommandVirtualizedGroup>
+    </BbCommandList>
+</BbCommand>
+
+@code {
+    private string? selected;
+    private void HandleSelect(string value) => selected = value;
+
+    // ItemsProvider replaces the eager Items list: it is invoked as the user scrolls and
+    // whenever the search changes, so only the visible slice is ever fetched. Apply the
+    // search yourself (request.SearchText) and return the matching slice + total count.
+    private async ValueTask<CommandItemsProviderResult<(string Name, int Index)>> LoadRecordsAsync(
+        CommandItemsProviderRequest request)
+    {
+        // In a real app this is a DB/API call, e.g.:
+        //   var query = db.Records.Where(...);
+        //   var total = await query.CountAsync(request.CancellationToken);
+        //   var items = await query.Skip(request.StartIndex).Take(request.Count).ToListAsync(...);
+        var query = AllRecords.AsEnumerable();
+        if (!string.IsNullOrWhiteSpace(request.SearchText))
+        {
+            query = query.Where(r => r.Name.Contains(request.SearchText, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var matched = query.ToList();
+        var slice = matched.Skip(request.StartIndex).Take(request.Count).ToList();
+
+        return new CommandItemsProviderResult<(string Name, int Index)>
+        {
+            Items = slice,
+            TotalItemCount = matched.Count,
+        };
+    }
+}

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CommandDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CommandDemo.razor
@@ -498,6 +498,48 @@
         <CodeBlock Source="Components/Command/lazy-loading.txt" />
     </section>
 
+    <!-- Server-Side Lazy Loading (ItemsProvider) -->
+    <section class="space-y-4">
+        <h2 class="text-2xl font-semibold">Server-Side Lazy Loading (ItemsProvider)</h2>
+        <p class="text-sm text-muted-foreground">
+            With <code class="text-xs bg-muted px-1 py-0.5 rounded">EnableLazyLoading</code> plus the
+            <code class="text-xs bg-muted px-1 py-0.5 rounded">Items</code> parameter you still have to
+            materialize the whole collection up front. Supply an
+            <code class="text-xs bg-muted px-1 py-0.5 rounded">ItemsProvider</code> instead to fetch only
+            the slice currently in view — ideal for data that lives in a database or API. The provider
+            receives the scroll range and the current search text and returns the matching slice plus a
+            total count. This example pages through <strong>25,000</strong> records (with a simulated
+            150&nbsp;ms latency) and never holds more than a screenful in the component.
+        </p>
+
+        <div class="flex flex-col gap-2">
+            <div class="border rounded-lg shadow-sm max-w-md">
+                <BlazorBlueprint.Components.BbCommand OnValueChange="@HandleProviderSelect">
+                    <BbCommandInput Placeholder="Search 25,000 records..." />
+                    <BbCommandList Class="max-h-[300px]">
+                        <BbCommandEmpty>No records found.</BbCommandEmpty>
+                        <BbCommandVirtualizedGroup TItem="(string Name, int Index)"
+                            Heading="Records"
+                            ItemsProvider="@LoadProductsAsync"
+                            ItemValue="@(p => p.Name)"
+                            EnableLazyLoading="true">
+                            <ItemTemplate Context="product">
+                                <span class="flex-1">@product.Name</span>
+                                <span class="text-xs text-muted-foreground ml-2">#@product.Index</span>
+                            </ItemTemplate>
+                        </BbCommandVirtualizedGroup>
+                    </BbCommandList>
+                </BlazorBlueprint.Components.BbCommand>
+            </div>
+            @if (!string.IsNullOrEmpty(providerSelected))
+            {
+                <p class="text-sm">Selected: <strong>@providerSelected</strong></p>
+            }
+        </div>
+
+        <CodeBlock Source="Components/Command/items-provider.txt" />
+    </section>
+
     <!-- Debounce -->
     <section class="space-y-4">
         <h2 class="text-2xl font-semibold">Debounce</h2>
@@ -717,6 +759,11 @@
         .ToArray();
     private static int TotalIconCount => _lucideIcons.Length + _featherIcons.Length + _heroIcons.Length;
 
+    // Stands in for a database/API for the ItemsProvider demo. The component never receives this list —
+    // only the slices the provider returns for the current scroll range + search.
+    private static readonly List<(string Name, int Index)> _allRecords =
+        Enumerable.Range(0, 25000).Select(i => ($"Record {i:00000}", i)).ToList();
+
     private IDisposable? _shortcutRegistration;
 
     // Independent state for each section
@@ -730,6 +777,7 @@
     private string? disabledSelected;
     private string? complexSelected;
     private string? lazySelected;
+    private string? providerSelected;
 
     // Individual handlers for each section
     private void HandlePaletteSelect(string value)
@@ -745,6 +793,30 @@
     private void HandleDisabledSelect(string value) => disabledSelected = value;
     private void HandleComplexSelect(string value) => complexSelected = value;
     private void HandleLazySelect(string value) => lazySelected = value;
+    private void HandleProviderSelect(string value) => providerSelected = value;
+
+    // ItemsProvider for the server-side lazy-loading demo. In a real app this would query a DB or API;
+    // here it filters the in-memory stand-in, pages it, and adds a small delay to simulate latency.
+    private async ValueTask<CommandItemsProviderResult<(string Name, int Index)>> LoadProductsAsync(
+        CommandItemsProviderRequest request)
+    {
+        await Task.Delay(150, request.CancellationToken); // simulate network/db latency
+
+        IEnumerable<(string Name, int Index)> query = _allRecords;
+        if (!string.IsNullOrWhiteSpace(request.SearchText))
+        {
+            query = query.Where(r => r.Name.Contains(request.SearchText, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var matched = query.ToList();
+        var slice = matched.Skip(request.StartIndex).Take(request.Count).ToList();
+
+        return new CommandItemsProviderResult<(string Name, int Index)>
+        {
+            Items = slice,
+            TotalItemCount = matched.Count,
+        };
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/BlazorBlueprint.Components/Components/Command/BbCommandVirtualizedGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Command/BbCommandVirtualizedGroup.razor
@@ -26,7 +26,9 @@
         </div>
     }
 
-    @if (_hasVisibleItems)
+    @* In provider mode the Virtualize stays in the tree even at count 0 (container hidden via
+       display:none above) so it remains mounted and re-queries the provider when the search changes. *@
+    @if (_hasVisibleItems || UseProvider)
     {
         @if (EnableLazyLoading)
         {
@@ -93,9 +95,24 @@
 
     /// <summary>
     /// Gets or sets the collection of items to display.
+    /// Required unless <see cref="ItemsProvider"/> is supplied (provider mode), in which case it is ignored.
     /// </summary>
-    [Parameter, EditorRequired]
+    [Parameter]
     public IReadOnlyList<TItem> Items { get; set; } = Array.Empty<TItem>();
+
+    /// <summary>
+    /// Gets or sets an async callback that fetches items on demand for true lazy loading,
+    /// instead of materializing the whole collection into <see cref="Items"/>.
+    /// </summary>
+    /// <remarks>
+    /// Requires <see cref="EnableLazyLoading"/> to be <c>true</c>. The provider is invoked as the user
+    /// scrolls and whenever the search query changes; it is responsible for applying the search
+    /// (<see cref="CommandItemsProviderRequest.SearchText"/>) and returning the matching slice plus the
+    /// total matching count. When set, <see cref="Items"/>, <see cref="MaxDisplayCount"/>, and the
+    /// component's built-in local filtering are not used.
+    /// </remarks>
+    [Parameter]
+    public CommandItemsProvider<TItem>? ItemsProvider { get; set; }
 
     /// <summary>
     /// Gets or sets the template for rendering each item.
@@ -155,6 +172,16 @@
     private List<TItem>? _lazyFilteredSource; // Full filtered list for lazy loading
     private int _lazyLoadedCount; // How many items currently loaded for lazy loading
 
+    // Provider mode (ItemsProvider supplied): the full set never lives in memory, so cache
+    // each slice the provider returns by absolute index for keyboard selection.
+    private CommandItemsProvider<TItem>? _cachedProvider;
+    private readonly Dictionary<int, TItem> _loadedItems = new();
+
+    /// <summary>
+    /// Whether items are sourced from <see cref="ItemsProvider"/> rather than the in-memory <see cref="Items"/>.
+    /// </summary>
+    private bool UseProvider => ItemsProvider is not null;
+
     private readonly struct IndexedItem
     {
         public readonly TItem Item;
@@ -182,7 +209,15 @@
 
     async Task IVirtualizedGroupHandler.SelectFocusedItemAsync()
     {
-        if (EnableLazyLoading)
+        if (UseProvider)
+        {
+            // The full set isn't in memory; the focused item must have been loaded into view to be focused.
+            if (_focusedIndex >= 0 && _loadedItems.TryGetValue(_focusedIndex, out var providerItem))
+            {
+                await SelectItem(providerItem);
+            }
+        }
+        else if (EnableLazyLoading)
         {
             var source = _lazyFilteredSource ?? (IReadOnlyList<TItem>)Items;
             if (source != null && _focusedIndex >= 0 && _focusedIndex < source.Count)
@@ -246,6 +281,13 @@
 
     protected override void OnInitialized()
     {
+        if (UseProvider && !EnableLazyLoading)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(BbCommandVirtualizedGroup<TItem>)}.{nameof(ItemsProvider)} requires {nameof(EnableLazyLoading)}=\"true\". " +
+                $"Set {nameof(EnableLazyLoading)} or supply {nameof(Items)} instead.");
+        }
+
         if (Context != null)
         {
             Context.OnSearchChanged += HandleSearchChanged;
@@ -253,8 +295,15 @@
             Context.RegisterVirtualizedGroup(this);
         }
         _cachedItems = Items;
+        _cachedProvider = ItemsProvider;
 
-        if (EnableLazyLoading)
+        if (UseProvider)
+        {
+            // Counts and visibility are learned from the provider's first response; show the
+            // Virtualize so it can issue that first request.
+            _hasVisibleItems = true;
+        }
+        else if (EnableLazyLoading)
         {
             UpdateLazyFilteredSource();
         }
@@ -266,6 +315,24 @@
 
     protected override async Task OnParametersSetAsync()
     {
+        if (UseProvider)
+        {
+            // Re-query if the provider delegate itself was swapped at runtime.
+            if (!ReferenceEquals(ItemsProvider, _cachedProvider))
+            {
+                _cachedProvider = ItemsProvider;
+                _loadedItems.Clear();
+                _lazyLoadedCount = 0;
+                _cachedSearchQuery = null;
+                _hasVisibleItems = true;
+                if (_virtualizeRef != null)
+                {
+                    await _virtualizeRef.RefreshDataAsync();
+                }
+            }
+            return;
+        }
+
         // Only re-filter if Items reference actually changed
         if (!ReferenceEquals(Items, _cachedItems))
         {
@@ -427,9 +494,14 @@
         _hasVisibleItems = _filteredCount > 0;
     }
 
-    private ValueTask<Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<IndexedItem>> LoadItemsAsync(
+    private async ValueTask<Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<IndexedItem>> LoadItemsAsync(
         Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest request)
     {
+        if (UseProvider)
+        {
+            return await LoadFromProviderAsync(request);
+        }
+
         // Determine the source list
         var source = _lazyFilteredSource ?? (IReadOnlyList<TItem>)Items;
         var totalItems = source.Count;
@@ -442,8 +514,8 @@
         
         if (count <= 0)
         {
-                        return ValueTask.FromResult(new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<IndexedItem>(
-                Array.Empty<IndexedItem>(), totalItems));
+            return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<IndexedItem>(
+                Array.Empty<IndexedItem>(), totalItems);
         }
 
         // Build the items for this batch
@@ -457,14 +529,80 @@
         // Track loaded count for keyboard navigation
         _lazyLoadedCount = Math.Max(_lazyLoadedCount, startIndex + count);
 
-        
-        return ValueTask.FromResult(new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<IndexedItem>(
-            items, totalItems));
+        return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<IndexedItem>(
+            items, totalItems);
+    }
+
+    private async ValueTask<Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<IndexedItem>> LoadFromProviderAsync(
+        Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest request)
+    {
+        var searchText = Context?.SearchQuery;
+        var providerRequest = new CommandItemsProviderRequest
+        {
+            StartIndex = request.StartIndex,
+            Count = request.Count,
+            SearchText = string.IsNullOrWhiteSpace(searchText) ? null : searchText,
+            CancellationToken = request.CancellationToken,
+        };
+
+        CommandItemsProviderResult<TItem> result;
+        try
+        {
+            result = await ItemsProvider!(providerRequest);
+        }
+        catch (OperationCanceledException)
+        {
+            // Request superseded (further scroll / new search) or component disposed — let Virtualize
+            // discard this batch without surfacing an error.
+            return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<IndexedItem>(
+                Array.Empty<IndexedItem>(), _filteredCount);
+        }
+
+        var batch = result.Items as IList<TItem> ?? result.Items.ToList();
+        var indexed = new IndexedItem[batch.Count];
+        for (int i = 0; i < batch.Count; i++)
+        {
+            var index = request.StartIndex + i;
+            indexed[i] = new IndexedItem(batch[i], index);
+            _loadedItems[index] = batch[i]; // cache by absolute index for keyboard selection
+        }
+
+        _lazyLoadedCount = Math.Max(_lazyLoadedCount, request.StartIndex + batch.Count);
+
+        // The provider is the source of truth for counts; reflect its total in the heading and
+        // visibility. Re-render the group (not just Virtualize) when those change.
+        var hadVisible = _hasVisibleItems;
+        if (_totalCount != result.TotalItemCount || _filteredCount != result.TotalItemCount || hadVisible != result.TotalItemCount > 0)
+        {
+            _totalCount = result.TotalItemCount;
+            _filteredCount = result.TotalItemCount;
+            _hasVisibleItems = result.TotalItemCount > 0;
+            StateHasChanged();
+        }
+
+        return new Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<IndexedItem>(
+            indexed, result.TotalItemCount);
     }
 
     private async void HandleSearchChanged()
     {
         _cachedSearchQuery = null; // Force rebuild
+
+        if (UseProvider)
+        {
+            // Drop the cached slices and optimistically re-show so the (kept-mounted) Virtualize
+            // re-queries the provider with the new search; the response resets the real count.
+            _loadedItems.Clear();
+            _lazyLoadedCount = 0;
+            _hasVisibleItems = true;
+            _focusedIndex = -1;
+            StateHasChanged();
+            if (_virtualizeRef != null)
+            {
+                await _virtualizeRef.RefreshDataAsync();
+            }
+            return;
+        }
 
         if (EnableLazyLoading)
         {

--- a/src/BlazorBlueprint.Components/Components/Command/CommandItemsProvider.cs
+++ b/src/BlazorBlueprint.Components/Components/Command/CommandItemsProvider.cs
@@ -1,0 +1,59 @@
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// Delegate for asynchronous, server-side data fetching in a <see cref="BbCommandVirtualizedGroup{TItem}"/>.
+/// Invoked as the user scrolls (and whenever the search query changes) when
+/// <c>EnableLazyLoading</c> is <c>true</c> and an <c>ItemsProvider</c> is supplied — so the caller
+/// never has to materialize the full collection up front.
+/// </summary>
+/// <typeparam name="TItem">The type of data items.</typeparam>
+/// <param name="request">The request describing the slice to fetch, the active search text, and a cancellation token.</param>
+/// <returns>A result containing the items for the requested slice and the total (filtered) count.</returns>
+public delegate ValueTask<CommandItemsProviderResult<TItem>> CommandItemsProvider<TItem>(
+    CommandItemsProviderRequest request);
+
+/// <summary>
+/// Describes the data request from <see cref="BbCommandVirtualizedGroup{TItem}"/> to the items provider.
+/// </summary>
+public class CommandItemsProviderRequest
+{
+    /// <summary>
+    /// Gets the zero-based index of the first item to return.
+    /// </summary>
+    public int StartIndex { get; init; }
+
+    /// <summary>
+    /// Gets the maximum number of items to return for this slice.
+    /// </summary>
+    public int Count { get; init; }
+
+    /// <summary>
+    /// Gets the active search text the provider should filter by, or <c>null</c> when no search is active.
+    /// Filtering is the provider's responsibility — the component does not filter provider results locally.
+    /// </summary>
+    public string? SearchText { get; init; }
+
+    /// <summary>
+    /// Gets the cancellation token for the request. Cancelled when the request is superseded
+    /// (e.g. the user keeps scrolling or changes the search) or the component is disposed.
+    /// </summary>
+    public CancellationToken CancellationToken { get; init; }
+}
+
+/// <summary>
+/// The result returned by a <see cref="CommandItemsProvider{TItem}"/>.
+/// </summary>
+/// <typeparam name="TItem">The type of data items.</typeparam>
+public class CommandItemsProviderResult<TItem>
+{
+    /// <summary>
+    /// Gets the items for the requested slice.
+    /// </summary>
+    public required ICollection<TItem> Items { get; init; }
+
+    /// <summary>
+    /// Gets the total number of items matching the current search across all slices.
+    /// Used to size the scroll area and drive keyboard navigation.
+    /// </summary>
+    public int TotalItemCount { get; init; }
+}

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -554,7 +554,8 @@
   - ItemSearchText : Func<TItem, String>
   - ItemTemplate : RenderFragment<TItem> [EditorRequired]
   - ItemValue : Func<TItem, String> [EditorRequired]
-  - Items : IReadOnlyList<TItem> [EditorRequired]
+  - Items : IReadOnlyList<TItem>
+  - ItemsProvider : CommandItemsProvider<TItem>
   - LazyLoadBatchSize : Int32
   - MaxDisplayCount : Int32
   - Context : CommandContext [CascadingParameter]


### PR DESCRIPTION
## Summary
Closes #338 — `BbCommandVirtualizedGroup` had `EnableLazyLoading`, but it only virtualized *rendering*: the caller still had to materialize the entire collection into `Items`. This adds a true **server-side `ItemsProvider`**, following the `BbDataView` precedent (#306).

## What's new
- New public delegate/types (`Components/Command/CommandItemsProvider.cs`): `CommandItemsProvider<TItem>`, `CommandItemsProviderRequest` (StartIndex / Count / SearchText / CancellationToken), and `CommandItemsProviderResult<TItem>` (Items + TotalItemCount). No `class` constraint, so value-tuple items work.
- New `ItemsProvider` parameter on `BbCommandVirtualizedGroup`. When set (requires `EnableLazyLoading=true`), the component fetches only the visible slice on demand — `Items`, `MaxDisplayCount`, and local filtering are bypassed.
- `Items` is no longer `[EditorRequired]` (optional in provider mode).
- Search is delegated to the provider via `request.SearchText`; counts come from `TotalItemCount`; loaded slices are cached by absolute index so keyboard selection still works without the full list in memory. Cancellation is honored (superseded scroll/search).
- Demo: new "Server-Side Lazy Loading (ItemsProvider)" section on the Command page paging through 25,000 records with simulated latency, plus a `items-provider.txt` code sample.

## Notes
- Provider mode requires `EnableLazyLoading=true` (throws a clear exception otherwise).
- Existing non-provider behavior is unchanged — all new logic is gated behind `ItemsProvider != null`.
- API-surface snapshot updated (`Items` loses `[EditorRequired]`; new `ItemsProvider` parameter).

## Verification
- **Browser:** initial load pages from the provider; scrolling fetches new slices on demand (scroll area sized to 25,000 × 32px from the provider's total); search filters server-side (`Record 01234`) and resets; selection callback fires. No console errors.
- **All 67 tests pass**, including the API-surface snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
