### PR TITLE
fix(combobox,multiselect): restore focus to trigger on close so Tab continues

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor
@@ -3,7 +3,7 @@
 @attribute [CascadingTypeParameter(nameof(TValue))]
 <CascadingValue Value="this" IsFixed="true">
     <div class="@ContainerClass">
-        <BbPopover Open="_isOpen" OpenChanged="HandleOpenChanged">
+        <BbPopover Open="_isOpen" OpenChanged="HandleOpenChanged" RestoreFocusOnClose="_restoreFocusOnClose">
             <BbPopoverTrigger AsChild="false" role="combobox"
                            aria-expanded="@GetIsOpen().ToString().ToLower()"
                            aria-controls="@($"{Id}-listbox")"

--- a/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor.cs
@@ -292,6 +292,12 @@ public partial class BbCombobox<TValue> : ComponentBase
     private bool _focusDone;
 
     /// <summary>
+    /// Whether the next controlled close should return focus to the trigger. Set true on
+    /// selection (intentional close) and reset on open. Bound to the popover's RestoreFocusOnClose.
+    /// </summary>
+    private bool _restoreFocusOnClose;
+
+    /// <summary>
     /// Item text registry for compositional mode display text lookup.
     /// </summary>
 #pragma warning disable CS8714 // TValue may be null but dictionary keys are non-null in practice
@@ -412,6 +418,12 @@ public partial class BbCombobox<TValue> : ComponentBase
     private async Task HandleOpenChanged(bool isOpen)
     {
         _isOpen = isOpen;
+        if (isOpen)
+        {
+            // Default to NOT restoring focus; only a selection-close opts in (see HandleSelect).
+            // This keeps click-outside dismissal leaving focus where the user clicked.
+            _restoreFocusOnClose = false;
+        }
         if (!isOpen)
         {
             _focusDone = false; // Reset for next open
@@ -453,7 +465,10 @@ public partial class BbCombobox<TValue> : ComponentBase
             _editContext.NotifyFieldChanged(_fieldIdentifier);
         }
 
-        // Close the popover after selection
+        // Close the popover after selection — an intentional close, so return focus to the
+        // trigger (the popover content unmounts; without this, focus is lost to <body> and the
+        // next Tab restarts from the top of the document).
+        _restoreFocusOnClose = true;
         _isOpen = false;
         // Note: _focusDone is reset by HandleOpenChanged
     }

--- a/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor
+++ b/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor
@@ -5,7 +5,7 @@
 
 <CascadingValue Value="this" IsFixed="true">
 <div class="@ContainerClass">
-    <BbPopover Open="_isOpen" OpenChanged="HandleOpenChanged">
+    <BbPopover Open="_isOpen" OpenChanged="HandleOpenChanged" RestoreFocusOnClose="_restoreFocusOnClose">
         <BbPopoverTrigger AsChild="false" role="combobox"
                         aria-expanded="@_isOpen.ToString().ToLower()"
                         aria-controls="@($"{Id}-listbox")"

--- a/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor.cs
@@ -240,6 +240,13 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
     private bool _isOpen { get; set; }
 
     /// <summary>
+    /// Whether the next close should return focus to the trigger. True for intentional
+    /// dismissals (Escape, the Close button); false for click-outside (focus stays where the
+    /// user clicked). Bound to the popover's RestoreFocusOnClose.
+    /// </summary>
+    private bool _restoreFocusOnClose;
+
+    /// <summary>
     /// Tracks the current search query for filtering.
     /// </summary>
     private string _searchQuery = string.Empty;
@@ -442,14 +449,23 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
             return;
         }
 
+        _restoreFocusOnClose = false; // reset; intentional closes opt back in
         _isOpen = true;
     }
 
     /// <summary>
-    /// Closes the dropdown.
+    /// Closes the dropdown as an intentional dismissal (Escape, Close button), returning focus
+    /// to the trigger so keyboard navigation continues from the right place.
     /// </summary>
-    private async Task Close()
+    private Task Close() => CloseCore(restoreFocus: true);
+
+    /// <summary>
+    /// Closes the dropdown. <paramref name="restoreFocus"/> controls whether focus returns to the
+    /// trigger — true for intentional dismissals, false for click-outside (leave focus where clicked).
+    /// </summary>
+    private async Task CloseCore(bool restoreFocus)
     {
+        _restoreFocusOnClose = restoreFocus;
         _isOpen = false;
         _searchQuery = string.Empty;
 
@@ -474,7 +490,7 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
     /// <summary>
     /// Handles click-outside events when AutoClose is enabled.
     /// </summary>
-    private async Task HandleClickOutside() => await Close();
+    private async Task HandleClickOutside() => await CloseCore(restoreFocus: false);
 
     /// <summary>
     /// Handles the popover content ready event to focus the search input.

--- a/src/BlazorBlueprint.Components/Components/Popover/BbPopover.razor
+++ b/src/BlazorBlueprint.Components/Components/Popover/BbPopover.razor
@@ -9,6 +9,7 @@
                                            OpenChanged="@OpenChanged"
                                            DefaultOpen="@DefaultOpen"
                                            OnOpenChange="@OnOpenChange"
+                                           RestoreFocusOnClose="@RestoreFocusOnClose"
                                            Modal="@Modal">
     @ChildContent
 </BlazorBlueprint.Primitives.Popover.BbPopover>
@@ -53,4 +54,12 @@
     /// </summary>
     [Parameter]
     public bool Modal { get; set; } = true;
+
+    /// <summary>
+    /// When the popover is closed via the controlled <see cref="Open"/> binding (consumer-driven,
+    /// e.g. after selecting an item), whether to return focus to the trigger. Defaults to false.
+    /// Click-outside and Escape dismissals are unaffected.
+    /// </summary>
+    [Parameter]
+    public bool RestoreFocusOnClose { get; set; }
 }

