### PR TITLE
New Component: Dock

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/basic.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/basic.txt
@@ -1,0 +1,13 @@
+<div class="h-[400px] rounded-lg border">
+    <BbDock>
+        <BbDockPanel Id="editor" Title="Editor" Region="DockZone.Center" Closable="false">
+            <div class="p-4">Main editor content</div>
+        </BbDockPanel>
+        <BbDockPanel Id="explorer" Title="Explorer" Region="DockZone.Left">
+            <div class="p-4">File tree</div>
+        </BbDockPanel>
+        <BbDockPanel Id="output" Title="Output" Region="DockZone.Bottom">
+            <div class="p-4">Build output</div>
+        </BbDockPanel>
+    </BbDock>
+</div>

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/constraints.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/constraints.txt
@@ -1,0 +1,23 @@
+<!-- Locked panels can't be moved, floated or closed. Min/Max sizes (pixels) are enforced
+     while resizing a floating window and applied as CSS constraints when docked. -->
+<BbDock>
+    <!-- A mandatory toolbox: locked in place, with a minimum docked width. -->
+    <BbDockPanel Id="toolbox" Title="Toolbox" Region="DockZone.Left" Locked="true" MinWidth="200">
+        <div class="p-2">Tools…</div>
+    </BbDockPanel>
+
+    <BbDockPanel Id="canvas" Title="Canvas" Region="DockZone.Center">
+        <div class="p-4">Workspace</div>
+    </BbDockPanel>
+
+    <!-- Floats to a window no smaller than 240x200 and no wider than 420px. -->
+    <BbDockPanel Id="inspector" Title="Inspector" Region="DockZone.Right"
+                 MinWidth="240" MaxWidth="420" MinHeight="200">
+        <div class="p-3">Inspector</div>
+    </BbDockPanel>
+
+    <!-- Can be re-docked anywhere, but never detached into a floating window. -->
+    <BbDockPanel Id="output" Title="Output" Region="DockZone.Bottom" CanFloat="false">
+        <div class="p-3">Output</div>
+    </BbDockPanel>
+</BbDock>

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/contextmenu.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/contextmenu.txt
@@ -1,6 +1,6 @@
 <!-- Right-click any tab for a context menu: Close, Close Other Tabs,
-     Close All Tabs and Pin Tab. Pinned tabs sit at the front of the strip
-     in pin order and can only be reordered amongst themselves. -->
+     Close All But Pinned, Close All Tabs and Pin Tab. Pinned tabs sit at the
+     front of the strip in pin order and can only be reordered amongst themselves. -->
 <div class="h-[360px] rounded-lg border">
     <BbDock>
         <BbDockPanel Id="index" Title="Index.razor" Region="DockZone.Center">

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/contextmenu.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/contextmenu.txt
@@ -1,0 +1,22 @@
+<!-- Right-click any tab for a context menu: Close, Close Other Tabs,
+     Close All Tabs and Pin Tab. Pinned tabs sit at the front of the strip
+     in pin order and can only be reordered amongst themselves. -->
+<div class="h-[360px] rounded-lg border">
+    <BbDock>
+        <BbDockPanel Id="index" Title="Index.razor" Region="DockZone.Center">
+            <div class="p-4">Right-click this tab to open the context menu.</div>
+        </BbDockPanel>
+        <BbDockPanel Id="layout" Title="Layout.razor" Region="DockZone.Center" Order="1">
+            <div class="p-4">Pin a couple of tabs, then try dragging to reorder.</div>
+        </BbDockPanel>
+        <BbDockPanel Id="counter" Title="Counter.razor" Region="DockZone.Center" Order="2">
+            <div class="p-4">Counter page.</div>
+        </BbDockPanel>
+        <BbDockPanel Id="weather" Title="Weather.razor" Region="DockZone.Center" Order="3">
+            <div class="p-4">Weather page.</div>
+        </BbDockPanel>
+        <BbDockPanel Id="fetch" Title="FetchData.razor" Region="DockZone.Center" Order="4">
+            <div class="p-4">Fetch data page.</div>
+        </BbDockPanel>
+    </BbDock>
+</div>

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/ide.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/ide.txt
@@ -1,0 +1,42 @@
+<div class="h-[600px] rounded-lg border">
+    <BbDock OnLayoutChanged="HandleLayoutChanged">
+        <BbDockPanel Id="explorer" Title="Explorer" Region="DockZone.Left">
+            <Icon><LucideIcon Name="files" Size="14" /></Icon>
+            <ChildContent><FileTree /></ChildContent>
+        </BbDockPanel>
+
+        <BbDockPanel Id="search" Title="Search" Region="DockZone.Left" Order="1">
+            <Icon><LucideIcon Name="search" Size="14" /></Icon>
+            <ChildContent><SearchPanel /></ChildContent>
+        </BbDockPanel>
+
+        <BbDockPanel Id="program" Title="Program.cs" Region="DockZone.Center" Closable="false">
+            <Icon><LucideIcon Name="file-code" Size="14" /></Icon>
+            <ChildContent><CodeView /></ChildContent>
+        </BbDockPanel>
+
+        <BbDockPanel Id="readme" Title="README.md" Region="DockZone.Center" Order="1">
+            <Icon><LucideIcon Name="file-text" Size="14" /></Icon>
+            <ChildContent><MarkdownView /></ChildContent>
+        </BbDockPanel>
+
+        <BbDockPanel Id="terminal" Title="Terminal" Region="DockZone.Bottom">
+            <Icon><LucideIcon Name="square-terminal" Size="14" /></Icon>
+            <ChildContent><TerminalView /></ChildContent>
+        </BbDockPanel>
+
+        <BbDockPanel Id="problems" Title="Problems" Region="DockZone.Bottom" Order="1">
+            <Icon><LucideIcon Name="circle-alert" Size="14" /></Icon>
+            <ChildContent><ProblemsView /></ChildContent>
+        </BbDockPanel>
+
+        <BbDockPanel Id="properties" Title="Properties" Region="DockZone.Right">
+            <Icon><LucideIcon Name="settings-2" Size="14" /></Icon>
+            <ChildContent><PropertiesView /></ChildContent>
+        </BbDockPanel>
+    </BbDock>
+</div>
+
+@code {
+    private void HandleLayoutChanged() => Console.WriteLine("Dock layout changed");
+}

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/reopen.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/reopen.txt
@@ -1,0 +1,51 @@
+<div class="flex items-center gap-2">
+    @foreach (var id in closedPanels)
+    {
+        <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline"
+                  OnClick="() => Reopen(id)">
+            Reopen @titles[id]
+        </BbButton>
+    }
+</div>
+
+<div class="h-[420px] rounded-lg border">
+    <BbDock @ref="dock" OnPanelClosed="OnPanelClosed">
+        <BbDockPanel Id="document" Title="Document" Region="DockZone.Center">
+            <div class="p-4">Document body</div>
+        </BbDockPanel>
+        <BbDockPanel Id="comments" Title="Comments" Region="DockZone.Right">
+            <div class="p-4">Comments</div>
+        </BbDockPanel>
+        <BbDockPanel Id="history" Title="History" Region="DockZone.Bottom">
+            <div class="p-4">Revision history</div>
+        </BbDockPanel>
+    </BbDock>
+</div>
+
+@code {
+    private BbDock? dock;
+    private readonly List<string> closedPanels = new();
+    private readonly Dictionary<string, string> titles = new()
+    {
+        ["document"] = "Document",
+        ["comments"] = "Comments",
+        ["history"] = "History",
+    };
+
+    private void OnPanelClosed(string id)
+    {
+        if (!closedPanels.Contains(id))
+        {
+            closedPanels.Add(id);
+        }
+    }
+
+    private async Task Reopen(string id)
+    {
+        closedPanels.Remove(id);
+        if (dock is not null)
+        {
+            await dock.OpenPanelAsync(id);
+        }
+    }
+}

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/reorder.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dock/reorder.txt
@@ -1,0 +1,20 @@
+<div class="h-[360px] rounded-lg border">
+    <BbDock>
+        <BbDockPanel Id="home" Title="Home.razor" Region="DockZone.Center" Closable="false">
+            <div class="p-4">Drag the tabs along the strip to reorder them.</div>
+        </BbDockPanel>
+        <BbDockPanel Id="about" Title="About.razor" Region="DockZone.Center" Order="1">
+            <div class="p-4">About page.</div>
+        </BbDockPanel>
+        <BbDockPanel Id="contact" Title="Contact.razor" Region="DockZone.Center" Order="2">
+            <div class="p-4">Contact page.</div>
+        </BbDockPanel>
+        <BbDockPanel Id="settings" Title="Settings.razor" Region="DockZone.Center" Order="3">
+            <div class="p-4">Settings page.</div>
+        </BbDockPanel>
+
+        <BbDockPanel Id="outline" Title="Outline" Region="DockZone.Right">
+            <div class="p-4">Drop a tab onto this strip to move it here at a precise position.</div>
+        </BbDockPanel>
+    </BbDock>
+</div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
@@ -380,11 +380,18 @@ $ _</code></pre>
 
     <AccessibilityList>
         <AriaAttributes>
-            <AccessibilityItem>Tabs use <code>role="tab"</code> with <code>aria-selected</code> reflecting the active panel.</AccessibilityItem>
+            <AccessibilityItem>Each tab strip is a <code>role="tablist"</code>; tabs use <code>role="tab"</code> with <code>aria-selected</code> reflecting the active panel and a roving <code>tabindex</code> (the active tab is in the tab order, the rest are reachable with the arrow keys).</AccessibilityItem>
+            <AccessibilityItem>Panel content renders in a <code>role="tabpanel"</code> linked to its tab via <code>aria-controls</code> and <code>aria-labelledby</code>.</AccessibilityItem>
             <AccessibilityItem>Close and maximize controls expose descriptive <code>aria-label</code>s.</AccessibilityItem>
             <AccessibilityItem>Resize handles between docked panels reuse the Resizable separator semantics.</AccessibilityItem>
         </AriaAttributes>
         <KeyboardNavigation>
+            <KeyboardShortcutItem Description="Move focus between tabs in a strip">
+                <BbKbd>Arrow Left</BbKbd> / <BbKbd>Arrow Right</BbKbd>
+            </KeyboardShortcutItem>
+            <KeyboardShortcutItem Description="Move focus to the first / last tab">
+                <BbKbd>Home</BbKbd> / <BbKbd>End</BbKbd>
+            </KeyboardShortcutItem>
             <KeyboardShortcutItem Description="Activate the focused tab">
                 <BbKbd>Enter</BbKbd> / <BbKbd>Space</BbKbd>
             </KeyboardShortcutItem>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
@@ -1,0 +1,393 @@
+@page "/components/dock"
+<PageTitle>Dock Component - Blazor Blueprint</PageTitle>
+
+<div class="space-y-8 max-w-5xl">
+    <div>
+        <div class="space-y-3">
+            <h1 class="text-4xl font-bold tracking-tight">Dock</h1>
+            <p class="text-xl text-muted-foreground">
+                An IDE-style docking workspace. Drag panels by their tabs to re-dock them as tabs or
+                splits, detach them into floating windows, maximize a group, or close and reopen panels —
+                the docking experience you know from Visual Studio, VS Code and dockspawn.
+            </p>
+        </div>
+    </div>
+
+    <!-- Interactions -->
+    <div class="rounded-lg border bg-muted/30 p-4">
+        <h2 class="mb-2 flex items-center gap-2 text-sm font-semibold">
+            <LucideIcon Name="move" Size="16" /> Try these interactions
+        </h2>
+        <ul class="grid gap-1.5 text-sm text-muted-foreground sm:grid-cols-2">
+            <li>• <strong class="text-foreground">Drag a tab</strong> onto another panel's center to combine them as tabs.</li>
+            <li>• <strong class="text-foreground">Drag to an edge</strong> of a panel (or the dock) to create a split.</li>
+            <li>• <strong class="text-foreground">Drag a tab outside</strong> the dock to float it in its own window.</li>
+            <li>• <strong class="text-foreground">Drag a floating window</strong> by its tab strip; resize it from the corner.</li>
+            <li>• <strong class="text-foreground">Maximize</strong> a group with the button in the tab bar.</li>
+            <li>• <strong class="text-foreground">Close</strong> a tab with its ✕, then reopen it (see below).</li>
+        </ul>
+    </div>
+
+    <!-- IDE workspace -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">IDE Workspace</h2>
+            <p class="text-sm text-muted-foreground">
+                A full layout with an explorer, tabbed editors, a bottom panel and an inspector — every
+                panel can be dragged, split, floated, maximized or closed.
+            </p>
+        </div>
+
+        <div class="h-[600px] rounded-lg border shadow-sm">
+            <BbDock OnLayoutChanged="() => layoutChanges++">
+                <BbDockPanel Id="explorer" Title="Explorer" Region="DockZone.Left">
+                    <Icon><LucideIcon Name="files" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="p-2 text-sm">
+                            <div class="px-2 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Workspace</div>
+                            @foreach (var (name, icon) in explorerItems)
+                            {
+                                <div class="flex items-center gap-2 rounded px-2 py-1 hover:bg-accent hover:text-accent-foreground">
+                                    <LucideIcon Name="@icon" Size="14" Class="text-muted-foreground" />
+                                    <span>@name</span>
+                                </div>
+                            }
+                        </div>
+                    </ChildContent>
+                </BbDockPanel>
+
+                <BbDockPanel Id="search" Title="Search" Region="DockZone.Left" Order="1">
+                    <Icon><LucideIcon Name="search" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="space-y-3 p-3 text-sm">
+                            <BbInput Placeholder="Search files..." />
+                            <p class="text-xs text-muted-foreground">3 results in 2 files</p>
+                            <div class="space-y-1">
+                                <div class="rounded bg-muted/50 px-2 py-1 text-xs">Program.cs · line 12</div>
+                                <div class="rounded bg-muted/50 px-2 py-1 text-xs">README.md · line 4</div>
+                            </div>
+                        </div>
+                    </ChildContent>
+                </BbDockPanel>
+
+                <BbDockPanel Id="program" Title="Program.cs" Region="DockZone.Center" Closable="false">
+                    <Icon><LucideIcon Name="file-code" Size="14" /></Icon>
+                    <ChildContent>
+                        <pre class="h-full overflow-auto bg-background p-4 text-xs leading-relaxed"><code>@programSource</code></pre>
+                    </ChildContent>
+                </BbDockPanel>
+
+                <BbDockPanel Id="readme" Title="README.md" Region="DockZone.Center" Order="1">
+                    <Icon><LucideIcon Name="file-text" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="space-y-3 p-4 text-sm">
+                            <h3 class="text-lg font-semibold">Blazor Blueprint</h3>
+                            <p class="text-muted-foreground">A two-layer Blazor component library inspired by shadcn/ui and Radix.</p>
+                            <p class="text-muted-foreground">Drag this tab around to see docking in action.</p>
+                        </div>
+                    </ChildContent>
+                </BbDockPanel>
+
+                <BbDockPanel Id="terminal" Title="Terminal" Region="DockZone.Bottom">
+                    <Icon><LucideIcon Name="square-terminal" Size="14" /></Icon>
+                    <ChildContent>
+                        <pre class="h-full overflow-auto bg-background p-3 font-mono text-xs leading-relaxed text-muted-foreground"><code>$ dotnet build
+  Determining projects to restore...
+  Restored BlazorBlueprint.Components (in 412 ms).
+  BlazorBlueprint.Components -> bin/Debug/net8.0/BlazorBlueprint.Components.dll
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ _</code></pre>
+                    </ChildContent>
+                </BbDockPanel>
+
+                <BbDockPanel Id="problems" Title="Problems" Region="DockZone.Bottom" Order="1">
+                    <Icon><LucideIcon Name="circle-alert" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="divide-y text-sm">
+                            <div class="flex items-center gap-2 px-3 py-2">
+                                <LucideIcon Name="circle-x" Size="14" Class="text-destructive" />
+                                <span>Unused variable <code class="text-xs">temp</code></span>
+                                <span class="ml-auto text-xs text-muted-foreground">Program.cs:24</span>
+                            </div>
+                            <div class="flex items-center gap-2 px-3 py-2">
+                                <LucideIcon Name="triangle-alert" Size="14" Class="text-yellow-500" />
+                                <span>Missing XML comment</span>
+                                <span class="ml-auto text-xs text-muted-foreground">Dock.cs:11</span>
+                            </div>
+                        </div>
+                    </ChildContent>
+                </BbDockPanel>
+
+                <BbDockPanel Id="properties" Title="Properties" Region="DockZone.Right">
+                    <Icon><LucideIcon Name="settings-2" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="space-y-3 p-3 text-sm">
+                            @foreach (var (label, value) in properties)
+                            {
+                                <div class="flex items-center justify-between gap-2">
+                                    <span class="text-muted-foreground">@label</span>
+                                    <span class="font-medium">@value</span>
+                                </div>
+                            }
+                        </div>
+                    </ChildContent>
+                </BbDockPanel>
+            </BbDock>
+        </div>
+        <p class="text-xs text-muted-foreground">Layout changes: @layoutChanges</p>
+
+        <CodeBlock Source="Components/Dock/ide.txt" />
+    </div>
+
+    <!-- Tab reordering -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Tab Reordering</h2>
+            <p class="text-sm text-muted-foreground">
+                Drag a tab along the strip to reorder it — an insertion line shows where it will land and the
+                surrounding layout stays put. Tabs can also be dropped onto another group's strip at a precise position.
+            </p>
+        </div>
+
+        <div class="h-[360px] rounded-lg border shadow-sm">
+            <BbDock>
+                <BbDockPanel Id="r-home" Title="Home.razor" Region="DockZone.Center" Closable="false">
+                    <Icon><LucideIcon Name="house" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="p-4 text-sm text-muted-foreground">Drag the tabs above to reorder them. The insertion line marks the drop slot.</div>
+                    </ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="r-about" Title="About.razor" Region="DockZone.Center" Order="1">
+                    <Icon><LucideIcon Name="info" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">About page.</div></ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="r-contact" Title="Contact.razor" Region="DockZone.Center" Order="2">
+                    <Icon><LucideIcon Name="mail" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Contact page.</div></ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="r-settings" Title="Settings.razor" Region="DockZone.Center" Order="3">
+                    <Icon><LucideIcon Name="settings" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Settings page.</div></ChildContent>
+                </BbDockPanel>
+
+                <BbDockPanel Id="r-outline" Title="Outline" Region="DockZone.Right">
+                    <Icon><LucideIcon Name="list-tree" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Drop a tab onto this strip to move it here at a precise position.</div></ChildContent>
+                </BbDockPanel>
+            </BbDock>
+        </div>
+
+        <CodeBlock Source="Components/Dock/reorder.txt" />
+    </div>
+
+    <!-- Close & reopen -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Close &amp; Reopen Panels</h2>
+            <p class="text-sm text-muted-foreground">
+                Closing a panel raises <code>OnPanelClosed</code>. Use the dock's
+                <code>OpenPanelAsync</code> method to bring it back.
+            </p>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-2">
+            @if (closedPanels.Count == 0)
+            {
+                <span class="text-sm text-muted-foreground">Close a tab below to reopen it here.</span>
+            }
+            @foreach (var id in closedPanels)
+            {
+                <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="() => Reopen(id)">
+                    <LucideIcon Name="plus" Size="14" Class="mr-1" /> Reopen @titles[id]
+                </BbButton>
+            }
+        </div>
+
+        <div class="h-[420px] rounded-lg border shadow-sm">
+            <BbDock @ref="reopenDock" OnPanelClosed="OnPanelClosed">
+                <BbDockPanel Id="document" Title="Document" Region="DockZone.Center">
+                    <Icon><LucideIcon Name="file-text" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="p-4 text-sm text-muted-foreground">The main document. This tab can be closed and reopened.</div>
+                    </ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="comments" Title="Comments" Region="DockZone.Right">
+                    <Icon><LucideIcon Name="message-square" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="p-4 text-sm text-muted-foreground">Reviewer comments.</div>
+                    </ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="history" Title="History" Region="DockZone.Bottom">
+                    <Icon><LucideIcon Name="history" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="p-4 text-sm text-muted-foreground">Revision history.</div>
+                    </ChildContent>
+                </BbDockPanel>
+            </BbDock>
+        </div>
+
+        <CodeBlock Source="Components/Dock/reopen.txt" />
+    </div>
+
+    <!-- Basic -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Basic</h2>
+            <p class="text-sm text-muted-foreground">
+                Panels are placed by <code>Region</code>. Panels sharing a region become tabs in the same group.
+            </p>
+        </div>
+
+        <div class="h-[400px] rounded-lg border shadow-sm">
+            <BbDock>
+                <BbDockPanel Id="b-editor" Title="Editor" Region="DockZone.Center" Closable="false">
+                    <div class="p-4 text-sm text-muted-foreground">Main editor content</div>
+                </BbDockPanel>
+                <BbDockPanel Id="b-explorer" Title="Explorer" Region="DockZone.Left">
+                    <div class="p-4 text-sm text-muted-foreground">File tree</div>
+                </BbDockPanel>
+                <BbDockPanel Id="b-output" Title="Output" Region="DockZone.Bottom">
+                    <div class="p-4 text-sm text-muted-foreground">Build output</div>
+                </BbDockPanel>
+            </BbDock>
+        </div>
+
+        <CodeBlock Source="Components/Dock/basic.txt" />
+    </div>
+
+    <AccessibilityList>
+        <AriaAttributes>
+            <AccessibilityItem>Tabs use <code>role="tab"</code> with <code>aria-selected</code> reflecting the active panel.</AccessibilityItem>
+            <AccessibilityItem>Close and maximize controls expose descriptive <code>aria-label</code>s.</AccessibilityItem>
+            <AccessibilityItem>Resize handles between docked panels reuse the Resizable separator semantics.</AccessibilityItem>
+        </AriaAttributes>
+        <KeyboardNavigation>
+            <KeyboardShortcutItem Description="Activate the focused tab">
+                <BbKbd>Enter</BbKbd> / <BbKbd>Space</BbKbd>
+            </KeyboardShortcutItem>
+            <KeyboardShortcutItem Description="Resize a split between panels">
+                <BbKbd>Arrow Keys</BbKbd>
+            </KeyboardShortcutItem>
+        </KeyboardNavigation>
+    </AccessibilityList>
+
+    <!-- API Reference -->
+    <section class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">API Reference</h2>
+            <p class="text-muted-foreground">Component properties and parameters.</p>
+        </div>
+
+        <div class="space-y-4">
+            <ApiReference ComponentName="BbDock">
+                <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
+                    The <code>BbDockPanel</code> declarations hosted by the dock.
+                </ApiParameter>
+                <ApiParameter Name="EmptyContent" Type="RenderFragment?" Default="null">
+                    Content shown when no panels are open.
+                </ApiParameter>
+                <ApiParameter Name="OnLayoutChanged" Type="EventCallback" Default="—">
+                    Invoked after the layout changes (docking, floating, closing, reopening).
+                </ApiParameter>
+                <ApiParameter Name="OnPanelClosed" Type="EventCallback&lt;string&gt;" Default="—">
+                    Invoked with the panel id when a panel is closed by the user.
+                </ApiParameter>
+                <ApiParameter Name="OpenPanelAsync(string)" Type="Task" Default="—">
+                    Method that reopens a closed panel into a default location.
+                </ApiParameter>
+                <ApiParameter Name="GetClosedPanelIds()" Type="IReadOnlyList&lt;string&gt;" Default="—">
+                    Method returning the ids of panels currently closed.
+                </ApiParameter>
+                <ApiParameter Name="Class" Type="string?" Default="null">
+                    Additional CSS classes for the dock surface.
+                </ApiParameter>
+            </ApiReference>
+
+            <ApiReference ComponentName="BbDockPanel">
+                <ApiParameter Name="Id" Type="string" Default="—">
+                    Required stable identifier used to track the panel across layout changes.
+                </ApiParameter>
+                <ApiParameter Name="Title" Type="string" Default="&quot;&quot;">
+                    The title shown on the panel's tab.
+                </ApiParameter>
+                <ApiParameter Name="Icon" Type="RenderFragment?" Default="null">
+                    Optional icon rendered before the title on the tab.
+                </ApiParameter>
+                <ApiParameter Name="Region" Type="DockZone" Default="Center">
+                    Initial placement region. Options: Center, Left, Right, Top, Bottom.
+                </ApiParameter>
+                <ApiParameter Name="Order" Type="int" Default="0">
+                    Ordering of panels within a region when the initial layout is built.
+                </ApiParameter>
+                <ApiParameter Name="Closable" Type="bool" Default="true">
+                    Whether the panel can be closed by the user.
+                </ApiParameter>
+                <ApiParameter Name="CanFloat" Type="bool" Default="true">
+                    Whether the panel can be detached into a floating window.
+                </ApiParameter>
+                <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
+                    The content rendered when the panel is the active tab.
+                </ApiParameter>
+            </ApiReference>
+        </div>
+    </section>
+</div>
+
+@code {
+    private int layoutChanges;
+
+    private BbDock? reopenDock;
+    private readonly List<string> closedPanels = new();
+    private readonly Dictionary<string, string> titles = new()
+    {
+        ["document"] = "Document",
+        ["comments"] = "Comments",
+        ["history"] = "History",
+    };
+
+    private readonly (string Name, string Icon)[] explorerItems =
+    {
+        ("src", "folder"),
+        ("Program.cs", "file-code"),
+        ("README.md", "file-text"),
+        ("appsettings.json", "braces"),
+        (".gitignore", "file"),
+    };
+
+    private readonly (string Label, string Value)[] properties =
+    {
+        ("Name", "Program.cs"),
+        ("Encoding", "UTF-8"),
+        ("Line endings", "LF"),
+        ("Language", "C#"),
+        ("Size", "1.4 KB"),
+    };
+
+    private const string programSource = @"using BlazorBlueprint.Components;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddBlazorBlueprintComponents();
+
+var app = builder.Build();
+app.MapRazorComponents<App>();
+app.Run();";
+
+    private void OnPanelClosed(string id)
+    {
+        if (titles.ContainsKey(id) && !closedPanels.Contains(id))
+        {
+            closedPanels.Add(id);
+        }
+    }
+
+    private async Task Reopen(string id)
+    {
+        closedPanels.Remove(id);
+        if (reopenDock is not null)
+        {
+            await reopenDock.OpenPanelAsync(id);
+        }
+    }
+}

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
@@ -25,6 +25,7 @@
             <li>• <strong class="text-foreground">Drag a floating window</strong> by its tab strip; resize it from the corner.</li>
             <li>• <strong class="text-foreground">Maximize</strong> a group with the button in the tab bar.</li>
             <li>• <strong class="text-foreground">Close</strong> a tab with its ✕, then reopen it (see below).</li>
