### PR TITLE
fix(input-otp): fire OnComplete when entering the OTP manually

### DIFF
--- a/src/BlazorBlueprint.Components/Components/InputOTP/BbInputOTP.razor
+++ b/src/BlazorBlueprint.Components/Components/InputOTP/BbInputOTP.razor
@@ -275,14 +275,11 @@
             await FocusInput(index + 1);
         }
 
-        // Check if complete
-        if (newValue.Length == Length && !newValue.Contains(""))
+        // Fire OnComplete once every slot is filled.
+        var completeValue = string.Join("", _values.Where(v => !string.IsNullOrEmpty(v)));
+        if (completeValue.Length == Length)
         {
-            var completeValue = string.Join("", _values.Where(v => !string.IsNullOrEmpty(v)));
-            if (completeValue.Length == Length)
-            {
-                await OnComplete.InvokeAsync(completeValue);
-            }
+            await OnComplete.InvokeAsync(completeValue);
         }
     }
 


### PR DESCRIPTION
## Description

`BbInputOTP.OnComplete` never fired when the OTP was typed one character at a time. `HandleInput` gated the callback on:

```csharp
if (newValue.Length == Length && !newValue.Contains(""))
```

`string.Contains("")` is always `true` (every string contains the empty substring), so `!newValue.Contains("")` is always `false` and the block could never run. Only the paste path (`OnPasteJs`) fired `OnComplete`, because it used a correct check.

The completion check now mirrors the paste path — fire once every slot is filled:

```csharp
var completeValue = string.Join("", _values.Where(v => !string.IsNullOrEmpty(v)));
if (completeValue.Length == Length)
{
    await OnComplete.InvokeAsync(completeValue);
}
```

Verified with a clean build (0 warnings) and the full test suite (67/67 passing). The change is pure C# logic with no render-mode-specific behavior; manual per-render-mode testing wasn't performed.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [ ] Blazor Server
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility
- [ ] Dark mode

## Related Issues

Closes #357