### PR TITLE
feat(select-family): align trigger heights to h-10 + MultiSelect SingleLine option

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/MultiSelect/single-line.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/MultiSelect/single-line.txt
@@ -1,0 +1,30 @@
+@* Default: tags wrap onto more rows and the trigger grows to fit. *@
+<BbMultiSelect TValue="string"
+               Options="technologies"
+               @bind-Values="selected"
+               Placeholder="Select technologies..."
+               MaxDisplayTags="3" />
+
+@* SingleLine: one fixed-height row — overflowing tags are clipped while the
+   "+N more" indicator and chevron stay pinned and visible. *@
+<BbMultiSelect TValue="string"
+               Options="technologies"
+               @bind-Values="selected"
+               Placeholder="Select technologies..."
+               MaxDisplayTags="3"
+               SingleLine="true" />
+
+@code {
+    private IEnumerable<string>? selected =
+        new[] { "react", "vue", "angular", "blazor", "nextjs", "dotnet" };
+
+    private readonly SelectOption<string>[] technologies =
+    [
+        new("react", "React"),
+        new("vue", "Vue.js"),
+        new("angular", "Angular"),
+        new("blazor", "Blazor"),
+        new("nextjs", "Next.js"),
+        new("dotnet", ".NET"),
+    ];
+}

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MultiSelectDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MultiSelectDemo.razor
@@ -89,6 +89,41 @@
         <CodeBlock Source="Components/MultiSelect/country.txt" />
     </section>
 
+    <!-- Single Line -->
+    <section class="space-y-4">
+        <h2 class="text-2xl font-semibold">Single Line</h2>
+        <p class="text-sm text-muted-foreground">
+            By default the trigger wraps tags onto additional rows and grows to fit. Set
+            <code>SingleLine="true"</code> to keep it one row at a fixed height — overflowing tags are
+            clipped while the "+N more" indicator and chevron stay pinned and visible. Both controls
+            below share the same selection.
+        </p>
+
+        <div class="grid gap-4 sm:grid-cols-2">
+            <div class="flex flex-col gap-2">
+                <span class="text-xs font-medium text-muted-foreground">Default (wraps &amp; grows)</span>
+                <BbMultiSelect TValue="string"
+                            Options="technologies"
+                            @bind-Values="singleLineValues"
+                            Placeholder="Select technologies..."
+                            MaxDisplayTags="3"
+                            PopoverWidth="w-[240px]" />
+            </div>
+            <div class="flex flex-col gap-2">
+                <span class="text-xs font-medium text-muted-foreground">SingleLine="true"</span>
+                <BbMultiSelect TValue="string"
+                            Options="technologies"
+                            @bind-Values="singleLineValues"
+                            Placeholder="Select technologies..."
+                            MaxDisplayTags="3"
+                            SingleLine="true"
+                            PopoverWidth="w-[240px]" />
+            </div>
+        </div>
+
+        <CodeBlock Source="Components/MultiSelect/single-line.txt" />
+    </section>
+
     <!-- Non-String Value Types -->
     <section class="space-y-4">
         <h2 class="text-2xl font-semibold">Non-String Value Types</h2>
@@ -470,6 +505,10 @@
                 <ApiParameter Name="MaxDisplayTags" Type="int" Default="3">
                     Maximum number of tags to display before showing "+N more".
                 </ApiParameter>
+                <ApiParameter Name="SingleLine" Type="bool" Default="false">
+                    Keep the trigger on a single row at a fixed height, clipping overflowing tags
+                    (the "+N more" indicator and chevron stay pinned). Default wraps and grows.
+                </ApiParameter>
                 <ApiParameter Name="Disabled" Type="bool" Default="false">
                     Whether the multiselect is disabled.
                 </ApiParameter>
@@ -539,6 +578,10 @@
 
     // Country example
     private IEnumerable<string>? selectedCountries;
+
+    // Single line example (shared by the wrap/single-line comparison)
+    private IEnumerable<string>? singleLineValues =
+        new[] { "react", "vue", "angular", "blazor", "nextjs", "dotnet" };
 
     // Framework example
     private IEnumerable<string>? selectedFrameworks;

--- a/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Combobox/BbCombobox.razor.cs
@@ -494,7 +494,7 @@ public partial class BbCombobox<TValue> : ComponentBase
         "disabled:opacity-50 disabled:pointer-events-none",
         "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         _isOpen ? ActiveClass : null,
-        "h-9 px-3",
+        "h-10 px-3",
         string.IsNullOrWhiteSpace(Class) ? PopoverWidth : null,
         Class
     );

--- a/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor
+++ b/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor
@@ -14,12 +14,12 @@
                         aria-describedby="@AriaDescribedBy"
                         disabled="@Disabled"
                         class="@TriggerCssClass">
-            <div class="flex flex-wrap items-center gap-1 flex-1 min-w-0">
+            <div class="@TagListClass">
                 @if (HasSelectedItems)
                 {
                     @foreach (var value in SelectedValues.Take(MaxDisplayTags))
                     {
-                        <BbBadge @key="value" Variant="BadgeVariant.Secondary" Class="gap-1">
+                        <BbBadge @key="value" Variant="BadgeVariant.Secondary" Class="@TagBadgeClass">
                             @GetDisplayText(value)
                             <button type="button"
                                     class="@TagRemoveButtonCssClass"
@@ -30,7 +30,9 @@
                             </button>
                         </BbBadge>
                     }
-                    @if (OverflowCount > 0)
+                    @* In wrap mode "+N more" flows with the tags; in single-line mode it is pinned
+                       to the right group below so it stays visible while the tags clip. *@
+                    @if (OverflowCount > 0 && !SingleLine)
                     {
                         <span class="text-xs text-muted-foreground">+@OverflowCount more</span>
                     }
@@ -40,7 +42,11 @@
                     <span class="text-muted-foreground">@EffectivePlaceholder</span>
                 }
             </div>
