### PR TITLE
feat(datagrid): CellClass/HeaderClass on BbDataGridSelectColumn (#332)

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/compact-rows.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/compact-rows.txt
@@ -1,0 +1,16 @@
+<BbDataGrid TData="Person" Items="@people" InitialPageSize="5"
+            SelectionMode="DataTableSelectionMode.Multiple">
+    <Columns>
+        @* CellClass/HeaderClass override the column's default padding. Apply it to the
+           select column too, otherwise its padding forces a taller row than the rest. *@
+        <BbDataGridSelectColumn TData="Person" CellClass="p-1" HeaderClass="p-1" />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)"
+                                  CellClass="p-1" HeaderClass="p-1" Sortable />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Email)"
+                                  CellClass="p-1" HeaderClass="p-1" />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)"
+                                  CellClass="p-1" HeaderClass="p-1" Sortable />
+        <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)"
+                                  Format="C0" CellClass="p-1" HeaderClass="p-1" Sortable />
+    </Columns>
+</BbDataGrid>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
@@ -149,6 +149,31 @@
         <CodeBlock Source="Components/DataGrid/row-selection.txt" />
     </div>
 
+    <!-- ── Compact Rows (CellClass / HeaderClass) ─────────────────── -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Compact Rows (CellClass / HeaderClass)</h2>
+            <p class="text-sm text-muted-foreground">
+                Every column &mdash; including <code class="bg-muted px-1 py-0.5 rounded">BbDataGridSelectColumn</code> &mdash;
+                accepts <code class="bg-muted px-1 py-0.5 rounded">CellClass</code> and
+                <code class="bg-muted px-1 py-0.5 rounded">HeaderClass</code>. Apply a smaller padding such as
+                <code class="bg-muted px-1 py-0.5 rounded">CellClass="p-1"</code> to every column, the checkbox column
+                included, for a dense grid &mdash; the select column no longer forces a taller row.
+            </p>
+        </div>
+        <BbDataGrid TData="Person" Items="@people" InitialPageSize="5"
+                   SelectionMode="DataTableSelectionMode.Multiple">
+            <Columns>
+                <BbDataGridSelectColumn TData="Person" CellClass="p-1" HeaderClass="p-1" />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" CellClass="p-1" HeaderClass="p-1" Sortable />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Email)" CellClass="p-1" HeaderClass="p-1" />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" CellClass="p-1" HeaderClass="p-1" Sortable />
+                <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" CellClass="p-1" HeaderClass="p-1" Sortable />
+            </Columns>
+        </BbDataGrid>
+        <CodeBlock Source="Components/DataGrid/compact-rows.txt" />
+    </div>
+
     <!-- ── Expandable Rows ────────────────────────────────────────── -->
     <div class="space-y-4">
         <div class="space-y-2">
@@ -1061,6 +1086,12 @@
             <ApiReference ComponentName="DataGridSelectColumn">
                 <ApiParameter Name="Width" Type="string?" Default="48px">
                     Column width for the checkbox column. Defaults to a compact checkbox width.
+                </ApiParameter>
+                <ApiParameter Name="CellClass" Type="string?">
+                    Additional CSS classes applied to the selection cells. Use e.g. "p-1" to override the default padding for a compact row height.
+                </ApiParameter>
+                <ApiParameter Name="HeaderClass" Type="string?">
+                    Additional CSS classes applied to the header cell (the select-all checkbox).
                 </ApiParameter>
                 <ApiParameter Name="Pinned" Type="ColumnPinning" Default="None">
                     Whether this column is pinned. Commonly set to BlazorBlueprint.Primitives.DataGrid.ColumnPinning.Left to keep the checkbox column visible when scrolling horizontally.

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
@@ -2843,7 +2843,9 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
 
         if (isSelectColumn || isExpandColumn)
         {
-            return ClassNames.cn(baseClass, "w-12", pinnedClass, separatorClass);
+            // column.HeaderClass last so callers can override the baked-in width/padding
+            // (e.g. compact select column). cn() is tailwind-merge, so later classes win.
+            return ClassNames.cn(baseClass, "w-12", pinnedClass, separatorClass, column.HeaderClass);
         }
 
         var needsGroup = column.Sortable || column.Filterable || (Reorderable && column.Reorderable);
