### PR TITLE
feat(datagrid): SelectAllScope option + exclusive "select all on this page"

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/select-all-scope.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/select-all-scope.txt
@@ -1,0 +1,21 @@
+@* CurrentPage: the header checkbox toggles only the current page's rows and
+   leaves selections on other pages untouched (no "this page / all items" menu).
+   Default is DataGridSelectAllScope.Prompt. *@
+<BbDataGrid TData="Person" Items="@people" InitialPageSize="5"
+            SelectionMode="DataTableSelectionMode.Multiple"
+            SelectedItemsChanged="HandleSelectionChanged">
+    <Columns>
+        <BbDataGridSelectColumn TData="Person"
+                                SelectAllScope="DataGridSelectAllScope.CurrentPage" />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Email)" />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable />
+    </Columns>
+</BbDataGrid>
+
+@code {
+    private List<Person> people = MockDataService.GeneratePersons(50);
+    private IReadOnlyCollection<Person> selected = Array.Empty<Person>();
+
+    private void HandleSelectionChanged(IReadOnlyCollection<Person> items) => selected = items;
+}

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
@@ -149,6 +149,35 @@
         <CodeBlock Source="Components/DataGrid/row-selection.txt" />
     </div>
 
+    <!-- ── Per-Page Select-All (SelectAllScope) ──────────────────── -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Per-Page Select-All</h2>
+            <p class="text-sm text-muted-foreground">
+                By default, the header checkbox of a paginated grid opens a menu to select all rows on the
+                current page or across every page. Set
+                <code class="bg-muted px-1 py-0.5 rounded">SelectAllScope="DataGridSelectAllScope.CurrentPage"</code>
+                to remove that menu — the header checkbox then toggles only the current page's rows and leaves
+                selections on other pages untouched. Select some rows, change pages, and the previous page's
+                selection is preserved.
+            </p>
+        </div>
+        <BbDataGrid TData="Person" Items="@people" InitialPageSize="5"
+                   SelectionMode="DataTableSelectionMode.Multiple"
+                   SelectedItemsChanged="HandlePerPageSelectionChanged">
+            <Columns>
+                <BbDataGridSelectColumn TData="Person" SelectAllScope="DataGridSelectAllScope.CurrentPage" />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Email)" />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable />
+            </Columns>
+        </BbDataGrid>
+        <p class="text-sm text-muted-foreground">
+            Selected across all pages: <span class="font-medium">@_perPageSelectedCount</span>
+        </p>
+        <CodeBlock Source="Components/DataGrid/select-all-scope.txt" />
+    </div>
+
     <!-- ── Compact Rows (CellClass / HeaderClass) ─────────────────── -->
     <div class="space-y-4">
         <div class="space-y-2">
@@ -1096,6 +1125,9 @@
                 <ApiParameter Name="Pinned" Type="ColumnPinning" Default="None">
                     Whether this column is pinned. Commonly set to BlazorBlueprint.Primitives.DataGrid.ColumnPinning.Left to keep the checkbox column visible when scrolling horizontally.
                 </ApiParameter>