-            <div class="flex items-center gap-1 ml-2">
+            <div class="flex shrink-0 items-center gap-1 ml-2">
+                @if (HasSelectedItems && OverflowCount > 0 && SingleLine)
+                {
+                    <span class="shrink-0 whitespace-nowrap text-xs text-muted-foreground">+@OverflowCount more</span>
+                }
                 @if (HasSelectedItems)
                 {
                     <button type="button"

--- a/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor.cs
@@ -173,6 +173,14 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
     public int MaxDisplayTags { get; set; } = 3;
 
     /// <summary>
+    /// When <c>true</c>, the trigger stays a single row at a fixed height: selected tags that
+    /// don't fit are clipped, while the "+N more" indicator and chevron remain pinned and visible.
+    /// When <c>false</c> (the default), tags wrap onto additional rows and the trigger grows to fit.
+    /// </summary>
+    [Parameter]
+    public bool SingleLine { get; set; }
+
+    /// <summary>
     /// Gets or sets the width of the popover content.
     /// Ignored when MatchTriggerWidth is true.
     /// </summary>
@@ -832,10 +840,26 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
         "disabled:opacity-50 disabled:pointer-events-none",
         "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         _isOpen ? ActiveClass : null,
-        "min-h-9 px-3 py-1.5",
+        // Single-line keeps a fixed height so wrapping tags can't grow the trigger; the default
+        // uses a min-height so the trigger expands to fit tags that wrap onto further rows.
+        SingleLine ? "h-10 px-3 py-1.5" : "min-h-10 px-3 py-1.5",
         PopoverWidth,
         Class
     );
+
+    /// <summary>
+    /// CSS for the tag list container. Single-line clips overflowing tags on one row; the default
+    /// wraps them onto additional rows.
+    /// </summary>
+    private string TagListClass => SingleLine
+        ? "flex flex-nowrap items-center gap-1 flex-1 min-w-0 overflow-hidden"
+        : "flex flex-wrap items-center gap-1 flex-1 min-w-0";
+
+    /// <summary>
+    /// CSS for each selected tag badge. In single-line mode tags keep their size (and clip) rather
+    /// than shrinking to fit.
+    /// </summary>
+    private string TagBadgeClass => SingleLine ? "gap-1 shrink-0" : "gap-1";
 
     /// <summary>
     /// Gets the CSS class for the tag remove button.

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -2205,6 +2205,7 @@
   - SearchQueryChanged : EventCallback<String>
   - SelectAllLabel : String
   - ShowSelectAll : Boolean
+  - SingleLine : Boolean
   - Values : IEnumerable<TValue>
   - ValuesChanged : EventCallback<IEnumerable<TValue>>
   - ValuesExpression : Expression<Func<IEnumerable<TValue>>>


### PR DESCRIPTION
## Description

Two related improvements to the Select-family trigger sizing/layout.

### 1. Consistent trigger heights (h-10)
Trigger heights were inconsistent across components that are commonly placed together:

| Component | Before | After |
|-----------|--------|-------|
| `BbSelect` (+ `BbInput`, `BbButton` Default) | `h-10` (40px) | `h-10` (unchanged) |
| `BbCombobox` | `h-9` (36px) | **`h-10`** |
| `BbMultiSelect` | `min-h-9` (36px) | **`min-h-10`** |

Combobox and MultiSelect now match the 40px house standard, so a `Select`/`Combobox`/`MultiSelect`/`Input` no longer mismatch by 4px in the same row.

### 2. `SingleLine` option on `BbMultiSelect`
By default the MultiSelect trigger wraps tags onto additional rows and grows taller. The new opt-in `SingleLine` parameter (default `false`, so existing behaviour is unchanged) keeps it to a single fixed-height row:

```razor
<BbMultiSelect TValue="string" Options="technologies" @bind-Values="selected"
               MaxDisplayTags="3" SingleLine="true" />
```

- Trigger stays fixed `h-10`; the tag list becomes `flex-nowrap overflow-hidden` so chips clip instead of wrapping.
- The **"+N more" indicator and chevron are pinned to the right group** so they stay visible while the chips clip (they would otherwise be the first thing clipped).
- Count is still bounded by the existing `MaxDisplayTags`. A single chip wider than the control will clip mid-label — for guaranteed no-clip you'd want a width-aware/auto-fit mode, which can be added later if desired.

Added a side-by-side demo (wrap vs single-line, shared selection), a `single-line.txt` CodeExample, and an API Reference entry.

## Verification

Visually verified in the running Blazor Server demo with Playwright:
- Default control renders multi-row (~62px) and wraps. ✅
- `SingleLine="true"` renders a single row at exactly **40px**, chips clipped, with **"+N more" and chevron still visible/pinned** (measured within bounds). ✅

Build clean (0 warnings); full test suite 67/67 passing.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [X] Blazor Server
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility
- [ ] Dark mode

## Related Issues

_None — follow-up from a maintainer review of Select-family trigger consistency._