+            <li>• <strong class="text-foreground">Right-click a tab</strong> to close others, close all, or pin it to the front.</li>
         </ul>
     </div>
 
@@ -180,6 +181,52 @@ $ _</code></pre>
         </div>
 
         <CodeBlock Source="Components/Dock/reorder.txt" />
+    </div>
+
+    <!-- Tab context menu -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Tab Context Menu &amp; Pinning</h2>
+            <p class="text-sm text-muted-foreground">
+                Right-click any tab for a context menu with <strong>Close</strong>,
+                <strong>Close Other Tabs</strong> (enabled only when the group has more than one tab),
+                <strong>Close All Tabs</strong> and <strong>Pin Tab</strong>. Pinned tabs show a pin
+                marker and sit at the front of the strip in the order they were pinned. Pinned tabs can
+                only be reordered amongst themselves, and unpinned tabs cannot be dragged ahead of them.
+            </p>
+        </div>
+
+        <div class="h-[360px] rounded-lg border shadow-sm">
+            <BbDock>
+                <BbDockPanel Id="c-index" Title="Index.razor" Region="DockZone.Center">
+                    <Icon><LucideIcon Name="house" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="space-y-2 p-4 text-sm text-muted-foreground">
+                            <p>Right-click any tab above to open its context menu.</p>
+                            <p>Pin a couple of tabs, then drag to reorder — pinned tabs stay grouped at the front.</p>
+                        </div>
+                    </ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="c-layout" Title="Layout.razor" Region="DockZone.Center" Order="1">
+                    <Icon><LucideIcon Name="layout-template" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Shared layout.</div></ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="c-counter" Title="Counter.razor" Region="DockZone.Center" Order="2">
+                    <Icon><LucideIcon Name="plus" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Counter page.</div></ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="c-weather" Title="Weather.razor" Region="DockZone.Center" Order="3">
+                    <Icon><LucideIcon Name="cloud-sun" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Weather page.</div></ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="c-fetch" Title="FetchData.razor" Region="DockZone.Center" Order="4">
+                    <Icon><LucideIcon Name="database" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Fetch data page.</div></ChildContent>
+                </BbDockPanel>
+            </BbDock>
+        </div>
+
+        <CodeBlock Source="Components/Dock/contextmenu.txt" />
     </div>
 
     <!-- Close & reopen -->

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
@@ -103,7 +103,8 @@
             <p class="text-sm text-muted-foreground">
                 Right-click any tab for a context menu with <strong>Close</strong>,
                 <strong>Close Other Tabs</strong> (enabled only when the group has more than one tab),
-                <strong>Close All Tabs</strong> and <strong>Pin Tab</strong>. Pinned tabs show a pin
+                <strong>Close All But Pinned</strong>, <strong>Close All Tabs</strong> and
+                <strong>Pin Tab</strong>. Pinned tabs show a pin
                 marker and sit at the front of the strip in the order they were pinned. Pinned tabs can
                 only be reordered amongst themselves, and unpinned tabs cannot be dragged ahead of them.
             </p>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
@@ -383,6 +383,29 @@ $ _</code></pre>
             </ApiReference>
         </div>
     </section>
+
+    <LocalizationSection
+        Description="Dock tab context-menu items, button aria-labels/tooltips, and the empty state are configurable via IBbLocalizer."
+        Labels="@(new LocalizationSection.LabelInfo[]
+        {
+            new("Close", "Close", "Context-menu item that closes the active tab"),
+            new("CloseTab", "Close {0}", "Aria-label/tooltip on a tab's close button ({0} = tab title)"),
+            new("CloseOtherTabs", "Close Other Tabs", "Context-menu item that closes the group's other tabs"),
+            new("CloseAllButPinned", "Close All But Pinned", "Context-menu item that closes all unpinned tabs"),
+            new("CloseAllTabs", "Close All Tabs", "Context-menu item that closes every tab in the group"),
+            new("PinTab", "Pin Tab", "Context-menu item shown when the tab is unpinned"),
+            new("UnpinTab", "Unpin Tab", "Context-menu item shown when the tab is pinned"),
+            new("ShowHiddenTabs", "Show {0} hidden tab(s)", "Aria-label/tooltip on the overflow dropdown ({0} = count)"),
+            new("MaximizePanelGroup", "Maximize panel group", "Aria-label/tooltip on the maximize button"),
+            new("RestorePanelGroup", "Restore panel group", "Aria-label/tooltip on the restore button"),
+            new("NoPanelsOpen", "No panels are open.", "Default empty state shown when no panels remain"),
+        })"
+        CodeExample="@(@"builder.Services.AddBlazorBlueprintComponents(localizer =>
+{
+    localizer.Set(""Dock.CloseAllTabs"", ""Alle Tabs schließen"");
+    localizer.Set(""Dock.PinTab"", ""Tab anheften"");
+    localizer.Set(""Dock.ShowHiddenTabs"", ""{0} ausgeblendete(s) Tab(s) anzeigen"");
+});")" />
 </div>
 
 @code {

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
@@ -307,6 +307,77 @@ $ _</code></pre>
     </div>
 
 
+    <!-- Size & movement constraints -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Size &amp; Movement Constraints</h2>
+            <p class="text-sm text-muted-foreground">
+                Lock a panel in place with <code>Locked</code> so it can't be moved, floated or closed — ideal
+                for a mandatory toolbox region. Constrain panel size with <code>MinWidth</code>,
+                <code>MinHeight</code>, <code>MaxWidth</code> and <code>MaxHeight</code> (pixels). Try to drag,
+                float or close the locked <strong>Toolbox</strong> — it stays put. Drag the <strong>Inspector</strong>
+                out to a floating window and resize it: it won't shrink below 240×200 or grow past 420px wide.
+                The <strong>Output</strong> tab can be re-docked but never floated (<code>CanFloat="false"</code>).
+            </p>
+        </div>
+
+        <div class="h-[600px] border">
+            <BbDock>
+                <BbDockPanel Id="toolbox" Title="Toolbox" Region="DockZone.Left" Locked="true" MinWidth="200">
+                    <Icon><LucideIcon Name="wrench" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="space-y-1 p-2 text-sm">
+                            <div class="flex items-center gap-1 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                <LucideIcon Name="lock" Size="12" /> Locked region
+                            </div>
+                            @foreach (var (name, icon) in toolboxItems)
+                            {
+                                <div class="flex items-center gap-2 rounded px-2 py-1 hover:bg-accent hover:text-accent-foreground">
+                                    <LucideIcon Name="@icon" Size="14" Class="text-muted-foreground" />
+                                    <span>@name</span>
+                                </div>
+                            }
+                        </div>
+                    </ChildContent>
+                </BbDockPanel>
+
+                <BbDockPanel Id="canvas" Title="Canvas" Region="DockZone.Center">
+                    <Icon><LucideIcon Name="layout-dashboard" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="space-y-2 p-4 text-sm text-muted-foreground">
+                            <p>The <strong>Toolbox</strong> on the left is locked: it has no close button and
+                            can't be dragged, reordered, re-docked or floated.</p>
+                            <p>The <strong>Inspector</strong> on the right enforces its min/max size when floated.</p>
+                        </div>
+                    </ChildContent>
+                </BbDockPanel>
+
+                <BbDockPanel Id="inspector" Title="Inspector" Region="DockZone.Right"
+                             MinWidth="240" MaxWidth="420" MinHeight="200">
+                    <Icon><LucideIcon Name="sliders-horizontal" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="space-y-3 p-3 text-sm">
+                            <p class="text-muted-foreground">Drag this tab out to a floating window, then resize it.</p>
+                            <p class="text-xs text-muted-foreground">Min 240×200 · Max width 420px.</p>
+                        </div>
+                    </ChildContent>
+                </BbDockPanel>
+
+                <BbDockPanel Id="output" Title="Output" Region="DockZone.Bottom" CanFloat="false">
+                    <Icon><LucideIcon Name="terminal" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="p-3 text-xs text-muted-foreground">
+                            This panel can be re-docked anywhere, but dragging it outside the dock won't detach it.
+                        </div>
+                    </ChildContent>
+                </BbDockPanel>
+            </BbDock>
+        </div>
+
+        <CodeBlock Source="Components/Dock/constraints.txt" />
+    </div>
+
+
     <AccessibilityList>
         <AriaAttributes>
             <AccessibilityItem>Tabs use <code>role="tab"</code> with <code>aria-selected</code> reflecting the active panel.</AccessibilityItem>
@@ -375,7 +446,23 @@ $ _</code></pre>
                     Whether the panel can be closed by the user.
                 </ApiParameter>
                 <ApiParameter Name="CanFloat" Type="bool" Default="true">
-                    Whether the panel can be detached into a floating window.
+                    Whether the panel can be detached into a floating window. Ignored when <code>Locked</code> is true.
+                </ApiParameter>
+                <ApiParameter Name="Locked" Type="bool" Default="false">
+                    When true, the panel can't be dragged to move/reorder/re-dock, detached into a floating window,
+                    or closed. Overrides <code>Closable</code> and <code>CanFloat</code>.
+                </ApiParameter>
+                <ApiParameter Name="MinWidth" Type="int?" Default="null">
+                    Minimum panel width in pixels. Enforced while resizing a floating window; applied as a CSS constraint when docked.
+                </ApiParameter>
+                <ApiParameter Name="MinHeight" Type="int?" Default="null">
+                    Minimum panel height in pixels. Enforced while resizing a floating window; applied as a CSS constraint when docked.
+                </ApiParameter>
+                <ApiParameter Name="MaxWidth" Type="int?" Default="null">
+                    Maximum panel width in pixels. Enforced while resizing a floating window; applied as a CSS constraint when docked.
+                </ApiParameter>
+                <ApiParameter Name="MaxHeight" Type="int?" Default="null">
+                    Maximum panel height in pixels. Enforced while resizing a floating window; applied as a CSS constraint when docked.
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
                     The content rendered when the panel is the active tab.
@@ -427,6 +514,15 @@ $ _</code></pre>
         ("README.md", "file-text"),
         ("appsettings.json", "braces"),
         (".gitignore", "file"),
+    };
+
+    private readonly (string Name, string Icon)[] toolboxItems =
+    {
+        ("Select", "mouse-pointer-2"),
+        ("Pen", "pencil"),
+        ("Shapes", "shapes"),
+        ("Text", "type"),
+        ("Colors", "palette"),
     };
 
     private readonly (string Label, string Value)[] properties =

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
@@ -28,7 +28,170 @@
             <li>• <strong class="text-foreground">Right-click a tab</strong> to close others, close all, or pin it to the front.</li>
         </ul>
     </div>
+    
+    <!-- Basic -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Basic</h2>
+            <p class="text-sm text-muted-foreground">
+                Panels are placed by <code>Region</code>. Panels sharing a region become tabs in the same group.
+            </p>
+        </div>
 
+        <div class="h-[400px] border">
+            <BbDock>
+                <BbDockPanel Id="b-editor" Title="Editor" Region="DockZone.Center" Closable="false">
+                    <div class="p-4 text-sm text-muted-foreground">Main editor content</div>
+                </BbDockPanel>
+                <BbDockPanel Id="b-explorer" Title="Explorer" Region="DockZone.Left">
+                    <div class="p-4 text-sm text-muted-foreground">File tree</div>
+                </BbDockPanel>
+                <BbDockPanel Id="b-output" Title="Output" Region="DockZone.Bottom">
+                    <div class="p-4 text-sm text-muted-foreground">Build output</div>
+                </BbDockPanel>
+            </BbDock>
+        </div>
+
+        <CodeBlock Source="Components/Dock/basic.txt" />
+    </div>
+
+    <!-- Tab reordering -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Tab Reordering</h2>
+            <p class="text-sm text-muted-foreground">
+                Drag a tab along the strip to reorder it — an insertion line shows where it will land and the
+                surrounding layout stays put. Tabs can also be dropped onto another group's strip at a precise position.
+            </p>
+        </div>
+
+        <div class="h-[360px] border">
+            <BbDock>
+                <BbDockPanel Id="r-home" Title="Home.razor" Region="DockZone.Center" Closable="false">
+                    <Icon><LucideIcon Name="house" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="p-4 text-sm text-muted-foreground">Drag the tabs above to reorder them. The insertion line marks the drop slot.</div>
+                    </ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="r-about" Title="About.razor" Region="DockZone.Center" Order="1">
+                    <Icon><LucideIcon Name="info" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">About page.</div></ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="r-contact" Title="Contact.razor" Region="DockZone.Center" Order="2">
+                    <Icon><LucideIcon Name="mail" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Contact page.</div></ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="r-settings" Title="Settings.razor" Region="DockZone.Center" Order="3">
+                    <Icon><LucideIcon Name="settings" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Settings page.</div></ChildContent>
+                </BbDockPanel>
+
+                <BbDockPanel Id="r-outline" Title="Outline" Region="DockZone.Right">
+                    <Icon><LucideIcon Name="list-tree" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Drop a tab onto this strip to move it here at a precise position.</div></ChildContent>
+                </BbDockPanel>
+            </BbDock>
+        </div>
+
+        <CodeBlock Source="Components/Dock/reorder.txt" />
+    </div>
+
+    <!-- Tab context menu -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Tab Context Menu &amp; Pinning</h2>
+            <p class="text-sm text-muted-foreground">
+                Right-click any tab for a context menu with <strong>Close</strong>,
+                <strong>Close Other Tabs</strong> (enabled only when the group has more than one tab),
+                <strong>Close All Tabs</strong> and <strong>Pin Tab</strong>. Pinned tabs show a pin
+                marker and sit at the front of the strip in the order they were pinned. Pinned tabs can
+                only be reordered amongst themselves, and unpinned tabs cannot be dragged ahead of them.
+            </p>
+        </div>
+
+        <div class="h-[360px] border">
+            <BbDock>
+                <BbDockPanel Id="c-index" Title="Index.razor" Region="DockZone.Center">
+                    <Icon><LucideIcon Name="house" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="space-y-2 p-4 text-sm text-muted-foreground">
+                            <p>Right-click any tab above to open its context menu.</p>
+                            <p>Pin a couple of tabs, then drag to reorder — pinned tabs stay grouped at the front.</p>
+                        </div>
+                    </ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="c-layout" Title="Layout.razor" Region="DockZone.Center" Order="1">
+                    <Icon><LucideIcon Name="layout-template" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Shared layout.</div></ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="c-counter" Title="Counter.razor" Region="DockZone.Center" Order="2">
+                    <Icon><LucideIcon Name="plus" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Counter page.</div></ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="c-weather" Title="Weather.razor" Region="DockZone.Center" Order="3">
+                    <Icon><LucideIcon Name="cloud-sun" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Weather page.</div></ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="c-fetch" Title="FetchData.razor" Region="DockZone.Center" Order="4">
+                    <Icon><LucideIcon Name="database" Size="14" /></Icon>
+                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Fetch data page.</div></ChildContent>
+                </BbDockPanel>
+            </BbDock>
+        </div>
+
+        <CodeBlock Source="Components/Dock/contextmenu.txt" />
+    </div>
+
+    <!-- Close & reopen -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Close &amp; Reopen Panels</h2>
+            <p class="text-sm text-muted-foreground">
+                Closing a panel raises <code>OnPanelClosed</code>. Use the dock's
+                <code>OpenPanelAsync</code> method to bring it back.
+            </p>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-2">
+            @if (closedPanels.Count == 0)
+            {
+                <span class="text-sm text-muted-foreground">Close a tab below to reopen it here.</span>
+            }
+            @foreach (var id in closedPanels)
+            {
+                <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="() => Reopen(id)">
+                    <LucideIcon Name="plus" Size="14" Class="mr-1" /> Reopen @titles[id]
+                </BbButton>
+            }
+        </div>
+
+        <div class="h-[420px] border">
+            <BbDock @ref="reopenDock" OnPanelClosed="OnPanelClosed">
+                <BbDockPanel Id="document" Title="Document" Region="DockZone.Center">
+                    <Icon><LucideIcon Name="file-text" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="p-4 text-sm text-muted-foreground">The main document. This tab can be closed and reopened.</div>
+                    </ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="comments" Title="Comments" Region="DockZone.Right">
+                    <Icon><LucideIcon Name="message-square" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="p-4 text-sm text-muted-foreground">Reviewer comments.</div>
+                    </ChildContent>
+                </BbDockPanel>
+                <BbDockPanel Id="history" Title="History" Region="DockZone.Bottom">
+                    <Icon><LucideIcon Name="history" Size="14" /></Icon>
+                    <ChildContent>
+                        <div class="p-4 text-sm text-muted-foreground">Revision history.</div>
+                    </ChildContent>
+                </BbDockPanel>
+            </BbDock>
+        </div>
+
+        <CodeBlock Source="Components/Dock/reopen.txt" />
+    </div>
+    
+    
     <!-- IDE workspace -->
     <div class="space-y-4">
         <div class="space-y-2">
@@ -39,7 +202,7 @@
             </p>
         </div>
 
-        <div class="h-[600px] rounded-lg border shadow-sm">
+        <div class="h-[600px] border">
             <BbDock OnLayoutChanged="() => layoutChanges++">
                 <BbDockPanel Id="explorer" Title="Explorer" Region="DockZone.Left">
                     <Icon><LucideIcon Name="files" Size="14" /></Icon>
@@ -142,167 +305,6 @@ $ _</code></pre>
         <CodeBlock Source="Components/Dock/ide.txt" />
     </div>
 
-    <!-- Tab reordering -->
-    <div class="space-y-4">
-        <div class="space-y-2">
-            <h2 class="text-2xl font-semibold">Tab Reordering</h2>
-            <p class="text-sm text-muted-foreground">
-                Drag a tab along the strip to reorder it — an insertion line shows where it will land and the
-                surrounding layout stays put. Tabs can also be dropped onto another group's strip at a precise position.
-            </p>
-        </div>
-
-        <div class="h-[360px] rounded-lg border shadow-sm">
-            <BbDock>
-                <BbDockPanel Id="r-home" Title="Home.razor" Region="DockZone.Center" Closable="false">
-                    <Icon><LucideIcon Name="house" Size="14" /></Icon>
-                    <ChildContent>
-                        <div class="p-4 text-sm text-muted-foreground">Drag the tabs above to reorder them. The insertion line marks the drop slot.</div>
-                    </ChildContent>
-                </BbDockPanel>
-                <BbDockPanel Id="r-about" Title="About.razor" Region="DockZone.Center" Order="1">
-                    <Icon><LucideIcon Name="info" Size="14" /></Icon>
-                    <ChildContent><div class="p-4 text-sm text-muted-foreground">About page.</div></ChildContent>
-                </BbDockPanel>
-                <BbDockPanel Id="r-contact" Title="Contact.razor" Region="DockZone.Center" Order="2">
-                    <Icon><LucideIcon Name="mail" Size="14" /></Icon>
-                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Contact page.</div></ChildContent>
-                </BbDockPanel>
-                <BbDockPanel Id="r-settings" Title="Settings.razor" Region="DockZone.Center" Order="3">
-                    <Icon><LucideIcon Name="settings" Size="14" /></Icon>
-                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Settings page.</div></ChildContent>
-                </BbDockPanel>
-
-                <BbDockPanel Id="r-outline" Title="Outline" Region="DockZone.Right">
-                    <Icon><LucideIcon Name="list-tree" Size="14" /></Icon>
-                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Drop a tab onto this strip to move it here at a precise position.</div></ChildContent>
-                </BbDockPanel>
-            </BbDock>
-        </div>
-
-        <CodeBlock Source="Components/Dock/reorder.txt" />
-    </div>
-
-    <!-- Tab context menu -->
-    <div class="space-y-4">
-        <div class="space-y-2">
-            <h2 class="text-2xl font-semibold">Tab Context Menu &amp; Pinning</h2>
-            <p class="text-sm text-muted-foreground">
-                Right-click any tab for a context menu with <strong>Close</strong>,
-                <strong>Close Other Tabs</strong> (enabled only when the group has more than one tab),
-                <strong>Close All Tabs</strong> and <strong>Pin Tab</strong>. Pinned tabs show a pin
-                marker and sit at the front of the strip in the order they were pinned. Pinned tabs can
-                only be reordered amongst themselves, and unpinned tabs cannot be dragged ahead of them.
-            </p>
-        </div>
-
-        <div class="h-[360px] rounded-lg border shadow-sm">
-            <BbDock>
-                <BbDockPanel Id="c-index" Title="Index.razor" Region="DockZone.Center">
-                    <Icon><LucideIcon Name="house" Size="14" /></Icon>
-                    <ChildContent>
-                        <div class="space-y-2 p-4 text-sm text-muted-foreground">
-                            <p>Right-click any tab above to open its context menu.</p>
-                            <p>Pin a couple of tabs, then drag to reorder — pinned tabs stay grouped at the front.</p>
-                        </div>
-                    </ChildContent>
-                </BbDockPanel>
-                <BbDockPanel Id="c-layout" Title="Layout.razor" Region="DockZone.Center" Order="1">
-                    <Icon><LucideIcon Name="layout-template" Size="14" /></Icon>
-                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Shared layout.</div></ChildContent>
-                </BbDockPanel>
-                <BbDockPanel Id="c-counter" Title="Counter.razor" Region="DockZone.Center" Order="2">
-                    <Icon><LucideIcon Name="plus" Size="14" /></Icon>
-                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Counter page.</div></ChildContent>
-                </BbDockPanel>
-                <BbDockPanel Id="c-weather" Title="Weather.razor" Region="DockZone.Center" Order="3">
-                    <Icon><LucideIcon Name="cloud-sun" Size="14" /></Icon>
-                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Weather page.</div></ChildContent>
-                </BbDockPanel>
-                <BbDockPanel Id="c-fetch" Title="FetchData.razor" Region="DockZone.Center" Order="4">
-                    <Icon><LucideIcon Name="database" Size="14" /></Icon>
-                    <ChildContent><div class="p-4 text-sm text-muted-foreground">Fetch data page.</div></ChildContent>
-                </BbDockPanel>
-            </BbDock>
-        </div>
-
-        <CodeBlock Source="Components/Dock/contextmenu.txt" />
-    </div>
-
-    <!-- Close & reopen -->
-    <div class="space-y-4">
-        <div class="space-y-2">
-            <h2 class="text-2xl font-semibold">Close &amp; Reopen Panels</h2>
-            <p class="text-sm text-muted-foreground">
-                Closing a panel raises <code>OnPanelClosed</code>. Use the dock's
-                <code>OpenPanelAsync</code> method to bring it back.
-            </p>
-        </div>
-
-        <div class="flex flex-wrap items-center gap-2">
-            @if (closedPanels.Count == 0)
-            {
-                <span class="text-sm text-muted-foreground">Close a tab below to reopen it here.</span>
-            }
-            @foreach (var id in closedPanels)
-            {
-                <BbButton Size="ButtonSize.Small" Variant="ButtonVariant.Outline" OnClick="() => Reopen(id)">
-                    <LucideIcon Name="plus" Size="14" Class="mr-1" /> Reopen @titles[id]
-                </BbButton>
-            }
-        </div>
-
-        <div class="h-[420px] rounded-lg border shadow-sm">
-            <BbDock @ref="reopenDock" OnPanelClosed="OnPanelClosed">
-                <BbDockPanel Id="document" Title="Document" Region="DockZone.Center">
-                    <Icon><LucideIcon Name="file-text" Size="14" /></Icon>
-                    <ChildContent>
-                        <div class="p-4 text-sm text-muted-foreground">The main document. This tab can be closed and reopened.</div>
-                    </ChildContent>
-                </BbDockPanel>
-                <BbDockPanel Id="comments" Title="Comments" Region="DockZone.Right">
-                    <Icon><LucideIcon Name="message-square" Size="14" /></Icon>
-                    <ChildContent>
-                        <div class="p-4 text-sm text-muted-foreground">Reviewer comments.</div>
-                    </ChildContent>
-                </BbDockPanel>
-                <BbDockPanel Id="history" Title="History" Region="DockZone.Bottom">
-                    <Icon><LucideIcon Name="history" Size="14" /></Icon>
-                    <ChildContent>
-                        <div class="p-4 text-sm text-muted-foreground">Revision history.</div>
-                    </ChildContent>
-                </BbDockPanel>
-            </BbDock>
-        </div>
-
-        <CodeBlock Source="Components/Dock/reopen.txt" />
-    </div>
-
-    <!-- Basic -->
-    <div class="space-y-4">
-        <div class="space-y-2">
-            <h2 class="text-2xl font-semibold">Basic</h2>
-            <p class="text-sm text-muted-foreground">
-                Panels are placed by <code>Region</code>. Panels sharing a region become tabs in the same group.
-            </p>
-        </div>
-
-        <div class="h-[400px] rounded-lg border shadow-sm">
-            <BbDock>
-                <BbDockPanel Id="b-editor" Title="Editor" Region="DockZone.Center" Closable="false">
-                    <div class="p-4 text-sm text-muted-foreground">Main editor content</div>
-                </BbDockPanel>
-                <BbDockPanel Id="b-explorer" Title="Explorer" Region="DockZone.Left">
-                    <div class="p-4 text-sm text-muted-foreground">File tree</div>
-                </BbDockPanel>
-                <BbDockPanel Id="b-output" Title="Output" Region="DockZone.Bottom">
-                    <div class="p-4 text-sm text-muted-foreground">Build output</div>
-                </BbDockPanel>
-            </BbDock>
-        </div>
-
-        <CodeBlock Source="Components/Dock/basic.txt" />
-    </div>
 
     <AccessibilityList>
         <AriaAttributes>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/Index.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/Index.razor