+                <ApiParameter Name="SelectAllScope" Type="DataGridSelectAllScope" Default="Prompt">
+                    Select-all header behaviour when paginated. <code>Prompt</code> (default) shows a "this page / all items" menu across pages; <code>CurrentPage</code> removes the menu so the header checkbox toggles only the current page's rows, leaving other pages' selections intact.
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DataGridExpandColumn">
@@ -1346,6 +1378,13 @@
     private void HandleSelectionChanged(IReadOnlyCollection<Person> selected)
     {
         _selectedPeople = selected;
+    }
+
+    private int _perPageSelectedCount;
+
+    private void HandlePerPageSelectionChanged(IReadOnlyCollection<Person> selected)
+    {
+        _perPageSelectedCount = selected.Count;
     }
 
     private async ValueTask<BlazorBlueprint.Primitives.DataGrid.DataGridResult<Person>> LoadPeopleAsync(

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor
@@ -109,7 +109,7 @@
                                                                   Class="pointer-events-none" />
                                                     </BbDropdownMenuTrigger>
                                                     <BbDropdownMenuContent Side="PopoverSide.Bottom" Align="PopoverAlign.Start">
-                                                        <BbDropdownMenuItem OnClick="@HandleSelectAllOnCurrentPage">
+                                                        <BbDropdownMenuItem OnClick="@HandleSelectOnlyCurrentPage">
                                                             @Localizer["DataGrid.SelectAllOnPage", _processedData.Count()]
                                                         </BbDropdownMenuItem>
                                                         <BbDropdownMenuItem OnClick="@HandleSelectAllItems">

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
@@ -2426,7 +2426,16 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     {
         if (!isChecked)
         {
-            await HandleClearSelection();
+            // In current-page scope the header only governs the current page, so unchecking it
+            // deselects this page's rows and leaves selections on other pages intact.
+            if (SelectAllScope == DataGridSelectAllScope.CurrentPage)
+            {
+                await HandleDeselectCurrentPage();
+            }
+            else
+            {
+                await HandleClearSelection();
+            }
             return;
         }
 
@@ -2440,12 +2449,47 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
         await HandleSelectAllOnCurrentPage();
     }
 
+    private async Task HandleDeselectCurrentPage()
+    {
+        _gridState.Selection.DeselectAll(_processedData);
+        _selectAllDropdownOpen = false;
+        _stateVersion++;
+
+        if (SelectedItemsChanged.HasDelegate)
+        {
+            await SelectedItemsChanged.InvokeAsync(_gridState.Selection.SelectedItems);
+        }
+
+        await NotifyStateChangedAsync();
+        StateHasChanged();
+    }
+
     private async Task HandleSelectAllOnCurrentPage()
     {
         foreach (var item in _processedData)
         {
             _gridState.Selection.Select(item);
         }
+
+        _selectAllDropdownOpen = false;
+        _stateVersion++;
+
+        if (SelectedItemsChanged.HasDelegate)
+        {
+            await SelectedItemsChanged.InvokeAsync(_gridState.Selection.SelectedItems);
+        }
+
+        await NotifyStateChangedAsync();
+        StateHasChanged();
+    }
+
+    private async Task HandleSelectOnlyCurrentPage()
+    {
+        // From the multi-page menu, "select all on this page" is an exclusive choice: it replaces the
+        // entire selection (including rows on other pages) with just the current page's rows. This is
+        // distinct from the additive current-page header checkbox used by DataGridSelectAllScope.CurrentPage.
+        _gridState.Selection.Clear();
+        _gridState.Selection.SelectAll(_processedData);
 
         _selectAllDropdownOpen = false;
         _stateVersion++;
@@ -2546,8 +2590,14 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
         StateHasChanged();
     }
 
+    private DataGridSelectAllScope SelectAllScope =>
+        _columns.OfType<BbDataGridSelectColumn<TData>>().FirstOrDefault()?.SelectAllScope
+            ?? DataGridSelectAllScope.Prompt;
+
     private bool ShouldShowSelectAllPrompt() =>
-        _allSortedData.Any() && _gridState.Pagination.TotalItems > _processedData.Count();
+        SelectAllScope == DataGridSelectAllScope.Prompt
+        && _allSortedData.Any()
+        && _gridState.Pagination.TotalItems > _processedData.Count();
 
     private async Task HandleRowSelectionChanged(TData item, bool isChecked)
     {

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridSelectColumn.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridSelectColumn.razor.cs
@@ -41,6 +41,15 @@ public partial class BbDataGridSelectColumn<TData> : ComponentBase, IDataGridCol
     public string? HeaderClass { get; set; }
 
     /// <summary>
+    /// Controls the select-all header checkbox behaviour when the grid is paginated.
+    /// <see cref="DataGridSelectAllScope.Prompt"/> (the default) offers a "this page / all items"
+    /// menu across pages; <see cref="DataGridSelectAllScope.CurrentPage"/> removes the menu and makes
+    /// the header checkbox toggle only the current page's rows, leaving other pages' selections intact.
+    /// </summary>
+    [Parameter]
+    public DataGridSelectAllScope SelectAllScope { get; set; } = DataGridSelectAllScope.Prompt;
+
+    /// <summary>
     /// The parent DataGrid component. Set via cascading parameter.
     /// </summary>
     [CascadingParameter]

--- a/src/BlazorBlueprint.Components/Components/DataGrid/DataGridSelectAllScope.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/DataGridSelectAllScope.cs
@@ -1,0 +1,20 @@
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// Controls how the select-all header checkbox of a <see cref="BbDataGridSelectColumn{TData}"/>
+/// behaves when the grid is paginated.
+/// </summary>
+public enum DataGridSelectAllScope
+{
+    /// <summary>
+    /// The default. When more than one page of data exists, clicking the header checkbox opens a
+    /// menu offering "select all on this page" and "select all items" (across every page).
+    /// </summary>
+    Prompt,
+
+    /// <summary>
+    /// No menu is shown. The header checkbox toggles only the rows on the current page, leaving any
+    /// selections on other pages untouched.
+    /// </summary>
+    CurrentPage
+}

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -784,6 +784,7 @@
   - CellClass : String
   - HeaderClass : String
   - Pinned : ColumnPinning
+  - SelectAllScope : DataGridSelectAllScope
   - Width : String
   - ParentGrid : BbDataGrid<TData> [CascadingParameter]
 
@@ -3588,6 +3589,10 @@
 ### DashboardBackground (BlazorBlueprint.Components)
   - None = 0
   - Grid = 1
+
+### DataGridSelectAllScope (BlazorBlueprint.Components)
+  - Prompt = 0
+  - CurrentPage = 1
 
 ### DataTableSelectionMode (BlazorBlueprint.Components)
   - None = 0


### PR DESCRIPTION
## Description

Addresses the select-all confusion reported in #360 with two changes.

### 1. New `SelectAllScope` option (opt-in)
Adds `SelectAllScope` to `BbDataGridSelectColumn` (enum `DataGridSelectAllScope`, default `Prompt` — unchanged behaviour):

```razor
<BbDataGridSelectColumn TData="Person" SelectAllScope="DataGridSelectAllScope.CurrentPage" />
```

- `Prompt` (default): the current cross-page menu ("Select all on this page" / "Select all N items") when paginated.
- `CurrentPage`: removes the menu — the header checkbox toggles **only the current page's rows**, leaving selections on other pages intact (additive select, subtractive deselect). This is the "disable the menu / only affect the immediate page" behaviour requested in the issue.

### 2. Exclusive "Select all on this page" (behaviour fix)
In the default `Prompt` menu, **"Select all on this page" is now exclusive**: it replaces the entire selection (including rows on other pages) with just the current page. Previously it was additive, so choosing it after "Select all N items" appeared to do nothing — the confusion described in the issue. Implemented via a separate handler so it does **not** affect the additive `CurrentPage` scope above.

> ⚠️ **Behaviour change:** this changes the default menu's "Select all on this page" from additive to exclusive. Anyone who relied on the old additive menu behaviour to accumulate selections across pages via the menu is affected. (The `CurrentPage` scope in change 1 is purely opt-in.)

## Verification

Visually verified in the running Blazor Server demo with Playwright:

**`SelectAllScope="CurrentPage"`:**
- Header checkbox shows no menu; selecting page 1 → 5 selected.
- Navigating to page 2 preserves page 1 (still 5); selecting page 2 → 10 total.
- Deselecting page 2 → back to 5 (page 1 intact).
- The default grid still shows its dropdown menu (unchanged).

**Exclusive "Select all on this page" (default menu):**
- "Select all 50 items" → 50 selected; then "Select all on this page" → exactly the 5 current-page rows; page 2 confirmed deselected.

Build clean (0 warnings); full test suite 67/67 passing; API surface snapshot updated (new `SelectAllScope` param + `DataGridSelectAllScope` enum). Demo example, CodeExample, and API reference entry added.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [X] Blazor Server
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility
- [ ] Dark mode

## Related Issues

Closes #360