### PR TITLE
fix(sidebar): let explicit IsActive override auto location matching

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarMenuButton.razor
+++ b/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarMenuButton.razor
@@ -57,10 +57,13 @@ else
     public SidebarMenuButtonVariant Variant { get; set; } = SidebarMenuButtonVariant.Default;
 
     /// <summary>
-    /// Whether this menu item is active/selected.
+    /// Explicitly controls whether this menu item is active/selected. When set, this value takes
+    /// precedence over automatic <see cref="Href"/>/<see cref="Match"/> location matching — so
+    /// <c>false</c> forces the item inactive even if its href matches the current URL. Leave
+    /// <c>null</c> (the default) to derive the active state from the current location.
     /// </summary>
     [Parameter]
-    public bool IsActive { get; set; }
+    public bool? IsActive { get; set; }
 
     /// <summary>
     /// The element type to render. Defaults to Button, but automatically switches to Anchor if Href is provided.
@@ -106,10 +109,10 @@ else
     private bool isActiveByLocation;
 
     /// <summary>
-    /// Whether the button should render as active — either explicitly via <see cref="IsActive"/>
-    /// or because its <see cref="Href"/> matches the current location.
+    /// Whether the button should render as active. An explicit <see cref="IsActive"/> value wins;
+    /// otherwise the state is derived from whether <see cref="Href"/> matches the current location.
     /// </summary>
-    private bool ResolvedActive => IsActive || isActiveByLocation;
+    private bool ResolvedActive => IsActive ?? isActiveByLocation;
 
     protected override void OnInitialized()
     {

--- a/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarMenuSubButton.razor
+++ b/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarMenuSubButton.razor
@@ -51,10 +51,13 @@ else
     public NavLinkMatch Match { get; set; } = NavLinkMatch.Prefix;
 
     /// <summary>
-    /// Whether this submenu item is active/selected.
+    /// Explicitly controls whether this submenu item is active/selected. When set, this value takes
+    /// precedence over automatic <see cref="Href"/>/<see cref="Match"/> location matching — so
+    /// <c>false</c> forces the item inactive even if its href matches the current URL. Leave
+    /// <c>null</c> (the default) to derive the active state from the current location.
     /// </summary>
     [Parameter]
-    public bool IsActive { get; set; }
+    public bool? IsActive { get; set; }
 
     /// <summary>
     /// Button size variant.
@@ -80,10 +83,10 @@ else
     private bool isActiveByLocation;
 
     /// <summary>
-    /// Whether the button should render as active — either explicitly via <see cref="IsActive"/>
-    /// or because its <see cref="Href"/> matches the current location.
+    /// Whether the button should render as active. An explicit <see cref="IsActive"/> value wins;
+    /// otherwise the state is derived from whether <see cref="Href"/> matches the current location.
     /// </summary>
-    private bool ResolvedActive => IsActive || isActiveByLocation;
+    private bool ResolvedActive => IsActive ?? isActiveByLocation;
 
     protected override void OnInitialized()
     {

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -2866,7 +2866,7 @@
   - ChildContent : RenderFragment
   - Class : String
   - Href : String
-  - IsActive : Boolean
+  - IsActive : Boolean?
   - Match : NavLinkMatch
   - OnClick : EventCallback<MouseEventArgs>
   - Size : SidebarMenuButtonSize
@@ -2901,7 +2901,7 @@
   - ChildContent : RenderFragment
   - Class : String
   - Href : String
-  - IsActive : Boolean
+  - IsActive : Boolean?
   - Match : NavLinkMatch
   - Size : SidebarMenuSubButtonSize
 


### PR DESCRIPTION
## Description

`BbSidebarMenuButton` and `BbSidebarMenuSubButton` computed their active state as `IsActive || isActiveByLocation`, so an explicit `IsActive="false"` could **never** deactivate an item whose `Href` matched the current URL. This is most visible with `Href="/"`, which — under the default `Match="NavLinkMatch.Prefix"` — matches every route (standard Blazor `NavLink` behaviour). Regression from 3.11.0, when automatic `data-active`-on-navigation was added (the `|| isActiveByLocation` term). Reported in #361.

**Fix:** `IsActive` is now `bool?` (default `null`):
- `IsActive` **set** → that value wins (`true`/`false`), overriding location matching.
- `IsActive` **null** (default) → keep the automatic `Href`/`Match` location matching added in 3.11.0.

```csharp
public bool? IsActive { get; set; }
private bool ResolvedActive => IsActive ?? isActiveByLocation;
```

**Notes:**
- **Scope:** this fixes the *explicit-override* problem (the reporter manages active state via `IsActive`). The separate fact that `Href="/"` auto-matches every route is standard `NavLink` semantics, which the matcher intentionally mirrors — for an auto-managed home link, use `Match="NavLinkMatch.All"` as you would with `NavLink`.
- **API surface:** `IsActive : Boolean → Boolean?` on both components (snapshot updated). Source-compatible for normal markup (`IsActive="true"/"false"/"@expr"` all still bind); on the v3 branch.
- The default/auto path is provably unchanged: `null ?? isActiveByLocation` == old `false || isActiveByLocation`.

## Verification

Visually verified in the running Blazor Server demo with Playwright across five cases (read each item's `data-active` + screenshot). All passed:

| Case | Setup | Expected | Result |
|------|-------|----------|--------|
| A | Href matches URL, no `IsActive` | active | ✅ active |
| B | Href matches URL, `IsActive="false"` | inactive | ✅ inactive |
| C | Href no match, `IsActive="true"` | active | ✅ active |
| D | `Href="/" IsActive="false"` (reporter's case) | inactive | ✅ inactive |
| E | `Href="/" Match="NavLinkMatch.All"`, no `IsActive`, off-home | inactive | ✅ inactive |

Build clean (0 warnings), full test suite 67/67 passing.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [X] Blazor Server
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility
- [ ] Dark mode

## Related Issues

Closes #361