@@ -275,6 +275,14 @@
                     </p>
                 </a>
 
+                <!-- Dock -->
+                <a href="/components/dock" class="group p-5 border rounded-lg hover:border-primary hover:bg-accent transition-colors no-underline">
+                    <h3 class="font-semibold text-lg mb-2 group-hover:text-primary">Dock</h3>
+                    <p class="text-sm text-muted-foreground">
+                        IDE-style docking workspace with draggable tabs, splits, and floating windows
+                    </p>
+                </a>
+
                 <!-- Drawer -->
                 <a href="/components/drawer" class="group p-5 border rounded-lg hover:border-primary hover:bg-accent transition-colors no-underline">
                     <h3 class="font-semibold text-lg mb-2 group-hover:text-primary">Drawer</h3>

--- a/demos/BlazorBlueprint.Demo.Shared/Shared/DemoSidebar.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Shared/DemoSidebar.razor
@@ -393,6 +393,11 @@
                                     </BbSidebarMenuSubButton>
                                 </BbSidebarMenuSubItem>
                                 <BbSidebarMenuSubItem>
+                                    <BbSidebarMenuSubButton AsChild="@SidebarMenuButtonElement.Anchor" Href="components/dock">
+                                        <span>Dock</span>
+                                    </BbSidebarMenuSubButton>
+                                </BbSidebarMenuSubItem>
+                                <BbSidebarMenuSubItem>
                                     <BbSidebarMenuSubButton AsChild="@SidebarMenuButtonElement.Anchor" Href="components/dropdown-menu">
                                         <span>Dropdown Menu</span>
                                     </BbSidebarMenuSubButton>

--- a/demos/BlazorBlueprint.Demo.Shared/Shared/DemoSidebar.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Shared/DemoSidebar.razor
@@ -398,13 +398,13 @@
                                     </BbSidebarMenuSubButton>
                                 </BbSidebarMenuSubItem>
                                 <BbSidebarMenuSubItem>
-                                    <BbSidebarMenuSubButton AsChild="@SidebarMenuButtonElement.Anchor" Href="components/dropdown-menu">
-                                        <span>Dropdown Menu</span>
+                                    <BbSidebarMenuSubButton AsChild="@SidebarMenuButtonElement.Anchor" Href="components/drawer">
+                                        <span>Drawer</span>
                                     </BbSidebarMenuSubButton>
                                 </BbSidebarMenuSubItem>
                                 <BbSidebarMenuSubItem>
-                                    <BbSidebarMenuSubButton AsChild="@SidebarMenuButtonElement.Anchor" Href="components/drawer">
-                                        <span>Drawer</span>
+                                    <BbSidebarMenuSubButton AsChild="@SidebarMenuButtonElement.Anchor" Href="components/dropdown-menu">
+                                        <span>Dropdown Menu</span>
                                     </BbSidebarMenuSubButton>
                                 </BbSidebarMenuSubItem>
                                 <BbSidebarMenuSubItem>

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor
@@ -8,9 +8,9 @@
     @ChildContent
 
     <div @ref="rootRef" class="@CssClass" data-dock-root="@dockId">
-        @if (maximizedGroup is not null)
+        @if (MaximizedGroup is not null)
         {
-            <BbDockNode Node="maximizedGroup" />
+            <BbDockNode Node="MaximizedGroup" />
         }
         else if (layout is not null)
         {

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor
@@ -31,20 +31,14 @@
 
         @foreach (var win in floatingWindows)
         {
-            <div class="absolute z-30 flex flex-col overflow-hidden rounded-lg border bg-background shadow-2xl ring-1 ring-black/5"
+            <div class="absolute z-30 flex flex-col overflow-hidden border bg-background shadow-2xl ring-1 ring-black/5"
                  style="@FloatingStyle(win)"
                  data-dock-window="@win.Id"
                  @key="win.Id">
                 <BbDockTabGroup Group="win.Group" FloatingWindowId="@win.Id" />
-                <div class="absolute bottom-0 right-0 z-10 h-3.5 w-3.5 cursor-nwse-resize text-muted-foreground/60"
+                <div class="absolute bottom-0 right-0 z-10 h-3.5 w-3.5 cursor-nwse-resize"
                      data-dock-window-resize="@win.Id"
                      @onpointerdown="e => StartWindowResize(win.Id, e)">
-                    <svg viewBox="0 0 10 10" class="h-full w-full" fill="currentColor" aria-hidden="true">
-                        <path d="M9 1v8H1z" fill="none" />
-                        <circle cx="8" cy="8" r="1" />
-                        <circle cx="8" cy="5" r="1" />
-                        <circle cx="5" cy="8" r="1" />
-                    </svg>
                 </div>
             </div>
         }

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor
@@ -1,4 +1,5 @@
 @namespace BlazorBlueprint.Components
+@inject IBbLocalizer Localizer
 
 @* Registration host: instantiating the BbDockPanel children causes them to register with
    this dock. They render no markup, so this produces no DOM. The CascadingValue also
@@ -24,7 +25,7 @@
                 }
                 else
                 {
-                    <span>No panels are open.</span>
+                    <span>@Localizer["Dock.NoPanelsOpen"]</span>
                 }
             </div>
         }

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor
@@ -1,0 +1,52 @@
+@namespace BlazorBlueprint.Components
+
+@* Registration host: instantiating the BbDockPanel children causes them to register with
+   this dock. They render no markup, so this produces no DOM. The CascadingValue also
+   covers the layout so that BbDockTabGroup receives the dock reference. *@
+<CascadingValue Value="this" IsFixed="true">
+    @ChildContent
+
+    <div @ref="rootRef" class="@CssClass" data-dock-root="@dockId">
+        @if (maximizedGroup is not null)
+        {
+            <BbDockNode Node="maximizedGroup" />
+        }
+        else if (layout is not null)
+        {
+            <BbDockNode Node="layout" />
+        }
+        else
+        {
+            <div class="flex h-full w-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
+                @if (EmptyContent is not null)
+                {
+                    @EmptyContent
+                }
+                else
+                {
+                    <span>No panels are open.</span>
+                }
+            </div>
+        }
+
+        @foreach (var win in floatingWindows)
+        {
+            <div class="absolute z-30 flex flex-col overflow-hidden rounded-lg border bg-background shadow-2xl ring-1 ring-black/5"
+                 style="@FloatingStyle(win)"
+                 data-dock-window="@win.Id"
+                 @key="win.Id">
+                <BbDockTabGroup Group="win.Group" FloatingWindowId="@win.Id" />
+                <div class="absolute bottom-0 right-0 z-10 h-3.5 w-3.5 cursor-nwse-resize text-muted-foreground/60"
+                     data-dock-window-resize="@win.Id"
+                     @onpointerdown="e => StartWindowResize(win.Id, e)">
+                    <svg viewBox="0 0 10 10" class="h-full w-full" fill="currentColor" aria-hidden="true">
+                        <path d="M9 1v8H1z" fill="none" />
+                        <circle cx="8" cy="8" r="1" />
+                        <circle cx="8" cy="5" r="1" />
+                        <circle cx="5" cy="8" r="1" />
+                    </svg>
+                </div>
+            </div>
+        }
+    </div>
+</CascadingValue>

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor.cs
@@ -65,7 +65,7 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
 
     private string? draggingPanelId;
 