--- a/src/BlazorBlueprint.Primitives/Primitives/Popover/BbPopover.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Popover/BbPopover.razor
@@ -51,6 +51,16 @@
     [Parameter]
     public bool Modal { get; set; } = true;
 
+    /// <summary>
+    /// When the popover is closed via the controlled <see cref="Open"/> binding (i.e. the consumer
+    /// set it to false — e.g. after selecting an item), whether to return focus to the trigger so
+    /// keyboard navigation (Tab) continues from the right place. Defaults to <c>false</c> to preserve
+    /// existing behavior. Dismissals that originate inside the popover (click-outside, Escape) are
+    /// unaffected — they already manage focus themselves.
+    /// </summary>
+    [Parameter]
+    public bool RestoreFocusOnClose { get; set; }
+
     protected override void OnInitialized()
     {
         // Initialize controllable state
@@ -92,7 +102,10 @@
                 }
                 else
                 {
-                    _context.Close();
+                    // Parent-initiated close (consumer set Open=false). Honour the consumer's
+                    // focus-restore intent — click-outside/Escape never reach here (they update
+                    // the context first, so this runs only when the parent drives the close).
+                    _context.Close(RestoreFocusOnClose);
                 }
 
                 _state.ControlledValue = Open.Value;

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -2411,6 +2411,7 @@
   - OnOpenChange : EventCallback<Boolean>
   - Open : Boolean?
   - OpenChanged : EventCallback<Boolean>
+  - RestoreFocusOnClose : Boolean
 
 ### BbPopoverContent (BlazorBlueprint.Components)
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]

--- a/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
@@ -459,6 +459,7 @@
   - OnOpenChange : EventCallback<Boolean>
   - Open : Boolean?
   - OpenChanged : EventCallback<Boolean>
+  - RestoreFocusOnClose : Boolean
 
 ### BbPopoverContent (BlazorBlueprint.Primitives.Popover)
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]


### PR DESCRIPTION
## Summary
Fixes a keyboard-focus bug: after selecting an item in **BbCombobox** (and closing **BbMultiSelect**), focus was lost — `document.activeElement` fell back to `<body>`, so the next Tab restarted from the top of the page instead of moving to the next form field ("focus blackhole").

## Root cause
Combobox and MultiSelect drive their popover in *controlled* mode (`<BbPopover Open="_isOpen" …>`). When the consumer closes it (selection / Close button), `BbPopover.OnParametersSet` always called `_context.Close()` with the default `restoreFocus: false`, so the trigger never regained focus and the unmounted portal content left focus on `<body>`. (`BbSelect` was unaffected — `SelectContext.SelectValue()` already sets `RestoreFocusOnClose = true`.)

Notably, that controlled-close branch is only reached on a **parent-initiated** close — click-outside and Escape update the context first and take the other branch — so the fix is naturally scoped to intentional closes.

## Fix
- Added a `RestoreFocusOnClose` parameter to `BbPopover` (primitive + styled passthrough), defaulting to `false`. When set, the controlled close routes through `_context.Close(restoreFocus: true)`, reusing the existing focus-restore machinery in `BbPopoverContent`.
- **BbCombobox** sets it `true` only on selection (reset on open), so selection restores focus while click-outside still leaves focus where the user clicked.
- **BbMultiSelect** sets it `true` for intentional dismissals (Escape, Close button) and `false` for click-outside (split `Close()` → `CloseCore(bool restoreFocus)`).

No behavior change for any other `BbPopover` consumer (default `false`).

## Verification (browser)
- Combobox: pick item → focus returns to trigger → Tab reaches the next field. ✅
- Select: unchanged, still reaches the next field. ✅
- MultiSelect: Close → focus returns to trigger (no more `<body>`). ✅
- Combobox click-outside: focus stays where clicked, not stolen back. ✅
- All 67 tests pass (API-surface snapshots updated for the new `RestoreFocusOnClose` param on both popovers).

Reproduction/regression page lives in the internal IssueTester at `/issues/tab-focus`.
