### PR TITLE
fix(dialog): honor ShowClose on programmatically opened dialogs

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DialogDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DialogDemo.razor
@@ -459,7 +459,8 @@
 
         <p class="text-muted-foreground text-sm">
             Use <code>DialogService.Open&lt;TComponent&gt;()</code> to render a fully custom dialog component.
-            Returns a <code>DialogResult</code>.
+            Returns a <code>DialogResult</code>. A close (&times;) button is shown by default; set
+            <code>ShowClose = false</code> in <code>DialogOpenOptions</code> to hide it.
         </p>
 
         <div class="flex items-center gap-4">

--- a/src/BlazorBlueprint.Components/Components/Dialog/Internals/ComponentDialog.razor
+++ b/src/BlazorBlueprint.Components/Components/Dialog/Internals/ComponentDialog.razor
@@ -1,4 +1,7 @@
 @using BlazorBlueprint.Components.Components.Dialog.Internals.Shared
+@using BlazorBlueprint.Icons.Lucide.Components
+@inject DialogService DialogService
+@inject IBbLocalizer Localizer
 
 <DialogHeader Title="@Dialog.Title"
               Description="@Dialog.Description"
@@ -10,10 +13,26 @@
                       Parameters="@Dialog.Parameters" />
 </CascadingValue>
 
+@* Close (X) button — gated on the ShowClose option. Rendered last so it is not the first
+   focusable element when focus is trapped. Independent of PreventClose, which only governs
+   Escape/backdrop dismissal: an explicit X is always a deliberate close. *@
+@if (Dialog.Options.ShowClose)
+{
+    <button type="button"
+            class="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none"
+            @onclick="Close">
+        <LucideIcon Name="x" Class="h-4 w-4" />
+        <span class="sr-only">@Localizer["Dialog.Close"]</span>
+    </button>
+}
+
 @code {
     [Parameter, EditorRequired]
     public ComponentDialogData Dialog { get; set; } = default!;
 
     [Parameter] public string? TitleId { get; set; }
     [Parameter] public string? DescriptionId { get; set; }
+
+    private void Close()
+        => DialogService.Resolve(Dialog.Id, DialogResult.Cancel());
 }


### PR DESCRIPTION
## Description

`DialogOpenOptions.ShowClose` had no effect: dialogs opened via `DialogService.OpenAsync<T>()` render through `BbDialogProvider → ComponentDialog → DialogHeader`, none of which rendered a close button or read `Options.ShowClose`. As a result, programmatically-opened component dialogs had **no X affordance at all**, regardless of the option's value (reported in #356).

`ComponentDialog` now renders a close (✕) button gated on `Options.ShowClose`, dismissing the dialog with `DialogResult.Cancel()`. It mirrors the declarative `BbDialogContent` close button — same markup/styling, the `Dialog.Close` localization key, and an `sr-only` accessible name.

**Notes:**
- `ShowClose` is **independent of `PreventClose`**. `PreventClose` only governs Escape/backdrop dismissal; an explicit X is always a deliberate close. A fully non-dismissable dialog sets both `PreventClose = true` and `ShowClose = false`.
- The button is rendered last so it isn't the first element focused by the focus trap.
- Scoped to component dialogs — `ShowClose` lives on `DialogOpenOptions` (the `OpenAsync<T>` path); Confirm/Alert/Prompt use their own option types.
- No public API change (`ShowClose` already existed), so no API-surface snapshot change.
- Demo: the existing "Edit User" example now shows the X by default; added a one-line note documenting `ShowClose = false`.

## Verification

Visually verified in the running Blazor Server demo with Playwright:
- The programmatic "Edit User" dialog now shows the X in the top-right.
- Clicking it dismisses the dialog (`Result: Cancelled`).
- The control is a native `<button>` with accessible name "Close" (via `sr-only` span).

Build clean (0 warnings), full test suite 67/67 passing.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [X] Blazor Server
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility
- [ ] Dark mode

## Related Issues

Closes #356