-    private DockTabGroupNode? maximizedGroup =>
+    private DockTabGroupNode? MaximizedGroup =>
         maximizedGroupId is null ? null : FindGroup(maximizedGroupId);
 
     private string CssClass => ClassNames.cn(
@@ -488,12 +488,6 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
     internal bool IsPinned(string panelId) => pinnedPanels.Contains(panelId);
 
     /// <summary>
-    /// The number of pinned panels at the front of the given group's tab strip.
-    /// </summary>
-    private int PinnedCount(DockTabGroupNode group) =>
-        group.PanelIds.Count(pinnedPanels.Contains);
-
-    /// <summary>
     /// Stable-partitions a group's tabs so pinned tabs sit at the front in pin order,
     /// followed by unpinned tabs in their existing order.
     /// </summary>
@@ -562,6 +556,13 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
         var panelId = draggingPanelId;
         draggingPanelId = null;
         if (panelId is null || !panels.TryGetValue(panelId, out var panel))
+        {
+            return;
+        }
+
+        // Re-validate server-side: JS input cannot move a locked panel regardless of what
+        // drop target it reports. The float case additionally requires CanDetach below.
+        if (!panel.CanMove)
         {
             return;
         }

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor.cs
@@ -561,7 +561,7 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
 
         var panelId = draggingPanelId;
         draggingPanelId = null;
-        if (panelId is null || !panels.ContainsKey(panelId))
+        if (panelId is null || !panels.TryGetValue(panelId, out var panel))
         {
             return;
         }
@@ -634,12 +634,22 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
 
             case "float":
             {
+                // A locked or non-floatable panel cannot be detached: leave it where it is.
+                if (!panel.CanDetach)
+                {
+                    return;
+                }
+
                 RemovePanelFromLayout(panelId);
+                var floatGroup = new DockTabGroupNode { PanelIds = { panelId }, ActivePanelId = panelId };
+                var (minW, minH, maxW, maxH) = GroupSizeBounds(floatGroup);
                 floatingWindows.Add(new DockFloatingWindow
                 {
-                    Group = new DockTabGroupNode { PanelIds = { panelId }, ActivePanelId = panelId },
+                    Group = floatGroup,
                     X = Math.Max(0, floatX),
-                    Y = Math.Max(0, floatY)
+                    Y = Math.Max(0, floatY),
+                    Width = Math.Clamp(DockFloatingWindow.DefaultWidth, minW, maxW),
+                    Height = Math.Clamp(DockFloatingWindow.DefaultHeight, minH, maxH)
                 });
                 break;
             }
@@ -661,7 +671,7 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
 
     internal async Task ClosePanelAsync(string panelId)
     {
-        if (!panels.ContainsKey(panelId))
+        if (!panels.TryGetValue(panelId, out var panel) || !panel.CanClose)
         {
             return;
         }
@@ -717,7 +727,7 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
 
         foreach (var id in panelIds)
         {
-            if (!panels.TryGetValue(id, out var panel) || !panel.Closable)
+            if (!panels.TryGetValue(id, out var panel) || !panel.CanClose)
             {
                 continue;
             }
@@ -797,10 +807,25 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
 
     private async Task StartWindowResize(string windowId, PointerEventArgs e)
     {
-        if (jsModule is not null && jsInitialized)
+        if (jsModule is null || !jsInitialized)
         {
-            await jsModule.InvokeVoidAsync("startWindowResize", dockId, windowId, e.ClientX, e.ClientY, e.PointerId);
+            return;
         }
+
+        var win = floatingWindows.FirstOrDefault(w => w.Id == windowId);
+        if (win is null)
+        {
+            return;
+        }
+
+        // Feed the live JS resize the same bounds we enforce server-side so the grip stops at
+        // the limit instead of snapping back on release. A max of 0 means "no maximum".
+        var (minW, minH, maxW, maxH) = GroupSizeBounds(win.Group);
+        var maxWArg = double.IsPositiveInfinity(maxW) ? 0 : maxW;
+        var maxHArg = double.IsPositiveInfinity(maxH) ? 0 : maxH;
+
+        await jsModule.InvokeVoidAsync(
+            "startWindowResize", dockId, windowId, e.ClientX, e.ClientY, e.PointerId, minW, minH, maxWArg, maxHArg);
     }
 
     [JSInvokable]
@@ -831,8 +856,9 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
         var win = floatingWindows.FirstOrDefault(w => w.Id == windowId);
         if (win is not null)
         {
-            win.Width = Math.Max(180, width);
-            win.Height = Math.Max(120, height);
+            var (minW, minH, maxW, maxH) = GroupSizeBounds(win.Group);
+            win.Width = Math.Clamp(width, minW, maxW);
+            win.Height = Math.Clamp(height, minH, maxH);
             StateHasChanged();
         }
     }
@@ -861,13 +887,127 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
         _ => DockZone.Center
     };
 
-    private static string FloatingStyle(DockFloatingWindow win)
+    private string FloatingStyle(DockFloatingWindow win)
     {
+        var (minW, minH, maxW, maxH) = GroupSizeBounds(win.Group);
         var x = win.X.ToString("F0", CultureInfo.InvariantCulture);
         var y = win.Y.ToString("F0", CultureInfo.InvariantCulture);
-        var w = win.Width.ToString("F0", CultureInfo.InvariantCulture);
-        var h = win.Height.ToString("F0", CultureInfo.InvariantCulture);
-        return $"left:{x}px;top:{y}px;width:{w}px;height:{h}px;";
+        var w = Math.Clamp(win.Width, minW, maxW).ToString("F0", CultureInfo.InvariantCulture);
+        var h = Math.Clamp(win.Height, minH, maxH).ToString("F0", CultureInfo.InvariantCulture);
+
+        var style = $"left:{x}px;top:{y}px;width:{w}px;height:{h}px;" +
+                    $"min-width:{minW.ToString("F0", CultureInfo.InvariantCulture)}px;" +
+                    $"min-height:{minH.ToString("F0", CultureInfo.InvariantCulture)}px;";
+        if (!double.IsPositiveInfinity(maxW))
+        {
+            style += $"max-width:{maxW.ToString("F0", CultureInfo.InvariantCulture)}px;";
+        }
+        if (!double.IsPositiveInfinity(maxH))
+        {
+            style += $"max-height:{maxH.ToString("F0", CultureInfo.InvariantCulture)}px;";
+        }
+        return style;
+    }
+
+    /// <summary>
+    /// Computes the effective pixel size bounds for a floating window hosting the given group.
+    /// Mins are the largest of the panels' minimums (floored at the usable window minimum); maxes
+    /// are the smallest of the panels' maximums, reconciled so that <c>max &gt;= min</c>.
+    /// </summary>
+    private (double MinW, double MinH, double MaxW, double MaxH) GroupSizeBounds(DockTabGroupNode group)
+    {
+        var minW = DockFloatingWindow.MinFloatingWidth;
+        var minH = DockFloatingWindow.MinFloatingHeight;
+        var maxW = double.PositiveInfinity;
+        var maxH = double.PositiveInfinity;
+
+        foreach (var id in group.PanelIds)
+        {
+            var panel = GetPanel(id);
+            if (panel is null)
+            {
+                continue;
+            }
+
+            if (panel.MinWidth is int pMinW)
+            {
+                minW = Math.Max(minW, pMinW);
+            }
+            if (panel.MinHeight is int pMinH)
+            {
+                minH = Math.Max(minH, pMinH);
+            }
+            if (panel.MaxWidth is int pMaxW)
+            {
+                maxW = Math.Min(maxW, pMaxW);
+            }
+            if (panel.MaxHeight is int pMaxH)
+            {
+                maxH = Math.Min(maxH, pMaxH);
+            }
+        }
+
+        // A minimum larger than the requested maximum wins, so the window stays usable.
+        maxW = Math.Max(maxW, minW);
+        maxH = Math.Max(maxH, minH);
+        return (minW, minH, maxW, maxH);
+    }
+
+    /// <summary>
+    /// Builds the inline CSS min/max size constraints for a docked tab group from the panels it
+    /// hosts, or <c>null</c> when no panel in the group declares any size constraint.
+    /// </summary>
+    internal string? GroupConstraintStyle(DockTabGroupNode group)
+    {
+        double minW = 0, minH = 0;
+        var maxW = double.PositiveInfinity;
+        var maxH = double.PositiveInfinity;
+
+        foreach (var id in group.PanelIds)
+        {
+            var panel = GetPanel(id);
+            if (panel is null)
+            {
+                continue;
+            }
+
+            if (panel.MinWidth is int pMinW)
+            {
+                minW = Math.Max(minW, pMinW);
+            }
+            if (panel.MinHeight is int pMinH)
+            {
+                minH = Math.Max(minH, pMinH);
+            }
+            if (panel.MaxWidth is int pMaxW)
+            {
+                maxW = Math.Min(maxW, pMaxW);
+            }
+            if (panel.MaxHeight is int pMaxH)
+            {
+                maxH = Math.Min(maxH, pMaxH);
+            }
+        }
+
+        var parts = new List<string>();
+        if (minW > 0)
+        {
+            parts.Add($"min-width:{minW.ToString("F0", CultureInfo.InvariantCulture)}px");
+        }
+        if (minH > 0)
+        {
+            parts.Add($"min-height:{minH.ToString("F0", CultureInfo.InvariantCulture)}px");
+        }
+        if (!double.IsPositiveInfinity(maxW))
+        {
+            parts.Add($"max-width:{Math.Max(maxW, minW).ToString("F0", CultureInfo.InvariantCulture)}px");
+        }
+        if (!double.IsPositiveInfinity(maxH))
+        {
+            parts.Add($"max-height:{Math.Max(maxH, minH).ToString("F0", CultureInfo.InvariantCulture)}px");
+        }
+
+        return parts.Count > 0 ? string.Join(';', parts) + ";" : null;
     }
 
     /// <inheritdoc />

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor.cs
@@ -1,0 +1,780 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
+
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// An IDE-style docking container. Panels declared with <see cref="BbDockPanel"/> can be
+/// dragged by their tabs and re-docked as tabs or splits, detached into floating windows,
+/// maximized, closed and reopened — similar to the docking experience in Visual Studio,
+/// VS Code or dockspawn.
+/// </summary>
+public partial class BbDock : ComponentBase, IAsyncDisposable
+{
+    [Inject]
+    private IJSRuntime JS { get; set; } = null!;
+
+    /// <summary>
+    /// The <see cref="BbDockPanel"/> declarations hosted by this dock.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Optional content shown when no panels are open.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? EmptyContent { get; set; }
+
+    /// <summary>
+    /// Additional CSS classes applied to the dock surface.
+    /// </summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    /// <summary>
+    /// Invoked after the layout changes (docking, floating, closing, reopening or reordering).
+    /// </summary>
+    [Parameter]
+    public EventCallback OnLayoutChanged { get; set; }
+
+    /// <summary>
+    /// Invoked when a panel is closed by the user, with the panel's identifier.
+    /// </summary>
+    [Parameter]
+    public EventCallback<string> OnPanelClosed { get; set; }
+
+    private readonly Dictionary<string, BbDockPanel> panels = new();
+    private readonly List<string> registrationOrder = new();
+    private readonly HashSet<string> closedPanels = new();
+    private readonly List<DockFloatingWindow> floatingWindows = new();
+
+    private DockNode? layout;
+    private string? maximizedGroupId;
+
+    private ElementReference rootRef;
+    private readonly string dockId = Guid.NewGuid().ToString("N");
+    private IJSObjectReference? jsModule;
+    private DotNetObjectReference<BbDock>? dotNetRef;
+    private bool jsInitialized;
+    private bool layoutBuilt;
+    private bool disposed;
+
+    private string? draggingPanelId;
+
+    private DockTabGroupNode? maximizedGroup =>
+        maximizedGroupId is null ? null : FindGroup(maximizedGroupId);
+
+    private string CssClass => ClassNames.cn(
+        "relative h-full w-full select-none overflow-hidden bg-muted/20 text-foreground",
+        Class);
+
+    // ----------------------------------------------------------------- Registration
+
+    internal void RegisterPanel(BbDockPanel panel)
+    {
+        panels[panel.Id] = panel;
+        if (!registrationOrder.Contains(panel.Id))
+        {
+            registrationOrder.Add(panel.Id);
+        }
+
+        // A panel added after the initial layout was built (e.g. conditionally rendered)
+        // is docked into a sensible default location.
+        if (layoutBuilt && !closedPanels.Contains(panel.Id) && FindGroupContaining(panel.Id) is null)
+        {
+            AddPanelToDefaultLocation(panel.Id);
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    internal void UnregisterPanel(BbDockPanel panel)
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        panels.Remove(panel.Id);
+        registrationOrder.Remove(panel.Id);
+
+        if (FindGroupContaining(panel.Id) is not null)
+        {
+            RemovePanelFromLayout(panel.Id);
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    internal BbDockPanel? GetPanel(string id) => panels.TryGetValue(id, out var p) ? p : null;
+
+    // ----------------------------------------------------------------- Lifecycle
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            BuildInitialLayout();
+            layoutBuilt = true;
+            await InitializeJsAsync();
+            StateHasChanged();
+        }
+    }
+
+    private async Task InitializeJsAsync()
+    {
+        try
+        {
+            jsModule = await JS.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/BlazorBlueprint.Components/js/dock.js");
+            dotNetRef = DotNetObjectReference.Create(this);
+            await jsModule.InvokeVoidAsync("initializeDock", dockId, rootRef, dotNetRef);
+            jsInitialized = true;
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        {
+            // Expected during circuit disconnect / prerender.
+        }
+        catch (InvalidOperationException)
+        {
+            // JS interop not available during prerendering.
+        }
+    }
+
+    // ----------------------------------------------------------------- Initial layout
+
+    private void BuildInitialLayout()
+    {
+        DockTabGroupNode? MakeGroup(DockZone region)
+        {
+            var ids = registrationOrder
+                .Where(id => panels.TryGetValue(id, out var p)
+                             && !closedPanels.Contains(id)
+                             && p.Region == region)
+                .OrderBy(id => panels[id].Order)
+                .ToList();
+
+            if (ids.Count == 0)
+            {
+                return null;
+            }
+
+            var group = new DockTabGroupNode { PanelIds = ids };
+            group.EnsureActive();
+            return group;
+        }
+
+        var left = MakeGroup(DockZone.Left);
+        var right = MakeGroup(DockZone.Right);
+        var top = MakeGroup(DockZone.Top);
+        var center = MakeGroup(DockZone.Center);
+        var bottom = MakeGroup(DockZone.Bottom);
+
+        var middleParts = new List<(DockNode Node, double Weight)>();
+        if (top is not null)
+        {
+            middleParts.Add((top, 25));
+        }
+        if (center is not null)
+        {
+            middleParts.Add((center, 50));
+        }
+        if (bottom is not null)
+        {
+            middleParts.Add((bottom, 25));
+        }
+
+        var middle = Combine(middleParts, DockOrientation.Vertical);
+
+        var rowParts = new List<(DockNode Node, double Weight)>();
+        if (left is not null)
+        {
+            rowParts.Add((left, 20));
+        }
+        if (middle is not null)
+        {
+            rowParts.Add((middle, 60));
+        }
+        if (right is not null)
+        {
+            rowParts.Add((right, 20));
+        }
+
+        layout = Combine(rowParts, DockOrientation.Horizontal);
+    }
+
+    private static DockNode? Combine(List<(DockNode Node, double Weight)> parts, DockOrientation orientation)
+    {
+        if (parts.Count == 0)
+        {
+            return null;
+        }
+
+        if (parts.Count == 1)
+        {
+            return parts[0].Node;
+        }
+
+        var split = new DockSplitNode
+        {
+            Orientation = orientation,
+            Children = parts.Select(p => p.Node).ToList(),
+            Sizes = parts.Select(p => p.Weight).ToList()
+        };
+        split.NormalizeSizes();
+        return split;
+    }
+
+    // ----------------------------------------------------------------- Tree traversal
+
+    private IEnumerable<DockTabGroupNode> AllGroups()
+    {
+        if (layout is not null)
+        {
+            foreach (var g in GroupsIn(layout))
+            {
+                yield return g;
+            }
+        }
+
+        foreach (var win in floatingWindows)
+        {
+            yield return win.Group;
+        }
+    }
+
+    private static IEnumerable<DockTabGroupNode> GroupsIn(DockNode node)
+    {
+        switch (node)
+        {
+            case DockTabGroupNode group:
+                yield return group;
+                break;
+            case DockSplitNode split:
+                foreach (var child in split.Children)
+                {
+                    foreach (var g in GroupsIn(child))
+                    {
+                        yield return g;
+                    }
+                }
+                break;
+        }
+    }
+
+    private DockTabGroupNode? FindGroup(string id) => AllGroups().FirstOrDefault(g => g.Id == id);
+
+    private DockTabGroupNode? FindGroupContaining(string panelId) =>
+        AllGroups().FirstOrDefault(g => g.PanelIds.Contains(panelId));
+
+    private DockSplitNode? FindParent(DockNode node)
+    {
+        if (layout is null)
+        {
+            return null;
+        }
+
+        return FindParentIn(layout, node);
+    }
+
+    private static DockSplitNode? FindParentIn(DockNode current, DockNode target)
+    {
+        if (current is DockSplitNode split)
+        {
+            if (split.Children.Contains(target))
+            {
+                return split;
+            }
+
+            foreach (var child in split.Children)
+            {
+                var found = FindParentIn(child, target);
+                if (found is not null)
+                {
+                    return found;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private void ReplaceInParent(DockNode oldNode, DockNode newNode)
+    {
+        if (ReferenceEquals(layout, oldNode))
+        {
+            layout = newNode;
+            return;
+        }
+
+        var parent = FindParent(oldNode);
+        if (parent is null)
+        {
+            return;
+        }
+
+        var index = parent.Children.IndexOf(oldNode);
+        if (index >= 0)
+        {
+            parent.Children[index] = newNode;
+        }
+    }
+
+    // ----------------------------------------------------------------- Removal / pruning
+
+    private void RemovePanelFromLayout(string panelId)
+    {
+        var group = FindGroupContaining(panelId);
+        if (group is null)
+        {
+            return;
+        }
+
+        group.PanelIds.Remove(panelId);
+        group.EnsureActive();
+
+        if (group.PanelIds.Count == 0)
+        {
+            RemoveEmptyGroup(group);
+        }
+    }
+
+    private void RemoveEmptyGroup(DockTabGroupNode group)
+    {
+        if (maximizedGroupId == group.Id)
+        {
+            maximizedGroupId = null;
+        }
+
+        var win = floatingWindows.FirstOrDefault(w => ReferenceEquals(w.Group, group));
+        if (win is not null)
+        {
+            floatingWindows.Remove(win);
+            return;
+        }
+
+        if (ReferenceEquals(layout, group))
+        {
+            layout = null;
+            return;
+        }
+
+        var parent = FindParent(group);
+        if (parent is null)
+        {
+            return;
+        }
+
+        parent.Children.Remove(group);
+        CollapseSplit(parent);
+    }
+
+    private void CollapseSplit(DockSplitNode split)
+    {
+        if (split.Children.Count == 1)
+        {
+            var only = split.Children[0];
+            ReplaceInParent(split, only);
+        }
+        else if (split.Children.Count == 0)
+        {
+            if (ReferenceEquals(layout, split))
+            {
+                layout = null;
+            }
+            else
+            {
+                var parent = FindParent(split);
+                if (parent is not null)
+                {
+                    parent.Children.Remove(split);
+                    CollapseSplit(parent);
+                }
+            }
+        }
+        else
+        {
+            split.NormalizeSizes();
+        }
+    }
+
+    // ----------------------------------------------------------------- Drop / docking
+
+    private void SplitAroundTarget(DockTabGroupNode target, DockNode newNode, DockZone zone)
+    {
+        var orientation = zone is DockZone.Left or DockZone.Right
+            ? DockOrientation.Horizontal
+            : DockOrientation.Vertical;
+        var newFirst = zone is DockZone.Left or DockZone.Top;
+
+        var split = new DockSplitNode
+        {
+            Orientation = orientation,
+            Children = newFirst ? new() { newNode, target } : new() { target, newNode },
+            Sizes = new() { 50, 50 }
+        };
+
+        ReplaceInParent(target, split);
+    }
+
+    private void SplitAtRoot(DockNode newNode, DockZone zone)
+    {
+        if (layout is null)
+        {
+            layout = newNode;
+            return;
+        }
+
+        var orientation = zone is DockZone.Left or DockZone.Right
+            ? DockOrientation.Horizontal
+            : DockOrientation.Vertical;
+        var newFirst = zone is DockZone.Left or DockZone.Top;
+
+        var split = new DockSplitNode
+        {
+            Orientation = orientation,
+            Children = newFirst ? new() { newNode, layout } : new() { layout, newNode },
+            Sizes = newFirst ? new() { 28, 72 } : new() { 72, 28 }
+        };
+        layout = split;
+    }
+
+    private void ReorderPanel(string panelId, DockTabGroupNode target, int index)
+    {
+        var source = FindGroupContaining(panelId);
+        if (source is null)
+        {
+            return;
+        }
+
+        if (ReferenceEquals(source, target))
+        {
+            // Move within the same group: account for the gap left by removing the panel.
+            var old = target.PanelIds.IndexOf(panelId);
+            if (old < 0)
+            {
+                return;
+            }
+
+            target.PanelIds.RemoveAt(old);
+            var insert = index;
+            if (old < insert)
+            {
+                insert--;
+            }
+            insert = Math.Clamp(insert, 0, target.PanelIds.Count);
+            target.PanelIds.Insert(insert, panelId);
+        }
+        else
+        {
+            // Move into another group's strip at a precise slot.
+            RemovePanelFromLayout(panelId);
+            var insert = Math.Clamp(index, 0, target.PanelIds.Count);
+            target.PanelIds.Insert(insert, panelId);
+        }
+
+        target.ActivePanelId = panelId;
+    }
+
+    private void AddPanelToDefaultLocation(string panelId)
+    {
+        var existing = AllGroups().FirstOrDefault();
+        if (existing is not null)
+        {
+            existing.PanelIds.Add(panelId);
+            existing.ActivePanelId = panelId;
+        }
+        else
+        {
+            var group = new DockTabGroupNode { PanelIds = { panelId }, ActivePanelId = panelId };
+            layout = group;
+        }
+    }
+
+    [JSInvokable]
+    public async Task OnTabDropped(string targetType, string? groupId, string zone, double floatX, double floatY, int index)
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        var panelId = draggingPanelId;
+        draggingPanelId = null;
+        if (panelId is null || !panels.ContainsKey(panelId))
+        {
+            return;
+        }
+
+        var dropZone = ParseZone(zone);
+        maximizedGroupId = null;
+
+        switch (targetType)
+        {
+            case "reorder":
+            {
+                var target = groupId is null ? null : FindGroup(groupId);
+                if (target is null)
+                {
+                    return;
+                }
+
+                // Reordering a lone panel within its own group is a no-op.
+                if (target.PanelIds.Count == 1 && target.PanelIds[0] == panelId)
+                {
+                    target.ActivePanelId = panelId;
+                    break;
+                }
+
+                ReorderPanel(panelId, target, index);
+                break;
+            }
+
+            case "group":
+            {
+                var target = groupId is null ? null : FindGroup(groupId);
+                if (target is null)
+                {
+                    return;
+                }
+
+                // Dropping a single-panel group onto itself is a no-op.
+                if (target.PanelIds.Count == 1 && target.PanelIds[0] == panelId)
+                {
+                    target.ActivePanelId = panelId;
+                    break;
+                }
+
+                if (dropZone == DockZone.Center)
+                {
+                    if (!target.PanelIds.Contains(panelId))
+                    {
+                        RemovePanelFromLayout(panelId);
+                        target.PanelIds.Add(panelId);
+                    }
+                    target.ActivePanelId = panelId;
+                }
+                else
+                {
+                    RemovePanelFromLayout(panelId);
+                    var newGroup = new DockTabGroupNode { PanelIds = { panelId }, ActivePanelId = panelId };
+                    SplitAroundTarget(target, newGroup, dropZone);
+                }
+                break;
+            }
+
+            case "root":
+            {
+                RemovePanelFromLayout(panelId);
+                var newGroup = new DockTabGroupNode { PanelIds = { panelId }, ActivePanelId = panelId };
+                SplitAtRoot(newGroup, dropZone);
+                break;
+            }
+
+            case "float":
+            {
+                RemovePanelFromLayout(panelId);
+                floatingWindows.Add(new DockFloatingWindow
+                {
+                    Group = new DockTabGroupNode { PanelIds = { panelId }, ActivePanelId = panelId },
+                    X = Math.Max(0, floatX),
+                    Y = Math.Max(0, floatY)
+                });
+                break;
+            }
+
+            default:
+                return;
+        }
+
+        await AfterMutateAsync();
+    }
+
+    // ----------------------------------------------------------------- Group/tab interactions
+
+    internal void ActivatePanel(DockTabGroupNode group, string panelId)
+    {
+        group.ActivePanelId = panelId;
+        StateHasChanged();
+    }
+
+    internal async Task ClosePanelAsync(string panelId)
+    {
+        if (!panels.ContainsKey(panelId))
+        {
+            return;
+        }
+
+        RemovePanelFromLayout(panelId);
+        closedPanels.Add(panelId);
+
+        if (OnPanelClosed.HasDelegate)
+        {
+            await OnPanelClosed.InvokeAsync(panelId);
+        }
+
+        await AfterMutateAsync();
+    }
+
+    /// <summary>
+    /// Reopens a previously closed panel, docking it into a sensible default location.
+    /// </summary>
+    /// <param name="panelId">The identifier of the panel to reopen.</param>
+    public async Task OpenPanelAsync(string panelId)
+    {
+        if (!panels.ContainsKey(panelId))
+        {
+            return;
+        }
+
+        closedPanels.Remove(panelId);
+
+        if (FindGroupContaining(panelId) is null)
+        {
+            AddPanelToDefaultLocation(panelId);
+        }
+
+        maximizedGroupId = null;
+        await AfterMutateAsync();
+    }
+
+    /// <summary>
+    /// Gets the identifiers of panels that are currently closed and can be reopened.
+    /// </summary>
+    /// <returns>The closed panel identifiers in registration order.</returns>
+    public IReadOnlyList<string> GetClosedPanelIds() =>
+        registrationOrder.Where(id => closedPanels.Contains(id)).ToList();
+
+    internal bool IsMaximized(DockTabGroupNode group) => maximizedGroupId == group.Id;
+
+    internal void ToggleMaximize(DockTabGroupNode group)
+    {
+        maximizedGroupId = maximizedGroupId == group.Id ? null : group.Id;
+        StateHasChanged();
+    }
+
+    internal async Task StartTabDragAsync(string panelId, PointerEventArgs e)
+    {
+        draggingPanelId = panelId;
+        var title = GetPanel(panelId)?.Title ?? string.Empty;
+
+        if (jsModule is not null && jsInitialized)
+        {
+            await jsModule.InvokeVoidAsync("startTabDrag", dockId, title, e.ClientX, e.ClientY, e.PointerId);
+        }
+    }
+
+    internal async Task StartWindowDragAsync(string windowId, PointerEventArgs e)
+    {
+        if (jsModule is not null && jsInitialized)
+        {
+            await jsModule.InvokeVoidAsync("startWindowDrag", dockId, windowId, e.ClientX, e.ClientY, e.PointerId);
+        }
+    }
+
+    private async Task StartWindowResize(string windowId, PointerEventArgs e)
+    {
+        if (jsModule is not null && jsInitialized)
+        {
+            await jsModule.InvokeVoidAsync("startWindowResize", dockId, windowId, e.ClientX, e.ClientY, e.PointerId);
+        }
+    }
+
+    [JSInvokable]
+    public void OnWindowMoved(string windowId, double x, double y)
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        var win = floatingWindows.FirstOrDefault(w => w.Id == windowId);
+        if (win is not null)
+        {
+            win.X = Math.Max(0, x);
+            win.Y = Math.Max(0, y);
+            StateHasChanged();
+        }
+    }
+
+    [JSInvokable]
+    public void OnWindowResized(string windowId, double width, double height)
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        var win = floatingWindows.FirstOrDefault(w => w.Id == windowId);
+        if (win is not null)
+        {
+            win.Width = Math.Max(180, width);
+            win.Height = Math.Max(120, height);
+            StateHasChanged();
+        }
+    }
+
+    private async Task AfterMutateAsync()
+    {
+        foreach (var group in AllGroups())
+        {
+            group.EnsureActive();
+        }
+
+        StateHasChanged();
+
+        if (OnLayoutChanged.HasDelegate)
+        {
+            await OnLayoutChanged.InvokeAsync();
+        }
+    }
+
+    private static DockZone ParseZone(string zone) => zone switch
+    {
+        "left" => DockZone.Left,
+        "right" => DockZone.Right,
+        "top" => DockZone.Top,
+        "bottom" => DockZone.Bottom,
+        _ => DockZone.Center
+    };
+
+    private static string FloatingStyle(DockFloatingWindow win)
+    {
+        var x = win.X.ToString("F0", CultureInfo.InvariantCulture);
+        var y = win.Y.ToString("F0", CultureInfo.InvariantCulture);
+        var w = win.Width.ToString("F0", CultureInfo.InvariantCulture);
+        var h = win.Height.ToString("F0", CultureInfo.InvariantCulture);
+        return $"left:{x}px;top:{y}px;width:{w}px;height:{h}px;";
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        disposed = true;
+
+        if (jsModule is not null && jsInitialized)
+        {
+            try
+            {
+                await jsModule.InvokeVoidAsync("disposeDock", dockId);
+            }
+            catch
+            {
+                // Ignore — circuit may already be gone.
+            }
+
+            try
+            {
+                await jsModule.DisposeAsync();
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            {
+                // Expected during circuit disconnect.
+            }
+        }
+
+        dotNetRef?.Dispose();
+    }
+}

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor.cs
@@ -690,6 +690,17 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
     }
 
     /// <summary>
+    /// Closes every closable, unpinned panel that shares a tab group with the given panel.
+    /// </summary>
+    internal Task CloseAllButPinnedPanelsInGroupAsync(string panelId)
+    {
+        var group = FindGroupContaining(panelId);
+        return group is null
+            ? Task.CompletedTask
+            : CloseManyAsync(group.PanelIds.Where(id => !pinnedPanels.Contains(id)).ToList());
+    }
+
+    /// <summary>
     /// Closes every closable panel in the given panel's tab group except the panel itself.
     /// </summary>
     internal Task CloseOtherPanelsInGroupAsync(string panelId)

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor.cs
@@ -49,6 +49,7 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
     private readonly Dictionary<string, BbDockPanel> panels = new();
     private readonly List<string> registrationOrder = new();
     private readonly HashSet<string> closedPanels = new();
+    private readonly HashSet<string> pinnedPanels = new();
     private readonly List<DockFloatingWindow> floatingWindows = new();
 
     private DockNode? layout;
@@ -474,7 +475,64 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
             target.PanelIds.Insert(insert, panelId);
         }
 
+        // Pinned tabs occupy the front of the strip: a pinned tab cannot be reordered
+        // behind an unpinned one, and an unpinned tab cannot jump ahead of a pinned one.
+        // The drop index above is honoured within whichever region the tab belongs to.
+        EnforcePinOrder(target);
+
         target.ActivePanelId = panelId;
+    }
+
+    // ----------------------------------------------------------------- Pinning
+
+    internal bool IsPinned(string panelId) => pinnedPanels.Contains(panelId);
+
+    /// <summary>
+    /// The number of pinned panels at the front of the given group's tab strip.
+    /// </summary>
+    private int PinnedCount(DockTabGroupNode group) =>
+        group.PanelIds.Count(pinnedPanels.Contains);
+
+    /// <summary>
+    /// Stable-partitions a group's tabs so pinned tabs sit at the front in pin order,
+    /// followed by unpinned tabs in their existing order.
+    /// </summary>
+    private void EnforcePinOrder(DockTabGroupNode group)
+    {
+        if (group.PanelIds.Count < 2)
+        {
+            return;
+        }
+
+        var pinnedHere = group.PanelIds.Where(pinnedPanels.Contains).ToList();
+        if (pinnedHere.Count == 0)
+        {
+            return;
+        }
+
+        var unpinnedHere = group.PanelIds.Where(id => !pinnedPanels.Contains(id));
+        group.PanelIds = pinnedHere.Concat(unpinnedHere).ToList();
+    }
+
+    /// <summary>
+    /// Toggles the pinned state of a panel. Pinning moves the tab to the back of the pinned
+    /// queue at the front of its group; unpinning returns it to the front of the unpinned tabs.
+    /// </summary>
+    internal async Task TogglePinAsync(string panelId)
+    {
+        var group = FindGroupContaining(panelId);
+        if (group is null)
+        {
+            return;
+        }
+
+        if (!pinnedPanels.Remove(panelId))
+        {
+            pinnedPanels.Add(panelId);
+        }
+
+        EnforcePinOrder(group);
+        await AfterMutateAsync();
     }
 
     private void AddPanelToDefaultLocation(string panelId)
@@ -483,6 +541,7 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
         if (existing is not null)
         {
             existing.PanelIds.Add(panelId);
+            EnforcePinOrder(existing);
             existing.ActivePanelId = panelId;
         }
         else
@@ -552,6 +611,7 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
                     {
                         RemovePanelFromLayout(panelId);
                         target.PanelIds.Add(panelId);
+                        EnforcePinOrder(target);
                     }
                     target.ActivePanelId = panelId;
                 }
@@ -607,6 +667,7 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
         }
 
         RemovePanelFromLayout(panelId);
+        pinnedPanels.Remove(panelId);
         closedPanels.Add(panelId);
 
         if (OnPanelClosed.HasDelegate)
@@ -615,6 +676,56 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
         }
 
         await AfterMutateAsync();
+    }
+
+    /// <summary>
+    /// Closes every closable panel that shares a tab group with the given panel.
+    /// </summary>
+    internal Task CloseAllPanelsInGroupAsync(string panelId)
+    {
+        var group = FindGroupContaining(panelId);
+        return group is null
+            ? Task.CompletedTask
+            : CloseManyAsync(group.PanelIds.ToList());
+    }
+
+    /// <summary>
+    /// Closes every closable panel in the given panel's tab group except the panel itself.
+    /// </summary>
+    internal Task CloseOtherPanelsInGroupAsync(string panelId)
+    {
+        var group = FindGroupContaining(panelId);
+        return group is null
+            ? Task.CompletedTask
+            : CloseManyAsync(group.PanelIds.Where(id => id != panelId).ToList());
+    }
+
+    private async Task CloseManyAsync(IReadOnlyList<string> panelIds)
+    {
+        var closedAny = false;
+
+        foreach (var id in panelIds)
+        {
+            if (!panels.TryGetValue(id, out var panel) || !panel.Closable)
+            {
+                continue;
+            }
+
+            RemovePanelFromLayout(id);
+            pinnedPanels.Remove(id);
+            closedPanels.Add(id);
+            closedAny = true;
+
+            if (OnPanelClosed.HasDelegate)
+            {
+                await OnPanelClosed.InvokeAsync(id);
+            }
+        }
+
+        if (closedAny)
+        {
+            await AfterMutateAsync();
+        }
     }
 
     /// <summary>

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockNode.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockNode.razor
@@ -1,0 +1,49 @@
+@namespace BlazorBlueprint.Components
+
+@* Recursively renders a dock layout node. Splits reuse the Resizable panel components;
+   tab groups render via BbDockTabGroup. The node is typed as object so the layout model
+   can remain internal while this component (which Razor generates as public) stays usable. *@
+
+@if (Node is DockSplitNode split)
+{
+    @* Keying by the structural signature forces a fresh Resizable group whenever the split's
+       shape changes, so the Resizable panel/handle index bookkeeping stays correct. *@
+    <BbResizablePanelGroup Direction="@Direction(split.Orientation)"
+                           Class="h-full w-full"
+                           @key="@($"split-{split.Id}-{split.Signature}")">
+        @for (var i = 0; i < split.Children.Count; i++)
+        {
+            var child = split.Children[i];
+            var size = i < split.Sizes.Count ? split.Sizes[i] : 100.0 / split.Children.Count;
+
+            if (i > 0)
+            {
+                @* Blend the divider at rest: the group borders provide the visible separation,
+                   so the handle's own line is transparent (hover/active highlight is kept). *@
+                <BbResizableHandle WithHandle="false" Class="bg-transparent hover:bg-primary/50 active:bg-primary" />
+            }
+
+            <BbResizablePanel DefaultSize="size" MinSize="8" Class="h-full" @key="@($"panel-{child.Id}")">
+                <BbDockNode Node="child" />
+            </BbResizablePanel>
+        }
+    </BbResizablePanelGroup>
+}
+else if (Node is DockTabGroupNode group)
+{
+    <BbDockTabGroup Group="group" />
+}
+
+@code {
+    /// <summary>
+    /// The layout node to render. Typed as <see cref="object"/> to keep the internal layout
+    /// model out of the public API; it is always an internal dock node.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public object Node { get; set; } = null!;
+
+    private static ResizableDirection Direction(DockOrientation orientation) =>
+        orientation == DockOrientation.Horizontal
+            ? ResizableDirection.Horizontal
+            : ResizableDirection.Vertical;
+}

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockPanel.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockPanel.razor
@@ -1,0 +1,4 @@
+@namespace BlazorBlueprint.Components
+
+@* BbDockPanel renders no markup of its own. It registers its metadata and content
+   with the parent BbDock, which renders the content inside the appropriate tab group. *@

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockPanel.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockPanel.razor.cs
@@ -53,15 +53,61 @@ public partial class BbDockPanel : ComponentBase, IDisposable
 
     /// <summary>
     /// Whether the panel can be detached into a floating window. Defaults to <c>true</c>.
+    /// Ignored when <see cref="Locked"/> is <c>true</c>.
     /// </summary>
     [Parameter]
     public bool CanFloat { get; set; } = true;