@@ -2909,7 +2911,9 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
 
         if (isSelectColumn || isExpandColumn)
         {
-            return ClassNames.cn(baseClass, "w-12", pinnedClass, separatorClass);
+            // column.CellClass last so callers can override the baked-in width/padding
+            // (e.g. CellClass="p-1" for a compact select column). cn() is tailwind-merge.
+            return ClassNames.cn(baseClass, "w-12", pinnedClass, separatorClass, column.CellClass);
         }
 
         var cellClass = column.CellClass;

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridSelectColumn.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridSelectColumn.razor.cs
@@ -27,6 +27,20 @@ public partial class BbDataGridSelectColumn<TData> : ComponentBase, IDataGridCol
     public ColumnPinning Pinned { get; set; } = ColumnPinning.None;
 
     /// <summary>
+    /// Additional CSS classes for the selection cells. Useful for matching a compact row height —
+    /// e.g. <c>CellClass="p-1"</c> to override the default cell padding so the checkbox column
+    /// doesn't force a taller row than the rest of the grid.
+    /// </summary>
+    [Parameter]
+    public string? CellClass { get; set; }
+
+    /// <summary>
+    /// Additional CSS classes for the header cell (the select-all checkbox).
+    /// </summary>
+    [Parameter]
+    public string? HeaderClass { get; set; }
+
+    /// <summary>
     /// The parent DataGrid component. Set via cascading parameter.
     /// </summary>
     [CascadingParameter]
@@ -58,9 +72,9 @@ public partial class BbDataGridSelectColumn<TData> : ComponentBase, IDataGridCol
 
     RenderFragment<DataGridHeaderContext<TData>>? IDataGridColumn<TData>.HeaderTemplate => null;
 
-    string? IDataGridColumn<TData>.CellClass => null;
+    string? IDataGridColumn<TData>.CellClass => CellClass;
 
-    string? IDataGridColumn<TData>.HeaderClass => null;
+    string? IDataGridColumn<TData>.HeaderClass => HeaderClass;
 
     bool IDataGridColumn<TData>.NoWrap => false;
 

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -780,6 +780,8 @@
   - ParentGrid : BbDataGrid<TData> [CascadingParameter]
 
 ### BbDataGridSelectColumn`1 (BlazorBlueprint.Components)
+  - CellClass : String
+  - HeaderClass : String
   - Pinned : ColumnPinning
   - Width : String
   - ParentGrid : BbDataGrid<TData> [CascadingParameter]


### PR DESCRIPTION
## Summary
Closes #332 — `BbDataGridSelectColumn` now accepts `CellClass` and `HeaderClass`, so the selection (checkbox) column can match a compact/dense grid instead of forcing a taller row.

Property columns already supported these, but the select (and expand) columns short-circuited in `GetCellClass`/`GetHeaderCellClass` with a hardcoded `p-4`, ignoring any column class — so adding a select column made it impossible to shrink the row height (exactly the problem in the issue's screenshots).

## Changes
- **`BbDataGridSelectColumn`**: new `CellClass` / `HeaderClass` parameters, surfaced through `IDataGridColumn` (previously hardcoded to `null`).
- **`BbDataGrid`**: the select/expand early-return in `GetCellClass`/`GetHeaderCellClass` now appends `column.CellClass` / `column.HeaderClass` last. Because `ClassNames.cn` is tailwind-merge, a caller's `CellClass="p-1"` overrides the baked-in `p-4`. (Also benefits the expand column if it later exposes the params; today it returns `null`, so no behavior change there.)

## Verification
- **Browser:** with `CellClass="p-1" HeaderClass="p-1"`, the select body and header cells render `p-1` (4px padding) with `p-4` merged away, while adjacent property cells stay `p-4` (16px) — only the select column changes.
- **All 67 tests pass** (API-surface snapshot updated: new `CellClass`/`HeaderClass` on `BbDataGridSelectColumn`).
