### PR TITLE
feat(theme-switcher): add Variant parameter to BbThemeSwitcher

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ThemeDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ThemeDemo.razor
@@ -46,9 +46,27 @@
                 </p>
             </div>
 
-            <div class="rounded-lg border bg-card p-6 flex items-center gap-4">
-                <BbThemeSwitcher />
-                <span class="text-sm text-muted-foreground">Click the icon to open the theme panel</span>
+            <div class="rounded-lg border bg-card p-6 space-y-4">
+                <div class="flex items-center gap-4">
+                    <BbThemeSwitcher />
+                    <span class="text-sm text-muted-foreground">Click the icon to open the theme panel</span>
+                </div>
+
+                <div class="space-y-2">
+                    <p class="text-sm font-medium">Trigger variants</p>
+                    <p class="text-xs text-muted-foreground">
+                        The trigger button defaults to <code class="text-xs bg-muted px-1 py-0.5 rounded">Outline</code>.
+                        Set <code class="text-xs bg-muted px-1 py-0.5 rounded">Variant</code> to match it to the
+                        surrounding UI.
+                    </p>
+                    <div class="flex items-center gap-3">
+                        <BbThemeSwitcher Variant="ButtonVariant.Default" />
+                        <BbThemeSwitcher Variant="ButtonVariant.Secondary" />
+                        <BbThemeSwitcher Variant="ButtonVariant.Ghost" />
+                        <BbThemeSwitcher Variant="ButtonVariant.Outline" />
+                    </div>
+                    <pre class="rounded-md bg-muted p-3 text-xs font-mono overflow-x-auto"><code>&lt;BbThemeSwitcher Variant="ButtonVariant.Ghost" /&gt;</code></pre>
+                </div>
             </div>
         </section>
 
@@ -153,6 +171,9 @@ await ThemeService.ToggleDarkModeAsync();</code></pre>
             </div>
             <div class="space-y-4">
                 <ApiReference ComponentName="BbThemeSwitcher">
+                    <ApiParameter Name="Variant" Type="ButtonVariant" Default="ButtonVariant.Outline">
+                        Visual variant of the trigger button.
+                    </ApiParameter>
                     <ApiParameter Name="TriggerClass" Type="string?" Default="null">
                         Additional CSS classes for the trigger button.
                     </ApiParameter>

--- a/src/BlazorBlueprint.Components/Components/Theme/BbThemeSwitcher.razor
+++ b/src/BlazorBlueprint.Components/Components/Theme/BbThemeSwitcher.razor
@@ -6,7 +6,7 @@
 
 <BbPopover @bind-Open="isOpen">
     <BbPopoverTrigger AsChild="true">
-        <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Icon" Class="@TriggerClass"
+        <BbButton Variant="@Variant" Size="ButtonSize.Icon" Class="@TriggerClass"
                   aria-label="@Localizer["Theme.Switcher.Label"]">
             <LucideIcon Name="paintbrush" Class="h-4 w-4" />
         </BbButton>
@@ -106,6 +106,12 @@
 
 @code {
     private bool isOpen;
+
+    /// <summary>
+    /// The visual variant of the trigger button. Defaults to <see cref="ButtonVariant.Outline"/>.
+    /// </summary>
+    [Parameter]
+    public ButtonVariant Variant { get; set; } = ButtonVariant.Outline;
 
     /// <summary>
     /// Additional CSS classes for the trigger button.

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -3098,6 +3098,7 @@
   - PopoverContentClass : String
   - Strategy : PositioningStrategy
   - TriggerClass : String
+  - Variant : ButtonVariant
 
 ### BbTimePicker (BlazorBlueprint.Components)
   - Class : String


### PR DESCRIPTION
## Description

The `BbThemeSwitcher` trigger button was hardcoded to `ButtonVariant.Outline`, so it couldn't be matched to the surrounding UI. This adds a `Variant` parameter (default `ButtonVariant.Outline`, preserving current behaviour) bound to the trigger button — mirroring the existing `BbDarkModeToggle.Variant`.

```razor
<BbThemeSwitcher Variant="ButtonVariant.Ghost" />
```

**Changes:**
- New `Variant` parameter on `BbThemeSwitcher`, defaulting to `Outline`.
- "Trigger variants" live demo example + API Reference entry on the Theme page.
- Accepted API surface snapshot (`BbThemeSwitcher … Variant : ButtonVariant`).

Verified with a clean build (0 warnings) and the full test suite (67/67 passing). Default behaviour is unchanged, so this is non-breaking.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [ ] Blazor Server
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility
- [ ] Dark mode

## Related Issues

Closes #352