+
+    /// <summary>
+    /// When <c>true</c>, the panel is locked in place: it cannot be dragged to move, reorder or
+    /// re-dock, detached into a floating window, or closed. Useful for a mandatory region such as
+    /// a toolbox. Overrides <see cref="Closable"/> and <see cref="CanFloat"/>. Defaults to <c>false</c>.
+    /// </summary>
+    [Parameter]
+    public bool Locked { get; set; }
+
+    /// <summary>
+    /// The minimum width of the panel in pixels. Enforced while resizing a floating window and
+    /// applied as a CSS constraint when docked. <c>null</c> (the default) means no minimum.
+    /// </summary>
+    [Parameter]
+    public int? MinWidth { get; set; }
+
+    /// <summary>
+    /// The minimum height of the panel in pixels. Enforced while resizing a floating window and
+    /// applied as a CSS constraint when docked. <c>null</c> (the default) means no minimum.
+    /// </summary>
+    [Parameter]
+    public int? MinHeight { get; set; }
+
+    /// <summary>
+    /// The maximum width of the panel in pixels. Enforced while resizing a floating window and
+    /// applied as a CSS constraint when docked. <c>null</c> (the default) means no maximum.
+    /// </summary>
+    [Parameter]
+    public int? MaxWidth { get; set; }
+
+    /// <summary>
+    /// The maximum height of the panel in pixels. Enforced while resizing a floating window and
+    /// applied as a CSS constraint when docked. <c>null</c> (the default) means no maximum.
+    /// </summary>
+    [Parameter]
+    public int? MaxHeight { get; set; }
 
     /// <summary>
     /// The content rendered inside the panel when it is the active tab.
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>Whether the user may close this panel. <c>false</c> when locked.</summary>
+    internal bool CanClose => Closable && !Locked;
+
+    /// <summary>Whether the user may detach this panel into a floating window. <c>false</c> when locked.</summary>
+    internal bool CanDetach => CanFloat && !Locked;
+
+    /// <summary>Whether the user may drag this panel to move, reorder or re-dock it. <c>false</c> when locked.</summary>
+    internal bool CanMove => !Locked;
 
     private bool registered;
 

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockPanel.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockPanel.razor.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// Declares a panel that can be docked, tabbed, floated and closed inside a <see cref="BbDock"/>.
+/// The panel renders no markup itself; its <see cref="ChildContent"/> is hoisted into the
+/// active tab group by the parent dock.
+/// </summary>
+public partial class BbDockPanel : ComponentBase, IDisposable
+{
+    [CascadingParameter]
+    private BbDock? Dock { get; set; }
+
+    /// <summary>
+    /// A stable, unique identifier for the panel. Required so the dock can track the panel
+    /// across layout changes (docking, floating, closing and reopening).
+    /// </summary>
+    [Parameter, EditorRequired]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The title shown on the panel's tab.
+    /// </summary>
+    [Parameter]
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// An optional icon rendered before the title on the tab.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? Icon { get; set; }
+
+    /// <summary>
+    /// The region the panel is placed in when the dock first builds its layout.
+    /// Panels sharing a region are grouped into the same tab group.
+    /// </summary>
+    [Parameter]
+    public DockZone Region { get; set; } = DockZone.Center;
+
+    /// <summary>
+    /// Controls the relative ordering of panels when the initial layout is built.
+    /// Lower values appear first within a region.
+    /// </summary>
+    [Parameter]
+    public int Order { get; set; }
+
+    /// <summary>
+    /// Whether the panel can be closed by the user. Defaults to <c>true</c>.
+    /// </summary>
+    [Parameter]
+    public bool Closable { get; set; } = true;
+
+    /// <summary>
+    /// Whether the panel can be detached into a floating window. Defaults to <c>true</c>.
+    /// </summary>
+    [Parameter]
+    public bool CanFloat { get; set; } = true;
+
+    /// <summary>
+    /// The content rendered inside the panel when it is the active tab.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private bool registered;
+
+    /// <inheritdoc />
+    protected override void OnInitialized()
+    {
+        if (Dock is null)
+        {
+            throw new InvalidOperationException($"{nameof(BbDockPanel)} must be placed inside a {nameof(BbDock)}.");
+        }
+
+        if (string.IsNullOrWhiteSpace(Id))
+        {
+            throw new InvalidOperationException($"{nameof(BbDockPanel)} requires a non-empty {nameof(Id)}.");
+        }
+
+        Dock.RegisterPanel(this);
+        registered = true;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        if (registered)
+        {
+            Dock?.UnregisterPanel(this);
+            registered = false;
+        }
+    }
+}

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
@@ -134,17 +134,25 @@
                 var panel = contextPanel;
                 var pinned = Dock.IsPinned(panel.Id);
                 <BbContextMenuItem Disabled="@(!panel.Closable)" OnClick="() => Dock.ClosePanelAsync(panel.Id)">
-                    Close
+                    <Icon><LucideIcon Name="x" Size="16" /></Icon>
+                    <ChildContent>Close</ChildContent>
                 </BbContextMenuItem>
                 <BbContextMenuItem Disabled="@(group.PanelIds.Count <= 1)" OnClick="() => Dock.CloseOtherPanelsInGroupAsync(panel.Id)">
-                    Close Other Tabs
+                    <Icon><LucideIcon Name="list-x" Size="16" /></Icon>
+                    <ChildContent>Close Other Tabs</ChildContent>
                 </BbContextMenuItem>
-                <BbContextMenuItem OnClick="() => Dock.CloseAllPanelsInGroupAsync(panel.Id)">
-                    Close All Tabs
+                <BbContextMenuItem Disabled="@(!group.PanelIds.Any(id => !Dock.IsPinned(id) && Dock.GetPanel(id)?.Closable == true))" OnClick="() => Dock.CloseAllButPinnedPanelsInGroupAsync(panel.Id)">
+                    <Icon><LucideIcon Name="pin" Size="16" /></Icon>
+                    <ChildContent>Close All But Pinned</ChildContent>
+                </BbContextMenuItem>
+                <BbContextMenuItem Disabled="@(group.PanelIds.All(id => Dock.GetPanel(id)?.Closable != true))" OnClick="() => Dock.CloseAllPanelsInGroupAsync(panel.Id)">
+                    <Icon><LucideIcon Name="circle-x" Size="16" /></Icon>
+                    <ChildContent>Close All Tabs</ChildContent>
                 </BbContextMenuItem>
                 <BbContextMenuSeparator />
                 <BbContextMenuItem OnClick="() => Dock.TogglePinAsync(panel.Id)">
-                    @(pinned ? "Unpin Tab" : "Pin Tab")
+                    <Icon><LucideIcon Name="@(pinned ? "pin-off" : "pin")" Size="16" /></Icon>
+                    <ChildContent>@(pinned ? "Unpin Tab" : "Pin Tab")</ChildContent>
                 </BbContextMenuItem>
             }
         </BbContextMenuContent>

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
@@ -28,11 +28,8 @@
                      @oncontextmenu:stopPropagation="true">
                     @if (Dock.IsPinned(panel.Id))
                     {
-                        <span class="flex h-3.5 w-3.5 shrink-0 items-center justify-center text-primary" aria-hidden="true">
-                            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
-                                <line x1="12" y1="17" x2="12" y2="22" />
-                                <path d="M5 17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24Z" />
-                            </svg>
+                        <span class="flex h-3.5 w-3.5 shrink-0 items-center justify-center" aria-hidden="true">
+                            <LucideIcon Name="pin" Size="11" />
                         </span>
                     }
                     else if (panel.Icon is not null)
@@ -48,9 +45,7 @@
                                 @onclick="() => Dock.ClosePanelAsync(panel.Id)"
                                 @onclick:stopPropagation="true"
                                 @onpointerdown:stopPropagation="true">
-                            <svg width="11" height="11" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                <path d="M11.78 4.03a.75.75 0 0 0-1.06-1.06L7.5 6.19 4.28 2.97a.75.75 0 0 0-1.06 1.06L6.44 7.25 3.22 10.47a.75.75 0 1 0 1.06 1.06L7.5 8.31l3.22 3.22a.75.75 0 0 0 1.06-1.06L8.56 7.25l3.22-3.22Z" fill="currentColor" />
-                            </svg>
+                            <LucideIcon Name="x" Size="11" />
                         </button>
                     }
                 </div>
@@ -92,9 +87,7 @@
                                                     aria-label="@($"Close {hiddenPanel.Title}")"
                                                     @onclick="() => Dock.ClosePanelAsync(hiddenPanel.Id)"
                                                     @onclick:stopPropagation="true">
-                                                <svg width="11" height="11" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                                    <path d="M11.78 4.03a.75.75 0 0 0-1.06-1.06L7.5 6.19 4.28 2.97a.75.75 0 0 0-1.06 1.06L6.44 7.25 3.22 10.47a.75.75 0 1 0 1.06 1.06L7.5 8.31l3.22 3.22a.75.75 0 0 0 1.06-1.06L8.56 7.25l3.22-3.22Z" fill="currentColor" />
-                                                </svg>
+                                                <LucideIcon Name="x" Size="11" />
                                             </button>
                                         }
                                     </div>

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
@@ -4,7 +4,7 @@
 <div class="@RootClass" data-dock-group="@group.Id">
     <div class="@StripClass"
          @onpointerdown="HandleStripPointerDown">
-        <div class="flex min-w-0 flex-1 items-stretch overflow-x-auto bb-dock-tabstrip" data-dock-tabstrip="@group.Id">
+        <div @ref="stripRef" class="flex min-w-0 flex-1 items-stretch overflow-hidden bb-dock-tabstrip" data-dock-tabstrip="@group.Id">
             @foreach (var panelId in group.PanelIds)
             {
                 var panel = Dock.GetPanel(panelId);
@@ -14,9 +14,10 @@
                 }
 
                 var isActive = group.ActivePanelId == panelId;
+                var isHidden = overflowPanelIds.Contains(panelId);
                 <div role="tab"
                      aria-selected="@(isActive ? "true" : "false")"
-                     class="@TabClass(isActive)"
+                     class="@TabClass(isActive, isHidden)"
                      title="@panel.Title"
                      data-dock-tab="@panel.Id"
                      @onpointerdown="e => HandleTabPointerDown(panel, e)"
@@ -56,16 +57,63 @@
             }
         </div>
 
-        @if (!IsFloating)
+        @if (overflowPanelIds.Count > 0 || !IsFloating)
         {
-            <div class="flex shrink-0 items-center gap-0.5 px-1">
-                <button type="button"
-                        class="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
-                        aria-label="@(IsMaximized ? "Restore panel group" : "Maximize panel group")"
-                        @onclick="() => Dock.ToggleMaximize(group)"
-                        @onpointerdown:stopPropagation="true">
-                    <LucideIcon Name="@(IsMaximized ? "minimize-2" : "maximize-2")" Size="14" />
-                </button>
+            <div class="flex shrink-0 items-center gap-0.5 px-1" @onpointerdown:stopPropagation="true">
+                @if (overflowPanelIds.Count > 0)
+                {
+                    <BbDropdownMenu>
+                        <BbDropdownMenuTrigger AsChild="false"
+                                               Class="inline-flex h-6 items-center justify-center gap-0.5 rounded-sm px-1 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+                                               aria-label="@($"Show {overflowPanelIds.Count} hidden tab(s)")">
+                            <LucideIcon Name="ellipsis" Size="14" />
+                            <span class="text-[10px] font-medium leading-none">@overflowPanelIds.Count</span>
+                        </BbDropdownMenuTrigger>
+                        <BbDropdownMenuContent Align="PopoverAlign.End" Class="min-w-[10rem] max-w-[16rem]">
+                            @foreach (var hiddenId in overflowPanelIds)
+                            {
+                                var hiddenPanel = Dock.GetPanel(hiddenId);
+                                if (hiddenPanel is null)
+                                {
+                                    continue;
+                                }
+
+                                <BbDropdownMenuItem Class="pr-1" OnClick="() => Dock.ActivatePanel(group, hiddenPanel.Id)">
+                                    <div class="flex w-full items-center gap-2">
+                                        @if (hiddenPanel.Icon is not null)
+                                        {
+                                            <span class="flex h-3.5 w-3.5 shrink-0 items-center justify-center">@hiddenPanel.Icon</span>
+                                        }
+                                        <span class="truncate">@hiddenPanel.Title</span>
+                                        @if (hiddenPanel.Closable)
+                                        {
+                                            <button type="button"
+                                                    class="ml-auto inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+                                                    aria-label="@($"Close {hiddenPanel.Title}")"
+                                                    @onclick="() => Dock.ClosePanelAsync(hiddenPanel.Id)"
+                                                    @onclick:stopPropagation="true">
+                                                <svg width="11" height="11" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                                    <path d="M11.78 4.03a.75.75 0 0 0-1.06-1.06L7.5 6.19 4.28 2.97a.75.75 0 0 0-1.06 1.06L6.44 7.25 3.22 10.47a.75.75 0 1 0 1.06 1.06L7.5 8.31l3.22 3.22a.75.75 0 0 0 1.06-1.06L8.56 7.25l3.22-3.22Z" fill="currentColor" />
+                                                </svg>
+                                            </button>
+                                        }
+                                    </div>
+                                </BbDropdownMenuItem>
+                            }
+                        </BbDropdownMenuContent>
+                    </BbDropdownMenu>
+                }
+
+                @if (!IsFloating)
+                {
+                    <button type="button"
+                            class="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+                            aria-label="@(IsMaximized ? "Restore panel group" : "Maximize panel group")"
+                            @onclick="() => Dock.ToggleMaximize(group)"
+                            @onpointerdown:stopPropagation="true">
+                        <LucideIcon Name="@(IsMaximized ? "minimize-2" : "maximize-2")" Size="14" />
+                    </button>
+                }
             </div>
         }
     </div>

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
@@ -1,5 +1,6 @@
 @namespace BlazorBlueprint.Components
 @using BlazorBlueprint.Icons.Lucide.Components
+@inject IBbLocalizer Localizer
 
 <div class="@RootClass" data-dock-group="@group.Id">
     <div class="@StripClass"
@@ -41,8 +42,8 @@
                     {
                         <button type="button"
                                 class="@CloseClass()"
-                                aria-label="@($"Close {panel.Title}")"
-                                title="@($"Close {panel.Title}")"
+                                aria-label="@Localizer["Dock.CloseTab", panel.Title]"
+                                title="@Localizer["Dock.CloseTab", panel.Title]"
                                 @onclick="() => Dock.ClosePanelAsync(panel.Id)"
                                 @onclick:stopPropagation="true"
                                 @onpointerdown:stopPropagation="true">
@@ -61,8 +62,8 @@
                     <BbDropdownMenu>
                         <BbDropdownMenuTrigger AsChild="false"
                                                Class="inline-flex h-6 items-center justify-center gap-0.5 rounded-sm px-1 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
-                                               aria-label="@($"Show {overflowPanelIds.Count} hidden tab(s)")"
-                                               title="@($"Show {overflowPanelIds.Count} hidden tab(s)")">
+                                               aria-label="@Localizer["Dock.ShowHiddenTabs", overflowPanelIds.Count]"
+                                               title="@Localizer["Dock.ShowHiddenTabs", overflowPanelIds.Count]">
                             <LucideIcon Name="ellipsis" Size="14" />
                             <span class="text-[10px] font-medium leading-none">@overflowPanelIds.Count</span>
                         </BbDropdownMenuTrigger>
@@ -86,8 +87,8 @@
                                         {
                                             <button type="button"
                                                     class="ml-auto inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
-                                                    aria-label="@($"Close {hiddenPanel.Title}")"
-                                                    title="@($"Close {hiddenPanel.Title}")"
+                                                    aria-label="@Localizer["Dock.CloseTab", hiddenPanel.Title]"
+                                                    title="@Localizer["Dock.CloseTab", hiddenPanel.Title]"
                                                     @onclick="() => Dock.ClosePanelAsync(hiddenPanel.Id)"
                                                     @onclick:stopPropagation="true">
                                                 <LucideIcon Name="x" Size="11" />
@@ -104,8 +105,8 @@
                 {
                     <button type="button"
                             class="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
-                            aria-label="@(IsMaximized ? "Restore panel group" : "Maximize panel group")"
-                            title="@(IsMaximized ? "Restore panel group" : "Maximize panel group")"
+                            aria-label="@(IsMaximized ? Localizer["Dock.RestorePanelGroup"] : Localizer["Dock.MaximizePanelGroup"])"
+                            title="@(IsMaximized ? Localizer["Dock.RestorePanelGroup"] : Localizer["Dock.MaximizePanelGroup"])"
                             @onclick="() => Dock.ToggleMaximize(group)"
                             @onpointerdown:stopPropagation="true">
                         <LucideIcon Name="@(IsMaximized ? "minimize-2" : "maximize-2")" Size="14" />
@@ -139,24 +140,24 @@
                 var pinned = Dock.IsPinned(panel.Id);
                 <BbContextMenuItem Disabled="@(!panel.Closable)" OnClick="() => Dock.ClosePanelAsync(panel.Id)">
                     <Icon><LucideIcon Name="x" Size="16" /></Icon>
-                    <ChildContent>Close</ChildContent>
+                    <ChildContent>@Localizer["Dock.Close"]</ChildContent>
                 </BbContextMenuItem>
                 <BbContextMenuItem Disabled="@(group.PanelIds.Count <= 1)" OnClick="() => Dock.CloseOtherPanelsInGroupAsync(panel.Id)">
                     <Icon><LucideIcon Name="list-x" Size="16" /></Icon>
-                    <ChildContent>Close Other Tabs</ChildContent>
+                    <ChildContent>@Localizer["Dock.CloseOtherTabs"]</ChildContent>
                 </BbContextMenuItem>
                 <BbContextMenuItem Disabled="@(!group.PanelIds.Any(id => !Dock.IsPinned(id) && Dock.GetPanel(id)?.Closable == true))" OnClick="() => Dock.CloseAllButPinnedPanelsInGroupAsync(panel.Id)">
                     <Icon><LucideIcon Name="pin" Size="16" /></Icon>
-                    <ChildContent>Close All But Pinned</ChildContent>
+                    <ChildContent>@Localizer["Dock.CloseAllButPinned"]</ChildContent>
                 </BbContextMenuItem>
                 <BbContextMenuItem Disabled="@(group.PanelIds.All(id => Dock.GetPanel(id)?.Closable != true))" OnClick="() => Dock.CloseAllPanelsInGroupAsync(panel.Id)">
                     <Icon><LucideIcon Name="circle-x" Size="16" /></Icon>
-                    <ChildContent>Close All Tabs</ChildContent>
+                    <ChildContent>@Localizer["Dock.CloseAllTabs"]</ChildContent>
                 </BbContextMenuItem>
                 <BbContextMenuSeparator />
                 <BbContextMenuItem OnClick="() => Dock.TogglePinAsync(panel.Id)">
                     <Icon><LucideIcon Name="@(pinned ? "pin-off" : "pin")" Size="16" /></Icon>
-                    <ChildContent>@(pinned ? "Unpin Tab" : "Pin Tab")</ChildContent>
+                    <ChildContent>@(pinned ? Localizer["Dock.UnpinTab"] : Localizer["Dock.PinTab"])</ChildContent>
                 </BbContextMenuItem>
             }
         </BbContextMenuContent>

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
@@ -26,21 +26,21 @@
                      @oncontextmenu="e => HandleTabContextMenu(panel, e)"
                      @oncontextmenu:preventDefault="true"
                      @oncontextmenu:stopPropagation="true">
+                    @if (panel.Icon is not null)
+                    {
+                        <span class="flex h-3.5 w-3.5 shrink-0 items-center justify-center">@panel.Icon</span>
+                    }
+                    <span class="truncate">@panel.Title</span>
                     @if (Dock.IsPinned(panel.Id))
                     {
                         <span class="flex h-3.5 w-3.5 shrink-0 items-center justify-center" aria-hidden="true">
                             <LucideIcon Name="pin" Size="11" />
                         </span>
                     }
-                    else if (panel.Icon is not null)
-                    {
-                        <span class="flex h-3.5 w-3.5 shrink-0 items-center justify-center">@panel.Icon</span>
-                    }
-                    <span class="truncate">@panel.Title</span>
                     @if (panel.Closable)
                     {
                         <button type="button"
-                                class="@CloseClass(isActive)"
+                                class="@CloseClass()"
                                 aria-label="@($"Close {panel.Title}")"
                                 title="@($"Close {panel.Title}")"
                                 @onclick="() => Dock.ClosePanelAsync(panel.Id)"

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
@@ -42,6 +42,7 @@
                         <button type="button"
                                 class="@CloseClass(isActive)"
                                 aria-label="@($"Close {panel.Title}")"
+                                title="@($"Close {panel.Title}")"
                                 @onclick="() => Dock.ClosePanelAsync(panel.Id)"
                                 @onclick:stopPropagation="true"
                                 @onpointerdown:stopPropagation="true">
@@ -60,7 +61,8 @@
                     <BbDropdownMenu>
                         <BbDropdownMenuTrigger AsChild="false"
                                                Class="inline-flex h-6 items-center justify-center gap-0.5 rounded-sm px-1 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
-                                               aria-label="@($"Show {overflowPanelIds.Count} hidden tab(s)")">
+                                               aria-label="@($"Show {overflowPanelIds.Count} hidden tab(s)")"
+                                               title="@($"Show {overflowPanelIds.Count} hidden tab(s)")">
                             <LucideIcon Name="ellipsis" Size="14" />
                             <span class="text-[10px] font-medium leading-none">@overflowPanelIds.Count</span>
                         </BbDropdownMenuTrigger>
@@ -85,6 +87,7 @@
                                             <button type="button"
                                                     class="ml-auto inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
                                                     aria-label="@($"Close {hiddenPanel.Title}")"
+                                                    title="@($"Close {hiddenPanel.Title}")"
                                                     @onclick="() => Dock.ClosePanelAsync(hiddenPanel.Id)"
                                                     @onclick:stopPropagation="true">
                                                 <LucideIcon Name="x" Size="11" />
@@ -102,6 +105,7 @@
                     <button type="button"
                             class="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
                             aria-label="@(IsMaximized ? "Restore panel group" : "Maximize panel group")"
+                            title="@(IsMaximized ? "Restore panel group" : "Maximize panel group")"
                             @onclick="() => Dock.ToggleMaximize(group)"
                             @onpointerdown:stopPropagation="true">
                         <LucideIcon Name="@(IsMaximized ? "minimize-2" : "maximize-2")" Size="14" />

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
@@ -2,11 +2,15 @@
 @using BlazorBlueprint.Icons.Lucide.Components
 @inject IBbLocalizer Localizer
 
-<div class="@RootClass" style="@ConstraintStyle" data-dock-group="@group.Id">
+<div class="@RootClass" style="@ConstraintStyle" data-dock-group="@GroupNode.Id">
     <div class="@StripClass"
          @onpointerdown="HandleStripPointerDown">
-        <div @ref="stripRef" class="flex min-w-0 flex-1 items-stretch overflow-hidden bb-dock-tabstrip" data-dock-tabstrip="@group.Id">
-            @foreach (var panelId in group.PanelIds)
+        <div @ref="stripRef"
+             role="tablist"
+             aria-orientation="horizontal"
+             class="flex min-w-0 flex-1 items-stretch overflow-hidden bb-dock-tabstrip"
+             data-dock-tabstrip="@GroupNode.Id">
+            @foreach (var panelId in GroupNode.PanelIds)
             {
                 var panel = Dock.GetPanel(panelId);
                 if (panel is null)
@@ -14,16 +18,21 @@
                     continue;
                 }
 
-                var isActive = group.ActivePanelId == panelId;
+                var isActive = GroupNode.ActivePanelId == panelId;
                 var isHidden = overflowPanelIds.Contains(panelId);
                 <div role="tab"
+                     id="@TabDomId(panel.Id)"
                      aria-selected="@(isActive ? "true" : "false")"
+                     aria-controls="@PanelDomId(panel.Id)"
+                     tabindex="@(isActive ? 0 : -1)"
                      class="@TabClass(isActive, isHidden)"
                      title="@panel.Title"
                      data-dock-tab="@panel.Id"
+                     @ref="tabRefs[panel.Id]"
+                     @onkeydown="e => HandleTabKeyDown(panel, e)"
                      @onpointerdown="e => HandleTabPointerDown(panel, e)"
                      @onpointerdown:stopPropagation="true"
-                     @onclick="() => Dock.ActivatePanel(group, panel.Id)"
+                     @onclick="() => Dock.ActivatePanel(GroupNode, panel.Id)"
                      @oncontextmenu="e => HandleTabContextMenu(panel, e)"
                      @oncontextmenu:preventDefault="true"
                      @oncontextmenu:stopPropagation="true">
@@ -76,7 +85,7 @@
                                     continue;
                                 }
 
-                                <BbDropdownMenuItem Class="pr-1" OnClick="() => Dock.ActivatePanel(group, hiddenPanel.Id)">
+                                <BbDropdownMenuItem Class="pr-1" OnClick="() => Dock.ActivatePanel(GroupNode, hiddenPanel.Id)">
                                     <div class="flex w-full items-center gap-2">
                                         @if (hiddenPanel.Icon is not null)
                                         {
@@ -107,7 +116,7 @@
                             class="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
                             aria-label="@(IsMaximized ? Localizer["Dock.RestorePanelGroup"] : Localizer["Dock.MaximizePanelGroup"])"
                             title="@(IsMaximized ? Localizer["Dock.RestorePanelGroup"] : Localizer["Dock.MaximizePanelGroup"])"
-                            @onclick="() => Dock.ToggleMaximize(group)"
+                            @onclick="() => Dock.ToggleMaximize(GroupNode)"
                             @onpointerdown:stopPropagation="true">
                         <LucideIcon Name="@(IsMaximized ? "minimize-2" : "maximize-2")" Size="14" />
                     </button>
@@ -117,7 +126,7 @@
     </div>
 
     <div class="relative min-h-0 flex-1 overflow-auto bg-background">
-        @foreach (var panelId in group.PanelIds)
+        @foreach (var panelId in GroupNode.PanelIds)
         {
             var panel = Dock.GetPanel(panelId);
             if (panel is null)
@@ -125,8 +134,13 @@
                 continue;
             }
 
-            var isActive = group.ActivePanelId == panelId;
-            <div class="@(isActive ? "h-full" : "hidden")" @key="panelId">
+            var isActive = GroupNode.ActivePanelId == panelId;
+            <div role="tabpanel"
+                 id="@PanelDomId(panelId)"
+                 aria-labelledby="@TabDomId(panelId)"
+                 tabindex="0"
+                 class="@(isActive ? "h-full" : "hidden")"
+                 @key="panelId">
                 @panel.ChildContent
             </div>
         }
@@ -142,15 +156,15 @@
                     <Icon><LucideIcon Name="x" Size="16" /></Icon>
                     <ChildContent>@Localizer["Dock.Close"]</ChildContent>
                 </BbContextMenuItem>
-                <BbContextMenuItem Disabled="@(!group.PanelIds.Any(id => id != panel.Id && Dock.GetPanel(id)?.CanClose == true))" OnClick="() => Dock.CloseOtherPanelsInGroupAsync(panel.Id)">
+                <BbContextMenuItem Disabled="@(!GroupNode.PanelIds.Any(id => id != panel.Id && Dock.GetPanel(id)?.CanClose == true))" OnClick="() => Dock.CloseOtherPanelsInGroupAsync(panel.Id)">
                     <Icon><LucideIcon Name="list-x" Size="16" /></Icon>
                     <ChildContent>@Localizer["Dock.CloseOtherTabs"]</ChildContent>
                 </BbContextMenuItem>
-                <BbContextMenuItem Disabled="@(!group.PanelIds.Any(id => !Dock.IsPinned(id) && Dock.GetPanel(id)?.CanClose == true))" OnClick="() => Dock.CloseAllButPinnedPanelsInGroupAsync(panel.Id)">
+                <BbContextMenuItem Disabled="@(!GroupNode.PanelIds.Any(id => !Dock.IsPinned(id) && Dock.GetPanel(id)?.CanClose == true))" OnClick="() => Dock.CloseAllButPinnedPanelsInGroupAsync(panel.Id)">
                     <Icon><LucideIcon Name="pin" Size="16" /></Icon>
                     <ChildContent>@Localizer["Dock.CloseAllButPinned"]</ChildContent>
                 </BbContextMenuItem>
-                <BbContextMenuItem Disabled="@(group.PanelIds.All(id => Dock.GetPanel(id)?.CanClose != true))" OnClick="() => Dock.CloseAllPanelsInGroupAsync(panel.Id)">
+                <BbContextMenuItem Disabled="@(GroupNode.PanelIds.All(id => Dock.GetPanel(id)?.CanClose != true))" OnClick="() => Dock.CloseAllPanelsInGroupAsync(panel.Id)">
                     <Icon><LucideIcon Name="circle-x" Size="16" /></Icon>
                     <ChildContent>@Localizer["Dock.CloseAllTabs"]</ChildContent>
                 </BbContextMenuItem>

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
@@ -1,4 +1,5 @@
 @namespace BlazorBlueprint.Components
+@using BlazorBlueprint.Icons.Lucide.Components
 
 <div class="@RootClass" data-dock-group="@group.Id">
     <div class="@StripClass"
@@ -20,8 +21,20 @@
                      data-dock-tab="@panel.Id"
                      @onpointerdown="e => HandleTabPointerDown(panel, e)"
                      @onpointerdown:stopPropagation="true"
-                     @onclick="() => Dock.ActivatePanel(group, panel.Id)">
-                    @if (panel.Icon is not null)
+                     @onclick="() => Dock.ActivatePanel(group, panel.Id)"
+                     @oncontextmenu="e => HandleTabContextMenu(panel, e)"
+                     @oncontextmenu:preventDefault="true"
+                     @oncontextmenu:stopPropagation="true">
+                    @if (Dock.IsPinned(panel.Id))
+                    {
+                        <span class="flex h-3.5 w-3.5 shrink-0 items-center justify-center text-primary" aria-hidden="true">
+                            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                                <line x1="12" y1="17" x2="12" y2="22" />
+                                <path d="M5 17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24Z" />
+                            </svg>
+                        </span>
+                    }
+                    else if (panel.Icon is not null)
                     {
                         <span class="flex h-3.5 w-3.5 shrink-0 items-center justify-center">@panel.Icon</span>
                     }
@@ -45,25 +58,13 @@
 
         @if (!IsFloating)
         {
-            <div class="flex shrink-0 items-center gap-0.5 border-l border-border/50 px-1">
+            <div class="flex shrink-0 items-center gap-0.5 px-1">
                 <button type="button"
                         class="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
                         aria-label="@(IsMaximized ? "Restore panel group" : "Maximize panel group")"
                         @onclick="() => Dock.ToggleMaximize(group)"
                         @onpointerdown:stopPropagation="true">
-                    @if (IsMaximized)
-                    {
-                        <svg width="14" height="14" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                            <path d="M5.5 9.5h-3v-1h2v-2h1v3Zm4-4h-1v-3h1v2h2v1h-2Z" fill="currentColor" />
-                            <rect x="1.5" y="1.5" width="12" height="12" rx="1.5" stroke="currentColor" fill="none" />
-                        </svg>
-                    }
-                    else
-                    {
-                        <svg width="14" height="14" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                            <rect x="2.5" y="2.5" width="10" height="10" rx="1.5" stroke="currentColor" fill="none" />
-                        </svg>
-                    }
+                    <LucideIcon Name="@(IsMaximized ? "minimize-2" : "maximize-2")" Size="14" />
                 </button>
             </div>
         }
@@ -84,4 +85,27 @@
             </div>
         }
     </div>
+
+    <BbContextMenu @ref="tabMenu">
+        <BbContextMenuContent>
+            @if (contextPanel is not null)
+            {
+                var panel = contextPanel;
+                var pinned = Dock.IsPinned(panel.Id);
+                <BbContextMenuItem Disabled="@(!panel.Closable)" OnClick="() => Dock.ClosePanelAsync(panel.Id)">
+                    Close
+                </BbContextMenuItem>
+                <BbContextMenuItem Disabled="@(group.PanelIds.Count <= 1)" OnClick="() => Dock.CloseOtherPanelsInGroupAsync(panel.Id)">
+                    Close Other Tabs
+                </BbContextMenuItem>
+                <BbContextMenuItem OnClick="() => Dock.CloseAllPanelsInGroupAsync(panel.Id)">
+                    Close All Tabs
+                </BbContextMenuItem>
+                <BbContextMenuSeparator />
+                <BbContextMenuItem OnClick="() => Dock.TogglePinAsync(panel.Id)">
+                    @(pinned ? "Unpin Tab" : "Pin Tab")
+                </BbContextMenuItem>
+            }
+        </BbContextMenuContent>
+    </BbContextMenu>
 </div>

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
@@ -2,7 +2,7 @@
 @using BlazorBlueprint.Icons.Lucide.Components
 @inject IBbLocalizer Localizer
 
-<div class="@RootClass" data-dock-group="@group.Id">
+<div class="@RootClass" style="@ConstraintStyle" data-dock-group="@group.Id">
     <div class="@StripClass"
          @onpointerdown="HandleStripPointerDown">
         <div @ref="stripRef" class="flex min-w-0 flex-1 items-stretch overflow-hidden bb-dock-tabstrip" data-dock-tabstrip="@group.Id">
@@ -38,7 +38,7 @@
                             <LucideIcon Name="pin" Size="11" />
                         </span>
                     }
