### PR TITLE
fix(collapsible,dropdown-menu): Space/Enter no longer double-toggles the trigger

### DIFF
--- a/src/BlazorBlueprint.Primitives/Primitives/Collapsible/BbCollapsibleTrigger.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Collapsible/BbCollapsibleTrigger.razor
@@ -10,12 +10,14 @@
 }
 else
 {
+    @* A native <button> already activates on Space/Enter (firing a click), so the trigger toggles
+       via @onclick. We intentionally do NOT also handle Space/Enter in keydown — doing so toggled
+       twice per press (keydown + the native click), which opened and closed in one go. *@
     <button type="button"
             data-state="@(Context?.Open ?? false ? "open" : "closed")"
             aria-expanded="@(Context?.Open ?? false)"
             disabled="@(Context?.Disabled ?? false)"
             @onclick="HandleClick"
-            @onkeydown="HandleKeyDown"
             @attributes="AdditionalAttributes">
         @ChildContent
     </button>

--- a/src/BlazorBlueprint.Primitives/Primitives/Collapsible/BbCollapsibleTrigger.razor.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/Collapsible/BbCollapsibleTrigger.razor.cs
@@ -116,27 +116,7 @@ public partial class BbCollapsibleTrigger : ComponentBase
         }
     }
 
-    /// <summary>
-    /// Handles keyboard events to support keyboard navigation (Space/Enter keys).
-    /// </summary>
-    /// <param name="args">The keyboard event arguments.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    /// <remarks>
-    /// Responds to Space and Enter keys for keyboard interaction.
-    /// </remarks>
-    private async Task HandleKeyDown(KeyboardEventArgs args)
-    {
-        if (Context?.Disabled ?? true)
-        {
-            return;
-        }
-
-        if (args.Key == " " || args.Key == "Enter")
-        {
-            if (Context?.Toggle != null)
-            {
-                await Context.Toggle.Invoke();
-            }
-        }
-    }
+    // Note: no keydown handler. The rendered element is a native <button>, which the browser
+    // activates on Space/Enter by dispatching a click — handled by HandleClick. Adding a keydown
+    // toggle as well caused a double-toggle (open + close) on each Space/Enter press.
 }

--- a/src/BlazorBlueprint.Primitives/Primitives/DropdownMenu/BbDropdownMenuTrigger.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/DropdownMenu/BbDropdownMenuTrigger.razor
@@ -117,13 +117,12 @@ else
     {
         if (Disabled) return;
 
-        // Enter or Space to toggle
-        if (args.Key == "Enter" || args.Key == " ")
-        {
-            Context.Toggle(_triggerRef);
-        }
+        // Space/Enter intentionally NOT handled here: this is a native <button>, so the browser
+        // activates it on Space/Enter and fires a click (handled by HandleClick). Toggling here as
+        // well opened then closed the menu in one press. Arrow keys still need explicit handling —
+        // they open the menu AND move focus to the first/last item, which a click does not.
         // Arrow Down to open and focus first item
-        else if (args.Key == "ArrowDown" && !Context.IsOpen)
+        if (args.Key == "ArrowDown" && !Context.IsOpen)
         {
             Context.Open(_triggerRef);
             Context.SetFocusedIndex(0);


### PR DESCRIPTION
## Summary
Pressing **Space** (or Enter) on a `BbCollapsibleTrigger` (e.g. the "View Code" toggles in the docs) opened and then immediately closed the panel in a single press. Same bug on the `BbDropdownMenuTrigger` (Space opened then closed the menu).

## Root cause
Both triggers render a native `<button>`. Browsers activate a native button on Space/Enter by dispatching a **click**, which the trigger already handles (`@onclick` → toggle). But the triggers *also* handled Space/Enter in `@onkeydown` and toggled again — so each press fired **two** toggles and netted no visible change.

(Other triggers were checked: `BbAccordionTrigger`/`BbSelectTrigger` guard with `@onkeydown:preventDefault`; `BbTabsTrigger` double-fires but only re-activates the already-active tab, so it's harmless — left as-is.)

## Fix
- **BbCollapsibleTrigger** — removed the keydown handler entirely; the native button's Space/Enter → click already toggles.
- **BbDropdownMenuTrigger** — removed only the Space/Enter branch from the native-button `HandleKeyDown`; kept the ArrowDown/ArrowUp handling (which opens the menu *and* moves focus — something a click doesn't do). The `AsChild` keydown path is unchanged, since there the consumer's element may not be a native button.

No public API change.

## Verification (browser)
- "View Code": one Space press opens and **stays open**; another closes and stays closed; Enter opens — one press = one toggle.
- DropdownMenu trigger: Space opens the menu and it stays open; Escape closes it.
- All 67 tests pass.