-                    @if (panel.Closable)
+                    @if (panel.CanClose)
                     {
                         <button type="button"
                                 class="@CloseClass()"
@@ -83,7 +83,7 @@
                                             <span class="flex h-3.5 w-3.5 shrink-0 items-center justify-center">@hiddenPanel.Icon</span>
                                         }
                                         <span class="truncate">@hiddenPanel.Title</span>
-                                        @if (hiddenPanel.Closable)
+                                        @if (hiddenPanel.CanClose)
                                         {
                                             <button type="button"
                                                     class="ml-auto inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
@@ -138,19 +138,19 @@
             {
                 var panel = contextPanel;
                 var pinned = Dock.IsPinned(panel.Id);
-                <BbContextMenuItem Disabled="@(!panel.Closable)" OnClick="() => Dock.ClosePanelAsync(panel.Id)">
+                <BbContextMenuItem Disabled="@(!panel.CanClose)" OnClick="() => Dock.ClosePanelAsync(panel.Id)">
                     <Icon><LucideIcon Name="x" Size="16" /></Icon>
                     <ChildContent>@Localizer["Dock.Close"]</ChildContent>
                 </BbContextMenuItem>
-                <BbContextMenuItem Disabled="@(group.PanelIds.Count <= 1)" OnClick="() => Dock.CloseOtherPanelsInGroupAsync(panel.Id)">
+                <BbContextMenuItem Disabled="@(!group.PanelIds.Any(id => id != panel.Id && Dock.GetPanel(id)?.CanClose == true))" OnClick="() => Dock.CloseOtherPanelsInGroupAsync(panel.Id)">
                     <Icon><LucideIcon Name="list-x" Size="16" /></Icon>
                     <ChildContent>@Localizer["Dock.CloseOtherTabs"]</ChildContent>
                 </BbContextMenuItem>
-                <BbContextMenuItem Disabled="@(!group.PanelIds.Any(id => !Dock.IsPinned(id) && Dock.GetPanel(id)?.Closable == true))" OnClick="() => Dock.CloseAllButPinnedPanelsInGroupAsync(panel.Id)">
+                <BbContextMenuItem Disabled="@(!group.PanelIds.Any(id => !Dock.IsPinned(id) && Dock.GetPanel(id)?.CanClose == true))" OnClick="() => Dock.CloseAllButPinnedPanelsInGroupAsync(panel.Id)">
                     <Icon><LucideIcon Name="pin" Size="16" /></Icon>
                     <ChildContent>@Localizer["Dock.CloseAllButPinned"]</ChildContent>
                 </BbContextMenuItem>
-                <BbContextMenuItem Disabled="@(group.PanelIds.All(id => Dock.GetPanel(id)?.Closable != true))" OnClick="() => Dock.CloseAllPanelsInGroupAsync(panel.Id)">
+                <BbContextMenuItem Disabled="@(group.PanelIds.All(id => Dock.GetPanel(id)?.CanClose != true))" OnClick="() => Dock.CloseAllPanelsInGroupAsync(panel.Id)">
                     <Icon><LucideIcon Name="circle-x" Size="16" /></Icon>
                     <ChildContent>@Localizer["Dock.CloseAllTabs"]</ChildContent>
                 </BbContextMenuItem>

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor
@@ -1,0 +1,87 @@
+@namespace BlazorBlueprint.Components
+
+<div class="@RootClass" data-dock-group="@group.Id">
+    <div class="@StripClass"
+         @onpointerdown="HandleStripPointerDown">
+        <div class="flex min-w-0 flex-1 items-stretch overflow-x-auto bb-dock-tabstrip" data-dock-tabstrip="@group.Id">
+            @foreach (var panelId in group.PanelIds)
+            {
+                var panel = Dock.GetPanel(panelId);
+                if (panel is null)
+                {
+                    continue;
+                }
+
+                var isActive = group.ActivePanelId == panelId;
+                <div role="tab"
+                     aria-selected="@(isActive ? "true" : "false")"
+                     class="@TabClass(isActive)"
+                     title="@panel.Title"
+                     data-dock-tab="@panel.Id"
+                     @onpointerdown="e => HandleTabPointerDown(panel, e)"
+                     @onpointerdown:stopPropagation="true"
+                     @onclick="() => Dock.ActivatePanel(group, panel.Id)">
+                    @if (panel.Icon is not null)
+                    {
+                        <span class="flex h-3.5 w-3.5 shrink-0 items-center justify-center">@panel.Icon</span>
+                    }
+                    <span class="truncate">@panel.Title</span>
+                    @if (panel.Closable)
+                    {
+                        <button type="button"
+                                class="@CloseClass(isActive)"
+                                aria-label="@($"Close {panel.Title}")"
+                                @onclick="() => Dock.ClosePanelAsync(panel.Id)"
+                                @onclick:stopPropagation="true"
+                                @onpointerdown:stopPropagation="true">
+                            <svg width="11" height="11" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                <path d="M11.78 4.03a.75.75 0 0 0-1.06-1.06L7.5 6.19 4.28 2.97a.75.75 0 0 0-1.06 1.06L6.44 7.25 3.22 10.47a.75.75 0 1 0 1.06 1.06L7.5 8.31l3.22 3.22a.75.75 0 0 0 1.06-1.06L8.56 7.25l3.22-3.22Z" fill="currentColor" />
+                            </svg>
+                        </button>
+                    }
+                </div>
+            }
+        </div>
+
+        @if (!IsFloating)
+        {
+            <div class="flex shrink-0 items-center gap-0.5 border-l border-border/50 px-1">
+                <button type="button"
+                        class="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+                        aria-label="@(IsMaximized ? "Restore panel group" : "Maximize panel group")"
+                        @onclick="() => Dock.ToggleMaximize(group)"
+                        @onpointerdown:stopPropagation="true">
+                    @if (IsMaximized)
+                    {
+                        <svg width="14" height="14" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                            <path d="M5.5 9.5h-3v-1h2v-2h1v3Zm4-4h-1v-3h1v2h2v1h-2Z" fill="currentColor" />
+                            <rect x="1.5" y="1.5" width="12" height="12" rx="1.5" stroke="currentColor" fill="none" />
+                        </svg>
+                    }
+                    else
+                    {
+                        <svg width="14" height="14" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                            <rect x="2.5" y="2.5" width="10" height="10" rx="1.5" stroke="currentColor" fill="none" />
+                        </svg>
+                    }
+                </button>
+            </div>
+        }
+    </div>
+
+    <div class="relative min-h-0 flex-1 overflow-auto bg-background">
+        @foreach (var panelId in group.PanelIds)
+        {
+            var panel = Dock.GetPanel(panelId);
+            if (panel is null)
+            {
+                continue;
+            }
+
+            var isActive = group.ActivePanelId == panelId;
+            <div class="@(isActive ? "h-full" : "hidden")" @key="panelId">
+                @panel.ChildContent
+            </div>
+        }
+    </div>
+</div>

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor.cs
@@ -30,11 +30,12 @@ public partial class BbDockTabGroup : ComponentBase, IAsyncDisposable
     [Parameter]
     public string? FloatingWindowId { get; set; }
 
-    private DockTabGroupNode group => (DockTabGroupNode)Group;
+    private DockTabGroupNode GroupNode => (DockTabGroupNode)Group;
 
     private BbContextMenu? tabMenu;
     private BbDockPanel? contextPanel;
 
+    private readonly Dictionary<string, ElementReference> tabRefs = new();
     private ElementReference stripRef;
     private IJSObjectReference? jsModule;
     private DotNetObjectReference<BbDockTabGroup>? dotNetRef;
@@ -45,11 +46,11 @@ public partial class BbDockTabGroup : ComponentBase, IAsyncDisposable
 
     private bool IsFloating => FloatingWindowId is not null;
 
-    private bool IsMaximized => Dock is not null && Dock.IsMaximized(group);
+    private bool IsMaximized => Dock is not null && Dock.IsMaximized(GroupNode);
 
     // Changes whenever the set, order or active state of tabs changes, so the strip is
     // re-measured for overflow even when its own size did not change.
-    private string TabSignature => $"{string.Join('|', group.PanelIds)}#{group.ActivePanelId}";
+    private string TabSignature => $"{string.Join('|', GroupNode.PanelIds)}#{GroupNode.ActivePanelId}";
 
     /// <inheritdoc />
     protected override void OnInitialized()
@@ -75,7 +76,7 @@ public partial class BbDockTabGroup : ComponentBase, IAsyncDisposable
 
             // (Re)attach the overflow observer whenever this instance starts rendering a
             // different tab group (Blazor reuses component instances across layout changes).
-            if (observedGroupId != group.Id)
+            if (observedGroupId != GroupNode.Id)
             {
                 if (observedGroupId is not null)
                 {
@@ -83,15 +84,15 @@ public partial class BbDockTabGroup : ComponentBase, IAsyncDisposable
                 }
 
                 dotNetRef ??= DotNetObjectReference.Create(this);
-                observedGroupId = group.Id;
+                observedGroupId = GroupNode.Id;
                 lastTabSignature = TabSignature;
-                await jsModule.InvokeVoidAsync("initTabOverflow", group.Id, stripRef, dotNetRef);
+                await jsModule.InvokeVoidAsync("initTabOverflow", GroupNode.Id, stripRef, dotNetRef);
             }
             else if (lastTabSignature != TabSignature)
             {
                 // Tabs were added, removed or reordered: re-measure without a size change.
                 lastTabSignature = TabSignature;
-                await jsModule.InvokeVoidAsync("remeasureTabOverflow", group.Id);
+                await jsModule.InvokeVoidAsync("remeasureTabOverflow", GroupNode.Id);
             }
         }
         catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
@@ -117,11 +118,92 @@ public partial class BbDockTabGroup : ComponentBase, IAsyncDisposable
             return;
         }
 
-        var next = ids.Where(id => group.PanelIds.Contains(id)).ToList();
+        var next = ids.Where(id => GroupNode.PanelIds.Contains(id)).ToList();
         if (!next.SequenceEqual(overflowPanelIds))
         {
             overflowPanelIds = next;
             StateHasChanged();
+        }
+    }
+
+    // Stable DOM ids so each tab and its panel can be linked with aria-controls /
+    // aria-labelledby per the WAI-ARIA tabs pattern.
+    private string TabDomId(string panelId) => $"bb-dock-tab-{GroupNode.Id}-{panelId}";
+
+    private string PanelDomId(string panelId) => $"bb-dock-panel-{GroupNode.Id}-{panelId}";
+
+    // The tabs currently reachable with the keyboard, in strip order. Overflowed tabs are
+    // display:none and surfaced through the overflow dropdown instead, so they are skipped.
+    private List<string> VisibleTabIds() =>
+        GroupNode.PanelIds
+            .Where(id => !overflowPanelIds.Contains(id) && Dock.GetPanel(id) is not null)
+            .ToList();
+
+    private async Task HandleTabKeyDown(BbDockPanel panel, KeyboardEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case "Enter" or " ":
+                Dock.ActivatePanel(GroupNode, panel.Id);
+                break;
+
+            case "ArrowLeft":
+                await FocusAdjacentTabAsync(panel.Id, -1);
+                break;
+
+            case "ArrowRight":
+                await FocusAdjacentTabAsync(panel.Id, 1);
+                break;
+
+            case "Home":
+            {
+                var visible = VisibleTabIds();
+                if (visible.Count > 0)
+                {
+                    await FocusTabAsync(visible[0]);
+                }
+                break;
+            }
+
+            case "End":
+            {
+                var visible = VisibleTabIds();
+                if (visible.Count > 0)
+                {
+                    await FocusTabAsync(visible[^1]);
+                }
+                break;
+            }
+        }
+    }
+
+    private async Task FocusAdjacentTabAsync(string panelId, int direction)
+    {
+        var visible = VisibleTabIds();
+        var current = visible.IndexOf(panelId);
+        if (current < 0 || visible.Count < 2)
+        {
+            return;
+        }
+
+        var next = (current + direction + visible.Count) % visible.Count;
+        await FocusTabAsync(visible[next]);
+    }
+
+    private async Task FocusTabAsync(string panelId)
+    {
+        if (!tabRefs.TryGetValue(panelId, out var el))
+        {
+            return;
+        }
+
+        try
+        {
+            await el.FocusAsync();
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
+        {
+            // Element may not be rendered yet or the circuit disconnected.
         }
     }
 
@@ -168,7 +250,7 @@ public partial class BbDockTabGroup : ComponentBase, IAsyncDisposable
 
     // Pixel min/max size constraints declared by the group's panels. The floating window wrapper
     // already sizes itself from these, so the constraint style only applies to docked groups.
-    private string? ConstraintStyle => IsFloating ? null : Dock.GroupConstraintStyle(group);
+    private string? ConstraintStyle => IsFloating ? null : Dock.GroupConstraintStyle(GroupNode);
 
     private string StripClass => ClassNames.cn(
         "flex h-8 shrink-0 items-stretch border-b border-border/60 bg-muted/50",

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor.cs
@@ -171,9 +171,8 @@ public partial class BbDockTabGroup : ComponentBase, IAsyncDisposable
             ? "z-10 -mb-px border-b border-background bg-background text-foreground after:absolute after:inset-x-0 after:top-0 after:h-[2px] after:bg-primary"
             : "bg-transparent text-muted-foreground hover:bg-background/50 hover:text-foreground");
 
-    private static string CloseClass(bool isActive) => ClassNames.cn(
-        "ml-auto inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm transition-opacity hover:bg-foreground/10 hover:!opacity-100",
-        isActive ? "opacity-60" : "opacity-0 group-hover/tab:opacity-60");
+    private static string CloseClass() => ClassNames.cn(
+        "ml-auto inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm opacity-60 transition-opacity hover:bg-foreground/10 hover:!opacity-100");
 
     /// <inheritdoc />
     public async ValueTask DisposeAsync()

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor.cs
@@ -133,6 +133,12 @@ public partial class BbDockTabGroup : ComponentBase, IAsyncDisposable
             return;
         }
 
+        // A locked panel cannot be dragged to move, reorder, re-dock or float.
+        if (!panel.CanMove)
+        {
+            return;
+        }
+
         await Dock.StartTabDragAsync(panel.Id, e);
     }
 
@@ -159,6 +165,10 @@ public partial class BbDockTabGroup : ComponentBase, IAsyncDisposable
         // Floating windows already have a bordered wrapper; docked groups draw their own
         // outline so adjacent panels read as distinct, framed surfaces (VS-style).
         IsFloating ? null : "border border-border/70");
+
+    // Pixel min/max size constraints declared by the group's panels. The floating window wrapper
+    // already sizes itself from these, so the constraint style only applies to docked groups.
+    private string? ConstraintStyle => IsFloating ? null : Dock.GroupConstraintStyle(group);
 
     private string StripClass => ClassNames.cn(
         "flex h-8 shrink-0 items-stretch border-b border-border/60 bg-muted/50",

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor.cs
@@ -28,6 +28,9 @@ public partial class BbDockTabGroup : ComponentBase
 
     private DockTabGroupNode group => (DockTabGroupNode)Group;
 
+    private BbContextMenu? tabMenu;
+    private BbDockPanel? contextPanel;
+
     private bool IsFloating => FloatingWindowId is not null;
 
     private bool IsMaximized => Dock is not null && Dock.IsMaximized(group);
@@ -52,6 +55,16 @@ public partial class BbDockTabGroup : ComponentBase
         await Dock.StartTabDragAsync(panel.Id, e);
     }
 
+    private async Task HandleTabContextMenu(BbDockPanel panel, MouseEventArgs e)
+    {
+        contextPanel = panel;
+
+        if (tabMenu is not null)
+        {
+            await tabMenu.OpenAt(e.ClientX, e.ClientY);
+        }
+    }
+
     private async Task HandleStripPointerDown(PointerEventArgs e)
     {
         if (IsFloating && e.Button == 0 && FloatingWindowId is not null)
@@ -71,7 +84,7 @@ public partial class BbDockTabGroup : ComponentBase
         IsFloating ? "cursor-move" : null);
 
     private static string TabClass(bool isActive) => ClassNames.cn(
-        "group/tab relative flex h-full min-w-[88px] max-w-[200px] cursor-grab items-center gap-1.5 border-r border-border/40 px-2.5 text-xs transition-colors active:cursor-grabbing",
+        "group/tab relative flex h-full min-w-[88px] max-w-[200px] cursor-default items-center gap-1.5 border-r border-border/40 px-2.5 text-xs transition-colors",
         isActive
             ? "z-10 -mb-px border-b border-background bg-background text-foreground after:absolute after:inset-x-0 after:top-0 after:h-[2px] after:bg-primary"
             : "bg-transparent text-muted-foreground hover:bg-background/50 hover:text-foreground");

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// Renders a single dock tab group: a tab strip plus the active panel's content.
+/// Used internally by <see cref="BbDock"/>; not intended for direct consumption.
+/// </summary>
+public partial class BbDockTabGroup : ComponentBase
+{
+    [CascadingParameter]
+    private BbDock Dock { get; set; } = null!;
+
+    /// <summary>
+    /// The tab group node to render. Typed as <see cref="object"/> so the internal layout
+    /// model stays out of the public API; it is always an internal tab group node.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public object Group { get; set; } = null!;
+
+    /// <summary>
+    /// When set, this group is the root of a floating window with the given identifier.
+    /// The tab strip then acts as the window's drag handle.
+    /// </summary>
+    [Parameter]
+    public string? FloatingWindowId { get; set; }
+
+    private DockTabGroupNode group => (DockTabGroupNode)Group;
+
+    private bool IsFloating => FloatingWindowId is not null;
+
+    private bool IsMaximized => Dock is not null && Dock.IsMaximized(group);
+
+    /// <inheritdoc />
+    protected override void OnInitialized()
+    {
+        if (Dock is null)
+        {
+            throw new InvalidOperationException($"{nameof(BbDockTabGroup)} must be used within a {nameof(BbDock)}.");
+        }
+    }
+
+    private async Task HandleTabPointerDown(BbDockPanel panel, PointerEventArgs e)
+    {
+        // Primary button only; let the click handler perform activation.
+        if (e.Button != 0)
+        {
+            return;
+        }
+
+        await Dock.StartTabDragAsync(panel.Id, e);
+    }
+
+    private async Task HandleStripPointerDown(PointerEventArgs e)
+    {
+        if (IsFloating && e.Button == 0 && FloatingWindowId is not null)
+        {
+            await Dock.StartWindowDragAsync(FloatingWindowId, e);
+        }
+    }
+
+    private string RootClass => ClassNames.cn(
+        "flex h-full w-full min-w-0 flex-col overflow-hidden bg-background",
+        // Floating windows already have a bordered wrapper; docked groups draw their own
+        // outline so adjacent panels read as distinct, framed surfaces (VS-style).
+        IsFloating ? null : "border border-border/70");
+
+    private string StripClass => ClassNames.cn(
+        "flex h-8 shrink-0 items-stretch border-b border-border/60 bg-muted/50",
+        IsFloating ? "cursor-move" : null);
+
+    private static string TabClass(bool isActive) => ClassNames.cn(
+        "group/tab relative flex h-full min-w-[88px] max-w-[200px] cursor-grab items-center gap-1.5 border-r border-border/40 px-2.5 text-xs transition-colors active:cursor-grabbing",
+        isActive
+            ? "z-10 -mb-px border-b border-background bg-background text-foreground after:absolute after:inset-x-0 after:top-0 after:h-[2px] after:bg-primary"
+            : "bg-transparent text-muted-foreground hover:bg-background/50 hover:text-foreground");
+
+    private static string CloseClass(bool isActive) => ClassNames.cn(
+        "ml-auto inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm transition-opacity hover:bg-foreground/10 hover:!opacity-100",
+        isActive ? "opacity-60" : "opacity-0 group-hover/tab:opacity-60");
+}

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDockTabGroup.razor.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 
 namespace BlazorBlueprint.Components;
 
@@ -7,8 +8,11 @@ namespace BlazorBlueprint.Components;
 /// Renders a single dock tab group: a tab strip plus the active panel's content.
 /// Used internally by <see cref="BbDock"/>; not intended for direct consumption.
 /// </summary>
-public partial class BbDockTabGroup : ComponentBase
+public partial class BbDockTabGroup : ComponentBase, IAsyncDisposable
 {
+    [Inject]
+    private IJSRuntime JS { get; set; } = null!;
+
     [CascadingParameter]
     private BbDock Dock { get; set; } = null!;
 
@@ -31,9 +35,21 @@ public partial class BbDockTabGroup : ComponentBase
     private BbContextMenu? tabMenu;
     private BbDockPanel? contextPanel;
 
+    private ElementReference stripRef;
+    private IJSObjectReference? jsModule;
+    private DotNetObjectReference<BbDockTabGroup>? dotNetRef;
+    private string? observedGroupId;
+    private string? lastTabSignature;
+    private List<string> overflowPanelIds = new();
+    private bool disposed;
+
     private bool IsFloating => FloatingWindowId is not null;
 
     private bool IsMaximized => Dock is not null && Dock.IsMaximized(group);
+
+    // Changes whenever the set, order or active state of tabs changes, so the strip is
+    // re-measured for overflow even when its own size did not change.
+    private string TabSignature => $"{string.Join('|', group.PanelIds)}#{group.ActivePanelId}";
 
     /// <inheritdoc />
     protected override void OnInitialized()
@@ -41,6 +57,71 @@ public partial class BbDockTabGroup : ComponentBase
         if (Dock is null)
         {
             throw new InvalidOperationException($"{nameof(BbDockTabGroup)} must be used within a {nameof(BbDock)}.");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            jsModule ??= await JS.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/BlazorBlueprint.Components/js/dock.js");
+
+            // (Re)attach the overflow observer whenever this instance starts rendering a
+            // different tab group (Blazor reuses component instances across layout changes).
+            if (observedGroupId != group.Id)
+            {
+                if (observedGroupId is not null)
+                {
+                    await jsModule.InvokeVoidAsync("disposeTabOverflow", observedGroupId);
+                }
+
+                dotNetRef ??= DotNetObjectReference.Create(this);
+                observedGroupId = group.Id;
+                lastTabSignature = TabSignature;
+                await jsModule.InvokeVoidAsync("initTabOverflow", group.Id, stripRef, dotNetRef);
+            }
+            else if (lastTabSignature != TabSignature)
+            {
+                // Tabs were added, removed or reordered: re-measure without a size change.
+                lastTabSignature = TabSignature;
+                await jsModule.InvokeVoidAsync("remeasureTabOverflow", group.Id);
+            }
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        {
+            // Expected during circuit disconnect / prerender.
+        }
+        catch (InvalidOperationException)
+        {
+            // JS interop not available during prerendering.
+        }
+    }
+
+    /// <summary>
+    /// Invoked from JS with the ids of tabs that no longer fit in the strip. These tabs are
+    /// hidden and surfaced through the overflow dropdown instead.
+    /// </summary>
+    /// <param name="ids">The overflowing panel ids, in strip order.</param>
+    [JSInvokable]
+    public void OnTabOverflowChanged(string[] ids)
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        var next = ids.Where(id => group.PanelIds.Contains(id)).ToList();
+        if (!next.SequenceEqual(overflowPanelIds))
+        {
+            overflowPanelIds = next;
+            StateHasChanged();
         }
     }
 
@@ -83,8 +164,9 @@ public partial class BbDockTabGroup : ComponentBase
         "flex h-8 shrink-0 items-stretch border-b border-border/60 bg-muted/50",
         IsFloating ? "cursor-move" : null);
 
-    private static string TabClass(bool isActive) => ClassNames.cn(
+    private static string TabClass(bool isActive, bool isHidden) => ClassNames.cn(
         "group/tab relative flex h-full min-w-[88px] max-w-[200px] cursor-default items-center gap-1.5 border-r border-border/40 px-2.5 text-xs transition-colors",
+        isHidden ? "hidden" : null,
         isActive
             ? "z-10 -mb-px border-b border-background bg-background text-foreground after:absolute after:inset-x-0 after:top-0 after:h-[2px] after:bg-primary"
             : "bg-transparent text-muted-foreground hover:bg-background/50 hover:text-foreground");
@@ -92,4 +174,30 @@ public partial class BbDockTabGroup : ComponentBase
     private static string CloseClass(bool isActive) => ClassNames.cn(
         "ml-auto inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm transition-opacity hover:bg-foreground/10 hover:!opacity-100",
         isActive ? "opacity-60" : "opacity-0 group-hover/tab:opacity-60");
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        disposed = true;
+
+        if (jsModule is not null)
+        {
+            try
+            {
+                if (observedGroupId is not null)
+                {
+                    await jsModule.InvokeVoidAsync("disposeTabOverflow", observedGroupId);
+                }
+
+                await jsModule.DisposeAsync();
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            {
+                // Expected during circuit disconnect.
+            }
+        }
+
+        dotNetRef?.Dispose();
+    }
 }

--- a/src/BlazorBlueprint.Components/Components/Dock/DockModel.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/DockModel.cs
@@ -106,6 +106,18 @@ internal sealed class DockTabGroupNode : DockNode
 /// </summary>
 internal sealed class DockFloatingWindow
 {
+    /// <summary>The default width (pixels) a floating window is created with, before constraints.</summary>
+    public const double DefaultWidth = 360;
+
+    /// <summary>The default height (pixels) a floating window is created with, before constraints.</summary>
+    public const double DefaultHeight = 260;
+
+    /// <summary>The smallest width (pixels) a floating window may be, regardless of panel constraints.</summary>
+    public const double MinFloatingWidth = 180;
+
+    /// <summary>The smallest height (pixels) a floating window may be, regardless of panel constraints.</summary>
+    public const double MinFloatingHeight = 120;
+
     /// <summary>Stable identity for the window.</summary>
     public string Id { get; init; } = Guid.NewGuid().ToString("N");
 
@@ -119,8 +131,8 @@ internal sealed class DockFloatingWindow
     public double Y { get; set; }
 
     /// <summary>Window width in pixels.</summary>
-    public double Width { get; set; } = 360;
+    public double Width { get; set; } = DefaultWidth;
 
     /// <summary>Window height in pixels.</summary>
-    public double Height { get; set; } = 260;
+    public double Height { get; set; } = DefaultHeight;
 }

--- a/src/BlazorBlueprint.Components/Components/Dock/DockModel.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/DockModel.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// Orientation of a dock split node.
+/// </summary>
+internal enum DockOrientation
+{
+    /// <summary>Children are arranged left-to-right.</summary>
+    Horizontal,
+
+    /// <summary>Children are arranged top-to-bottom.</summary>
+    Vertical
+}
+
+/// <summary>
+/// Base type for a node in the dock layout tree. A node is either a
+/// <see cref="DockSplitNode"/> (a horizontal/vertical split) or a
+/// <see cref="DockTabGroupNode"/> (a set of tabbed panels).
+/// </summary>
+internal abstract class DockNode
+{
+    /// <summary>Stable identity for the node, used for diffing and keying.</summary>
+    public string Id { get; init; } = Guid.NewGuid().ToString("N");
+}
+
+/// <summary>
+/// A split container that arranges two or more child nodes along an axis.
+/// </summary>
+internal sealed class DockSplitNode : DockNode
+{
+    /// <summary>The axis along which children are arranged.</summary>
+    public DockOrientation Orientation { get; set; }
+
+    /// <summary>The ordered child nodes.</summary>
+    public List<DockNode> Children { get; set; } = new();
+
+    /// <summary>The size of each child as a percentage of the split (parallel to <see cref="Children"/>).</summary>
+    public List<double> Sizes { get; set; } = new();
+
+    /// <summary>Returns a structural signature that changes whenever the split's shape changes.</summary>
+    public string Signature => $"{Orientation}:{string.Join(',', Children.Select(c => c.Id))}";
+
+    /// <summary>Ensures the <see cref="Sizes"/> list matches the number of children, distributing evenly.</summary>
+    public void NormalizeSizes()
+    {
+        if (Children.Count == 0)
+        {
+            Sizes.Clear();
+            return;
+        }
+
+        if (Sizes.Count != Children.Count)
+        {
+            var even = 100.0 / Children.Count;
+            Sizes = Enumerable.Repeat(even, Children.Count).ToList();
+            return;
+        }
+
+        var total = Sizes.Sum();
+        if (total <= 0)
+        {
+            var even = 100.0 / Children.Count;
+            Sizes = Enumerable.Repeat(even, Children.Count).ToList();
+            return;
+        }
+
+        // Re-scale to total 100 so flex percentages stay sensible.
+        for (var i = 0; i < Sizes.Count; i++)
+        {
+            Sizes[i] = Sizes[i] / total * 100.0;
+        }
+    }
+}
+
+/// <summary>
+/// A group of panels rendered as tabs. Exactly one panel is active at a time.
+/// </summary>
+internal sealed class DockTabGroupNode : DockNode
+{
+    /// <summary>The ordered panel identifiers shown as tabs.</summary>
+    public List<string> PanelIds { get; set; } = new();
+
+    /// <summary>The identifier of the currently active panel, if any.</summary>
+    public string? ActivePanelId { get; set; }
+
+    /// <summary>Ensures <see cref="ActivePanelId"/> references a panel that is still present.</summary>
+    public void EnsureActive()
+    {
+        if (PanelIds.Count == 0)
+        {
+            ActivePanelId = null;
+            return;
+        }
+
+        if (ActivePanelId is null || !PanelIds.Contains(ActivePanelId))
+        {
+            ActivePanelId = PanelIds[0];
+        }
+    }
+}
+
+/// <summary>
+/// A free-floating window that hosts a tab group detached from the docked layout.
+/// </summary>
+internal sealed class DockFloatingWindow
+{
+    /// <summary>Stable identity for the window.</summary>
+    public string Id { get; init; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>The tab group hosted by this window.</summary>
+    public DockTabGroupNode Group { get; set; } = new();
+
+    /// <summary>Horizontal offset (pixels) within the dock surface.</summary>
+    public double X { get; set; }
+
+    /// <summary>Vertical offset (pixels) within the dock surface.</summary>
+    public double Y { get; set; }
+
+    /// <summary>Window width in pixels.</summary>
+    public double Width { get; set; } = 360;
+
+    /// <summary>Window height in pixels.</summary>
+    public double Height { get; set; } = 260;
+}

--- a/src/BlazorBlueprint.Components/Components/Dock/DockZone.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/DockZone.cs
@@ -1,0 +1,33 @@
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// Identifies a region of a dock target. Used both for the initial placement of a
+/// <see cref="BbDockPanel"/> and for the drop zone resolved while dragging a tab.
+/// </summary>
+public enum DockZone
+{
+    /// <summary>
+    /// The center of the target. Dropping here adds the panel as a tab to the target group.
+    /// </summary>
+    Center,
+
+    /// <summary>
+    /// The left edge of the target. Dropping here creates a horizontal split with the panel on the left.
+    /// </summary>
+    Left,
+
+    /// <summary>
+    /// The right edge of the target. Dropping here creates a horizontal split with the panel on the right.
+    /// </summary>
+    Right,
+
+    /// <summary>
+    /// The top edge of the target. Dropping here creates a vertical split with the panel on top.
+    /// </summary>
+    Top,
+
+    /// <summary>
+    /// The bottom edge of the target. Dropping here creates a vertical split with the panel on the bottom.
+    /// </summary>
+    Bottom
+}

--- a/src/BlazorBlueprint.Components/Components/Resizable/BbResizableHandle.razor
+++ b/src/BlazorBlueprint.Components/Components/Resizable/BbResizableHandle.razor
@@ -52,8 +52,10 @@
         IsHorizontal
             ? "w-px cursor-col-resize hover:bg-primary/50 active:bg-primary"
             : "h-px cursor-row-resize hover:bg-primary/50 active:bg-primary",
-        "after:absolute after:inset-y-0 after:left-1/2 after:-translate-x-1/2",
-        IsHorizontal ? "after:w-1" : "after:h-1",
+        "after:absolute",
+        IsHorizontal
+            ? "after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2"
+            : "after:inset-x-0 after:top-1/2 after:h-1 after:-translate-y-1/2",
         Class
     );
 

--- a/src/BlazorBlueprint.Components/Localization/DefaultBbLocalizer.cs
+++ b/src/BlazorBlueprint.Components/Localization/DefaultBbLocalizer.cs
@@ -140,6 +140,19 @@ public class DefaultBbLocalizer : IBbLocalizer
         // Dialog
         ["Dialog.Close"] = "Close",
 
+        // Dock
+        ["Dock.Close"] = "Close",
+        ["Dock.CloseTab"] = "Close {0}",
+        ["Dock.CloseOtherTabs"] = "Close Other Tabs",
+        ["Dock.CloseAllButPinned"] = "Close All But Pinned",
+        ["Dock.CloseAllTabs"] = "Close All Tabs",
+        ["Dock.PinTab"] = "Pin Tab",
+        ["Dock.UnpinTab"] = "Unpin Tab",
+        ["Dock.ShowHiddenTabs"] = "Show {0} hidden tab(s)",
+        ["Dock.MaximizePanelGroup"] = "Maximize panel group",
+        ["Dock.RestorePanelGroup"] = "Restore panel group",
+        ["Dock.NoPanelsOpen"] = "No panels are open.",
+
         // FilterBuilder
         ["FilterBuilder.FilterBuilderAriaLabel"] = "Filter builder",
         ["FilterBuilder.SelectField"] = "Select field...",

--- a/src/BlazorBlueprint.Components/wwwroot/js/dock.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/dock.js
@@ -24,6 +24,88 @@ export function disposeDock(dockId) {
     docks.delete(dockId);
 }
 
+// ---------------------------------------------------------------- tab strip overflow
+
+// One entry per observed tab strip, keyed by the tab group's id.
+const tabOverflowObservers = new Map();
+
+// Sets up overflow tracking for a tab strip. Whenever the strip resizes, the set of tabs
+// that no longer fit is recomputed and reported to .NET so it can hide them and surface an
+// overflow ("…") dropdown instead of a scrollbar.
+export function initTabOverflow(groupId, stripEl, dotNetRef) {
+    if (!groupId || !stripEl || !dotNetRef) {
+        return;
+    }
+
+    disposeTabOverflow(groupId);
+
+    const ro = new ResizeObserver(() => reportTabOverflow(groupId));
+    ro.observe(stripEl);
+
+    tabOverflowObservers.set(groupId, { observer: ro, stripEl, dotNetRef });
+    reportTabOverflow(groupId);
+}
+
+// Recomputes overflow for an already-observed strip (e.g. after tabs are added or removed).
+export function remeasureTabOverflow(groupId) {
+    reportTabOverflow(groupId);
+}
+
+export function disposeTabOverflow(groupId) {
+    const entry = tabOverflowObservers.get(groupId);
+    if (entry) {
+        entry.observer.disconnect();
+        tabOverflowObservers.delete(groupId);
+    }
+}
+
+function reportTabOverflow(groupId) {
+    const entry = tabOverflowObservers.get(groupId);
+    if (!entry) {
+        return;
+    }
+
+    const ids = computeOverflowIds(entry.stripEl);
+    entry.dotNetRef.invokeMethodAsync("OnTabOverflowChanged", ids).catch(() => { });
+}
+
+// Returns the ids of tabs that do not fully fit within the strip's visible width, in order.
+// Tabs may currently be hidden (display:none) from a previous pass, so each is temporarily
+// forced visible for measurement and then restored — the natural widths stay stable, which
+// prevents the hide/show feedback loop a naive measurement would cause.
+function computeOverflowIds(stripEl) {
+    if (!stripEl) {
+        return [];
+    }
+
+    const tabs = Array.from(stripEl.querySelectorAll("[data-dock-tab]"));
+    if (tabs.length === 0) {
+        return [];
+    }
+
+    const saved = tabs.map((t) => t.style.display);
+    for (const t of tabs) {
+        t.style.display = "flex";
+    }
+
+    const available = stripEl.clientWidth;
+    const overflow = [];
+    let used = 0;
+    for (const t of tabs) {
+        used += t.offsetWidth;
+        // A 1px tolerance absorbs sub-pixel rounding so a tab that exactly fits is not hidden.
+        if (used > available + 1) {
+            overflow.push(t.getAttribute("data-dock-tab"));
+        }
+    }
+
+    for (let i = 0; i < tabs.length; i++) {
+        tabs[i].style.display = saved[i];
+    }
+
+    return overflow;
+}
+
 // ---------------------------------------------------------------- shared pointer session
 
 function attachSession(handlers) {

--- a/src/BlazorBlueprint.Components/wwwroot/js/dock.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/dock.js
@@ -1,0 +1,409 @@
+// Docking interactions for BbDock.
+//
+// Handles three pointer-driven gestures:
+//   1. Dragging a panel tab to re-dock it (as a tab or a split), to a dock edge, or out to a
+//      floating window. Draws a live drop indicator and reports the resolved drop to .NET.
+//   2. Dragging a floating window by its tab strip to reposition it.
+//   3. Dragging a floating window's resize grip to resize it.
+//
+// .NET owns the layout model; this module only computes drop targets and reports results.
+
+const docks = new Map();
+const DRAG_THRESHOLD = 4;
+const ACCENT_BG = "rgba(59, 130, 246, 0.28)";
+const ACCENT_BORDER = "2px solid rgba(59, 130, 246, 0.9)";
+
+export function initializeDock(dockId, rootEl, dotNetRef) {
+    if (!dockId || !rootEl || !dotNetRef) {
+        return;
+    }
+    docks.set(dockId, { rootEl, dotNetRef });
+}
+
+export function disposeDock(dockId) {
+    docks.delete(dockId);
+}
+
+// ---------------------------------------------------------------- shared pointer session
+
+function attachSession(handlers) {
+    const onMove = (e) => handlers.move(e);
+    const onUp = (e) => {
+        cleanup();
+        handlers.up(e);
+    };
+    const cleanup = () => {
+        document.removeEventListener("pointermove", onMove);
+        document.removeEventListener("pointerup", onUp);
+        document.removeEventListener("pointercancel", onUp);
+        document.body.style.userSelect = "";
+        document.body.style.cursor = "";
+    };
+
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp);
+    document.addEventListener("pointercancel", onUp);
+    document.body.style.userSelect = "none";
+    return cleanup;
+}
+
+// ---------------------------------------------------------------- tab drag → docking
+
+export function startTabDrag(dockId, title, clientX, clientY, pointerId) {
+    const dock = docks.get(dockId);
+    if (!dock) {
+        return;
+    }
+
+    const state = {
+        dock,
+        title: title || "Panel",
+        pointerId,
+        startX: clientX,
+        startY: clientY,
+        active: false,
+        ghost: null,
+        indicator: null,
+        target: null
+    };
+
+    attachSession({
+        move: (e) => {
+            if (e.pointerId !== pointerId) {
+                return;
+            }
+            onTabMove(state, e);
+        },
+        up: (e) => {
+            if (e.pointerId !== pointerId) {
+                return;
+            }
+            onTabUp(state, e);
+        }
+    });
+}
+
+function onTabMove(state, e) {
+    if (!state.active) {
+        const dx = e.clientX - state.startX;
+        const dy = e.clientY - state.startY;
+        if (Math.hypot(dx, dy) < DRAG_THRESHOLD) {
+            return;
+        }
+        state.active = true;
+        state.ghost = createGhost(state.title);
+        document.body.style.cursor = "grabbing";
+    }
+
+    moveGhost(state.ghost, e.clientX, e.clientY);
+    state.target = computeTarget(state.dock, e.clientX, e.clientY);
+    drawIndicator(state, state.target);
+}
+
+function onTabUp(state, e) {
+    removeEl(state.ghost);
+    removeEl(state.indicator);
+    state.ghost = null;
+    state.indicator = null;
+
+    if (!state.active) {
+        // No movement past the threshold — treat as a click, not a drag.
+        return;
+    }
+
+    const t = state.target || { type: "none" };
+    let floatX = 0;
+    let floatY = 0;
+
+    if (t.type === "float") {
+        const r = state.dock.rootEl.getBoundingClientRect();
+        floatX = e.clientX - r.left - 24;
+        floatY = e.clientY - r.top - 12;
+    }
+
+    state.dock.dotNetRef
+        .invokeMethodAsync("OnTabDropped", t.type, t.groupId || null, t.zone || "center", floatX, floatY, typeof t.index === "number" ? t.index : -1)
+        .catch(() => { });
+}
+
+function computeTarget(dock, x, y) {
+    const r = dock.rootEl.getBoundingClientRect();
+
+    if (x < r.left || x > r.right || y < r.top || y > r.bottom) {
+        return { type: "float" };
+    }
+
+    // Hovering a tab strip reorders within (or into) that group without changing the layout.
+    const stripEl = findClosestAt(dock, x, y, "[data-dock-tabstrip]");
+    if (stripEl) {
+        return {
+            type: "reorder",
+            groupId: stripEl.getAttribute("data-dock-tabstrip"),
+            index: computeInsertIndex(stripEl, x)
+        };
+    }
+
+    // A band along the dock's outer border docks against the whole dock.
+    const edge = 26;
+    if (x - r.left < edge) {
+        return { type: "root", zone: "left" };
+    }
+    if (r.right - x < edge) {
+        return { type: "root", zone: "right" };
+    }
+    if (y - r.top < edge) {
+        return { type: "root", zone: "top" };
+    }
+    if (r.bottom - y < edge) {
+        return { type: "root", zone: "bottom" };
+    }
+
+    const groupEl = findGroupAt(dock, x, y);
+    if (!groupEl) {
+        return { type: "float" };
+    }
+
+    const gid = groupEl.getAttribute("data-dock-group");
+    const zone = zoneWithin(groupEl.getBoundingClientRect(), x, y);
+    return { type: "group", groupId: gid, zone };
+}
+
+function findGroupAt(dock, x, y) {
+    return findClosestAt(dock, x, y, "[data-dock-group]");
+}
+
+function findClosestAt(dock, x, y, selector) {
+    const els = document.elementsFromPoint(x, y);
+    for (const el of els) {
+        if (!el.closest) {
+            continue;
+        }
+        const match = el.closest(selector);
+        if (match && dock.rootEl.contains(match)) {
+            return match;
+        }
+    }
+    return null;
+}
+
+// The insertion slot (0..tabCount) for a pointer x over a tab strip, using each tab's midpoint.
+function computeInsertIndex(stripEl, x) {
+    const tabs = stripEl.querySelectorAll("[data-dock-tab]");
+    for (let i = 0; i < tabs.length; i++) {
+        const tr = tabs[i].getBoundingClientRect();
+        if (x < tr.left + tr.width / 2) {
+            return i;
+        }
+    }
+    return tabs.length;
+}
+
+function zoneWithin(r, x, y) {
+    const rx = (x - r.left) / r.width;
+    const ry = (y - r.top) / r.height;
+    const m = 0.22;
+    const inMidX = rx > m && rx < 1 - m;
+    const inMidY = ry > m && ry < 1 - m;
+
+    if (rx < m && inMidY) {
+        return "left";
+    }
+    if (rx > 1 - m && inMidY) {
+        return "right";
+    }
+    if (ry < m && inMidX) {
+        return "top";
+    }
+    if (ry > 1 - m && inMidX) {
+        return "bottom";
+    }
+    return "center";
+}
+
+function drawIndicator(state, t) {
+    if (!t || t.type === "none" || t.type === "float") {
+        if (state.indicator) {
+            state.indicator.style.display = "none";
+        }
+        return;
+    }
+
+    if (!state.indicator) {
+        const ind = document.createElement("div");
+        ind.style.cssText =
+            "position:fixed;z-index:10001;pointer-events:none;border-radius:6px;box-sizing:border-box;" +
+            "transition:left .07s ease,top .07s ease,width .07s ease,height .07s ease;";
+        ind.style.background = ACCENT_BG;
+        ind.style.border = ACCENT_BORDER;
+        document.body.appendChild(ind);
+        state.indicator = ind;
+    }
+
+    const ind = state.indicator;
+    ind.style.display = "block";
+
+    let box;
+    if (t.type === "reorder") {
+        const stripEl = state.dock.rootEl.querySelector(`[data-dock-tabstrip="${t.groupId}"]`);
+        if (!stripEl) {
+            ind.style.display = "none";
+            return;
+        }
+        box = insertionLineBox(stripEl, t.index);
+        // A solid caret line between tabs rather than a translucent fill.
+        ind.style.background = "rgba(59, 130, 246, 0.95)";
+        ind.style.border = "none";
+    } else {
+        ind.style.background = ACCENT_BG;
+        ind.style.border = ACCENT_BORDER;
+        if (t.type === "root") {
+            box = zoneBox(state.dock.rootEl.getBoundingClientRect(), t.zone, 0.3);
+        } else {
+            const gEl = state.dock.rootEl.querySelector(`[data-dock-group="${t.groupId}"]`);
+            if (!gEl) {
+                ind.style.display = "none";
+                return;
+            }
+            box = zoneBox(gEl.getBoundingClientRect(), t.zone, 0.5);
+        }
+    }
+
+    ind.style.left = `${box.left}px`;
+    ind.style.top = `${box.top}px`;
+    ind.style.width = `${box.width}px`;
+    ind.style.height = `${box.height}px`;
+}
+
+function insertionLineBox(stripEl, index) {
+    const tabs = stripEl.querySelectorAll("[data-dock-tab]");
+    const sr = stripEl.getBoundingClientRect();
+    let lineX;
+    if (tabs.length === 0) {
+        lineX = sr.left;
+    } else if (index >= tabs.length) {
+        lineX = tabs[tabs.length - 1].getBoundingClientRect().right;
+    } else {
+        lineX = tabs[index].getBoundingClientRect().left;
+    }
+    return { left: lineX - 1, top: sr.top, width: 2, height: sr.height };
+}
+
+function zoneBox(r, zone, frac) {
+    switch (zone) {
+        case "left":
+            return { left: r.left, top: r.top, width: r.width * frac, height: r.height };
+        case "right":
+            return { left: r.right - r.width * frac, top: r.top, width: r.width * frac, height: r.height };
+        case "top":
+            return { left: r.left, top: r.top, width: r.width, height: r.height * frac };
+        case "bottom":
+            return { left: r.left, top: r.bottom - r.height * frac, width: r.width, height: r.height * frac };
+        default:
+            return { left: r.left, top: r.top, width: r.width, height: r.height };
+    }
+}
+
+function createGhost(title) {
+    const g = document.createElement("div");
+    g.textContent = title;
+    g.style.cssText =
+        "position:fixed;z-index:10002;pointer-events:none;padding:4px 10px;font-size:12px;font-weight:500;" +
+        "border-radius:6px;background:#1f2937;color:#fff;box-shadow:0 6px 20px rgba(0,0,0,0.28);opacity:.92;" +
+        "white-space:nowrap;transform:translate(10px,10px);";
+    document.body.appendChild(g);
+    return g;
+}
+
+function moveGhost(g, x, y) {
+    if (g) {
+        g.style.left = `${x}px`;
+        g.style.top = `${y}px`;
+    }
+}
+
+function removeEl(el) {
+    if (el && el.parentNode) {
+        el.parentNode.removeChild(el);
+    }
+}
+
+// ---------------------------------------------------------------- floating window move
+
+export function startWindowDrag(dockId, windowId, clientX, clientY, pointerId) {
+    const dock = docks.get(dockId);
+    if (!dock) {
+        return;
+    }
+
+    const winEl = dock.rootEl.querySelector(`[data-dock-window="${windowId}"]`);
+    if (!winEl) {
+        return;
+    }
+
+    const rootRect = dock.rootEl.getBoundingClientRect();
+    const startLeft = parseFloat(winEl.style.left) || 0;
+    const startTop = parseFloat(winEl.style.top) || 0;
+    const offsetX = clientX - (rootRect.left + startLeft);
+    const offsetY = clientY - (rootRect.top + startTop);
+
+    attachSession({
+        move: (e) => {
+            if (e.pointerId !== pointerId) {
+                return;
+            }
+            const left = Math.max(0, e.clientX - rootRect.left - offsetX);
+            const top = Math.max(0, e.clientY - rootRect.top - offsetY);
+            winEl.style.left = `${left}px`;
+            winEl.style.top = `${top}px`;
+        },
+        up: (e) => {
+            if (e.pointerId !== pointerId) {
+                return;
+            }
+            const left = parseFloat(winEl.style.left) || 0;
+            const top = parseFloat(winEl.style.top) || 0;
+            dock.dotNetRef.invokeMethodAsync("OnWindowMoved", windowId, left, top).catch(() => { });
+        }
+    });
+    document.body.style.cursor = "move";
+}
+
+// ---------------------------------------------------------------- floating window resize
+
+export function startWindowResize(dockId, windowId, clientX, clientY, pointerId) {
+    const dock = docks.get(dockId);
+    if (!dock) {
+        return;
+    }
+
+    const winEl = dock.rootEl.querySelector(`[data-dock-window="${windowId}"]`);
+    if (!winEl) {
+        return;
+    }
+
+    const startWidth = winEl.offsetWidth;
+    const startHeight = winEl.offsetHeight;
+    const startX = clientX;
+    const startY = clientY;
+
+    attachSession({
+        move: (e) => {
+            if (e.pointerId !== pointerId) {
+                return;
+            }
+            const width = Math.max(180, startWidth + (e.clientX - startX));
+            const height = Math.max(120, startHeight + (e.clientY - startY));
+            winEl.style.width = `${width}px`;
+            winEl.style.height = `${height}px`;
+        },
+        up: (e) => {
+            if (e.pointerId !== pointerId) {
+                return;
+            }
+            dock.dotNetRef
+                .invokeMethodAsync("OnWindowResized", windowId, winEl.offsetWidth, winEl.offsetHeight)
+                .catch(() => { });
+        }
+    });
+    document.body.style.cursor = "nwse-resize";
+}

--- a/src/BlazorBlueprint.Components/wwwroot/js/dock.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/dock.js
@@ -10,17 +10,25 @@
 
 const docks = new Map();
 const DRAG_THRESHOLD = 4;
-const ACCENT_BG = "rgba(59, 130, 246, 0.28)";
-const ACCENT_BORDER = "2px solid rgba(59, 130, 246, 0.9)";
+// Theme design tokens (full color values, oklch) so the overlays match both light and dark themes.
+const ACCENT_BG = "color-mix(in oklab, var(--primary) 25%, transparent)";
+const ACCENT_BORDER = "2px solid var(--primary)";
+const ACCENT_SOLID = "var(--primary)";
 
 export function initializeDock(dockId, rootEl, dotNetRef) {
     if (!dockId || !rootEl || !dotNetRef) {
         return;
     }
-    docks.set(dockId, { rootEl, dotNetRef });
+    docks.set(dockId, { rootEl, dotNetRef, cancelSession: null });
 }
 
 export function disposeDock(dockId) {
+    const dock = docks.get(dockId);
+    if (dock && dock.cancelSession) {
+        // Abort any in-flight drag so ghost/indicator elements and document-level
+        // listeners are not orphaned when the component is disposed mid-gesture.
+        dock.cancelSession();
+    }
     docks.delete(dockId);
 }
 
@@ -42,7 +50,20 @@ export function initTabOverflow(groupId, stripEl, dotNetRef) {
     const ro = new ResizeObserver(() => reportTabOverflow(groupId));
     ro.observe(stripEl);
 
-    tabOverflowObservers.set(groupId, { observer: ro, stripEl, dotNetRef });
+    // The tabs are divs, so keys the tablist handles (roving focus + activation, done in
+    // .NET) would otherwise also scroll the page. Buttons inside a tab (e.g. close) are
+    // left alone so Space/Enter still click them.
+    const onKeyDown = (e) => {
+        if (!e.target.closest || !e.target.closest("[data-dock-tab]") || e.target.closest("button")) {
+            return;
+        }
+        if (e.key === " " || e.key === "ArrowLeft" || e.key === "ArrowRight" || e.key === "Home" || e.key === "End") {
+            e.preventDefault();
+        }
+    };
+    stripEl.addEventListener("keydown", onKeyDown);
+
+    tabOverflowObservers.set(groupId, { observer: ro, stripEl, dotNetRef, onKeyDown });
     reportTabOverflow(groupId);
 }
 
@@ -55,6 +76,7 @@ export function disposeTabOverflow(groupId) {
     const entry = tabOverflowObservers.get(groupId);
     if (entry) {
         entry.observer.disconnect();
+        entry.stripEl.removeEventListener("keydown", entry.onKeyDown);
         tabOverflowObservers.delete(groupId);
     }
 }
@@ -108,25 +130,56 @@ function computeOverflowIds(stripEl) {
 
 // ---------------------------------------------------------------- shared pointer session
 
-function attachSession(handlers) {
-    const onMove = (e) => handlers.move(e);
+// Runs a document-level pointer session for a single pointer. Events from other pointers
+// (a second finger, a touch during a mouse drag) are ignored entirely so they can neither
+// commit nor tear down the session. pointerup commits via handlers.up; pointercancel
+// aborts via handlers.cancel (no commit). The session registers a cancel handle on the
+// dock so disposeDock can abort an in-flight gesture.
+function attachSession(dock, pointerId, handlers) {
+    const onMove = (e) => {
+        if (e.pointerId !== pointerId) {
+            return;
+        }
+        handlers.move(e);
+    };
     const onUp = (e) => {
-        cleanup();
+        if (e.pointerId !== pointerId) {
+            return;
+        }
+        detach();
         handlers.up(e);
     };
-    const cleanup = () => {
+    const onCancel = (e) => {
+        if (e.pointerId !== pointerId) {
+            return;
+        }
+        cancel();
+    };
+    const detach = () => {
         document.removeEventListener("pointermove", onMove);
         document.removeEventListener("pointerup", onUp);
-        document.removeEventListener("pointercancel", onUp);
+        document.removeEventListener("pointercancel", onCancel);
         document.body.style.userSelect = "";
         document.body.style.cursor = "";
+        if (dock && dock.cancelSession === cancel) {
+            dock.cancelSession = null;
+        }
+    };
+    const cancel = () => {
+        detach();
+        if (handlers.cancel) {
+            handlers.cancel();
+        }
     };
 
     document.addEventListener("pointermove", onMove);
     document.addEventListener("pointerup", onUp);
-    document.addEventListener("pointercancel", onUp);
+    document.addEventListener("pointercancel", onCancel);
     document.body.style.userSelect = "none";
-    return cleanup;
+
+    if (dock) {
+        dock.cancelSession = cancel;
+    }
 }
 
 // ---------------------------------------------------------------- tab drag → docking
@@ -149,20 +202,20 @@ export function startTabDrag(dockId, title, clientX, clientY, pointerId) {
         target: null
     };
 
-    attachSession({
-        move: (e) => {
-            if (e.pointerId !== pointerId) {
-                return;
-            }
-            onTabMove(state, e);
-        },
-        up: (e) => {
-            if (e.pointerId !== pointerId) {
-                return;
-            }
-            onTabUp(state, e);
-        }
+    attachSession(dock, pointerId, {
+        move: (e) => onTabMove(state, e),
+        up: (e) => onTabUp(state, e),
+        cancel: () => abortTabDrag(state)
     });
+}
+
+// A cancelled gesture (pointercancel, or the dock being disposed mid-drag) aborts the
+// drag: the ghost and drop indicator are removed and no drop is reported to .NET.
+function abortTabDrag(state) {
+    removeEl(state.ghost);
+    removeEl(state.indicator);
+    state.ghost = null;
+    state.indicator = null;
 }
 
 function onTabMove(state, e) {
@@ -333,7 +386,7 @@ function drawIndicator(state, t) {
         }
         box = insertionLineBox(stripEl, t.index);
         // A solid caret line between tabs rather than a translucent fill.
-        ind.style.background = "rgba(59, 130, 246, 0.95)";
+        ind.style.background = ACCENT_SOLID;
         ind.style.border = "none";
     } else {
         ind.style.background = ACCENT_BG;
@@ -390,7 +443,8 @@ function createGhost(title) {
     g.textContent = title;
     g.style.cssText =
         "position:fixed;z-index:10002;pointer-events:none;padding:4px 10px;font-size:12px;font-weight:500;" +
-        "border-radius:6px;background:#1f2937;color:#fff;box-shadow:0 6px 20px rgba(0,0,0,0.28);opacity:.92;" +
+        "border-radius:6px;background:var(--background);color:var(--foreground);border:1px solid var(--border);" +
+        "box-shadow:0 6px 20px rgba(0,0,0,0.28);opacity:.92;" +
         "white-space:nowrap;transform:translate(10px,10px);";
     document.body.appendChild(g);
     return g;
@@ -428,23 +482,22 @@ export function startWindowDrag(dockId, windowId, clientX, clientY, pointerId) {
     const offsetX = clientX - (rootRect.left + startLeft);
     const offsetY = clientY - (rootRect.top + startTop);
 
-    attachSession({
+    attachSession(dock, pointerId, {
         move: (e) => {
-            if (e.pointerId !== pointerId) {
-                return;
-            }
             const left = Math.max(0, e.clientX - rootRect.left - offsetX);
             const top = Math.max(0, e.clientY - rootRect.top - offsetY);
             winEl.style.left = `${left}px`;
             winEl.style.top = `${top}px`;
         },
-        up: (e) => {
-            if (e.pointerId !== pointerId) {
-                return;
-            }
+        up: () => {
             const left = parseFloat(winEl.style.left) || 0;
             const top = parseFloat(winEl.style.top) || 0;
             dock.dotNetRef.invokeMethodAsync("OnWindowMoved", windowId, left, top).catch(() => { });
+        },
+        cancel: () => {
+            // Cancelled gesture: put the window back where it started, commit nothing.
+            winEl.style.left = `${startLeft}px`;
+            winEl.style.top = `${startTop}px`;
         }
     });
     document.body.style.cursor = "move";
@@ -475,23 +528,22 @@ export function startWindowResize(dockId, windowId, clientX, clientY, pointerId,
     const startX = clientX;
     const startY = clientY;
 
-    attachSession({
+    attachSession(dock, pointerId, {
         move: (e) => {
-            if (e.pointerId !== pointerId) {
-                return;
-            }
             const width = Math.min(maxW, Math.max(minW, startWidth + (e.clientX - startX)));
             const height = Math.min(maxH, Math.max(minH, startHeight + (e.clientY - startY)));
             winEl.style.width = `${width}px`;
             winEl.style.height = `${height}px`;
         },
-        up: (e) => {
-            if (e.pointerId !== pointerId) {
-                return;
-            }
+        up: () => {
             dock.dotNetRef
                 .invokeMethodAsync("OnWindowResized", windowId, winEl.offsetWidth, winEl.offsetHeight)
                 .catch(() => { });
+        },
+        cancel: () => {
+            // Cancelled gesture: restore the original size, commit nothing.
+            winEl.style.width = `${startWidth}px`;
+            winEl.style.height = `${startHeight}px`;
         }
     });
     document.body.style.cursor = "nwse-resize";

--- a/src/BlazorBlueprint.Components/wwwroot/js/dock.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/dock.js
@@ -452,7 +452,9 @@ export function startWindowDrag(dockId, windowId, clientX, clientY, pointerId) {
 
 // ---------------------------------------------------------------- floating window resize
 
-export function startWindowResize(dockId, windowId, clientX, clientY, pointerId) {
+// minWidth/minHeight default to the usable window minimum; a max of 0 (or omitted) means
+// "no maximum". These mirror the per-panel size constraints enforced on the .NET side.
+export function startWindowResize(dockId, windowId, clientX, clientY, pointerId, minWidth, minHeight, maxWidth, maxHeight) {
     const dock = docks.get(dockId);
     if (!dock) {
         return;
@@ -462,6 +464,11 @@ export function startWindowResize(dockId, windowId, clientX, clientY, pointerId)
     if (!winEl) {
         return;
     }
+
+    const minW = minWidth > 0 ? minWidth : 180;
+    const minH = minHeight > 0 ? minHeight : 120;
+    const maxW = maxWidth > 0 ? maxWidth : Infinity;
+    const maxH = maxHeight > 0 ? maxHeight : Infinity;
 
     const startWidth = winEl.offsetWidth;
     const startHeight = winEl.offsetHeight;
@@ -473,8 +480,8 @@ export function startWindowResize(dockId, windowId, clientX, clientY, pointerId)
             if (e.pointerId !== pointerId) {
                 return;
             }
-            const width = Math.max(180, startWidth + (e.clientX - startX));
-            const height = Math.max(120, startHeight + (e.clientY - startY));
+            const width = Math.min(maxW, Math.max(minW, startWidth + (e.clientX - startX)));
+            const height = Math.min(maxH, Math.max(minH, startHeight + (e.clientY - startY)));
             winEl.style.width = `${width}px`;
             winEl.style.height = `${height}px`;
         },

--- a/src/BlazorBlueprint.Components/wwwroot/js/dock.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/dock.js
@@ -92,7 +92,7 @@ function onTabMove(state, e) {
         }
         state.active = true;
         state.ghost = createGhost(state.title);
-        document.body.style.cursor = "grabbing";
+        document.body.style.cursor = "default";
     }
 
     moveGhost(state.ghost, e.clientX, e.clientY);

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -1077,6 +1077,11 @@
   - Closable : Boolean
   - Icon : RenderFragment
   - Id : String [EditorRequired]
+  - Locked : Boolean
+  - MaxHeight : Int32?
+  - MaxWidth : Int32?
+  - MinHeight : Int32?
+  - MinWidth : Int32?
   - Order : Int32
   - Region : DockZone
   - Title : String

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -1061,6 +1061,32 @@
   - AsChild : Boolean
   - ChildContent : RenderFragment
 
+### BbDock (BlazorBlueprint.Components)
+  - ChildContent : RenderFragment
+  - Class : String
+  - EmptyContent : RenderFragment
+  - OnLayoutChanged : EventCallback
+  - OnPanelClosed : EventCallback<String>
+
+### BbDockNode (BlazorBlueprint.Components)
+  - Node : Object [EditorRequired]
+
+### BbDockPanel (BlazorBlueprint.Components)
+  - CanFloat : Boolean
+  - ChildContent : RenderFragment
+  - Closable : Boolean
+  - Icon : RenderFragment
+  - Id : String [EditorRequired]
+  - Order : Int32
+  - Region : DockZone
+  - Title : String
+  - Dock : BbDock [CascadingParameter]
+
+### BbDockTabGroup (BlazorBlueprint.Components)
+  - FloatingWindowId : String
+  - Group : Object [EditorRequired]
+  - Dock : BbDock [CascadingParameter]
+
 ### BbDrawer (BlazorBlueprint.Components)
   - ChildContent : RenderFragment
   - DefaultOpen : Boolean
@@ -3610,6 +3636,13 @@
   - Large = 2
   - ExtraLarge = 3
   - Full = 4
+
+### DockZone (BlazorBlueprint.Components)
+  - Center = 0
+  - Left = 1
+  - Right = 2
+  - Top = 3
+  - Bottom = 4
 
 ### DrawerDirection (BlazorBlueprint.Components)
   - Top = 0


### PR DESCRIPTION
## Description

Added `BbDock`, `BbDockPanel` and other helpers to create an IDE-style docking control.

Features:

- Drag and Drop panels within regions of the BbDock component.
- Maximize/minimize the current panel to fill the dock view.
- Close current tab, close all tabs, close other tabs but current.
- Pin tabs to the front of the tab strip.
- Drag panels outside of BbDock to create a 'pop-out' panel.
- Dropdown to view tabs that can't fit inside a tab strip when the view is resized.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [X] Blazor Server
- [X] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [X] Keyboard navigation / accessibility
- [X] Dark mode

## Preview:


https://github.com/user-attachments/assets/9b183788-a899-4ab9-ab38-523c923dad3c


