### PR TITLE
feat(calendar): clickable outside-month days + keyboard nav focus on open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-06-17
+
+### Added
+
+- **BbCalendar: selectable previous/next-month days** — "Outside" days shown for the adjacent months were rendered disabled purely for belonging to another month; they now keep their muted styling but are selectable. Clicking one selects that date and moves the view to its month. Dates disabled via `MinDate`/`MaxDate`/`DisabledDates` stay non-interactive. ([#370](https://github.com/blazorblueprintui/ui/pull/370))
+- **BbCalendar: `AutoFocus` parameter + `FocusActiveDayAsync()`** — New opt-in `AutoFocus` parameter moves focus to the active day on first render so arrow-key navigation works immediately (ideal for inline/revealed calendars), plus a public `FocusActiveDayAsync()` method for overlays that position their content asynchronously. ([#370](https://github.com/blazorblueprintui/ui/pull/370))
+
+### Fixed
+
+- **BbDatePicker: keyboard navigation didn't work when the calendar opened** — The calendar grid's key handler only runs once a day has focus, but opening the date-picker popover left focus on the trigger, so arrow keys scrolled the page instead of moving between days. The date picker now focuses the active day once the popover is positioned (via the calendar's new `FocusActiveDayAsync()`), re-focusing on each open. ([#370](https://github.com/blazorblueprintui/ui/pull/370))
+
+---
+
 ## 2026-06-14
 
 ### Added

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Calendar/auto-focus.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Calendar/auto-focus.txt
@@ -1,0 +1,1 @@
+<BbCalendar @bind-Selected="_selectedDate" AutoFocus="true" />

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CalendarDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CalendarDemo.razor
@@ -124,6 +124,35 @@
         <CodeBlock Source="Components/Calendar/week-start.txt" />
     </div>
 
+    <!-- Auto Focus -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Auto Focus</h2>
+            <p class="text-sm text-muted-foreground">
+                Set <code>AutoFocus</code> to move keyboard focus to the active day as soon as the calendar
+                renders, so arrow keys work immediately without clicking first. Ideal when the calendar
+                appears in a popover or dialog (the date picker uses this internally). Leave it off for
+                always-visible inline calendars to avoid stealing focus on page load.
+            </p>
+        </div>
+        <div class="space-y-3">
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _showAutoFocusCalendar = !_showAutoFocusCalendar)">
+                @(_showAutoFocusCalendar ? "Hide calendar" : "Show calendar")
+            </BbButton>
+            @if (_showAutoFocusCalendar)
+            {
+                <div class="border rounded-lg w-fit">
+                    <BbCalendar @bind-Selected="_autoFocusDate" AutoFocus="true" />
+                </div>
+                <p class="text-sm text-muted-foreground">
+                    Focus lands on the active day &mdash; use the arrow keys straight away. Selected:
+                    @(_autoFocusDate?.ToString("MMMM d, yyyy") ?? "None")
+                </p>
+            }
+        </div>
+        <CodeBlock Source="Components/Calendar/auto-focus.txt" />
+    </div>
+
     <AccessibilityList>
         <AriaAttributes>
             <AccessibilityItem>Uses role="grid" for the calendar table</AccessibilityItem>
@@ -179,6 +208,9 @@
                 <ApiParameter Name="ShowMonthYearDropdowns" Type="bool" Default="true">
                     Whether to show month/year dropdown selectors. When false, displays a simple text header.
                 </ApiParameter>
+                <ApiParameter Name="AutoFocus" Type="bool" Default="false">
+                    Whether to move keyboard focus to the active day when the calendar first renders, so arrow-key navigation works immediately. Useful for calendars shown in a popover or dialog.
+                </ApiParameter>
                 <ApiParameter Name="OnSelect" Type="EventCallback&lt;DateTime&gt;">
                     Callback when a date is selected.
                 </ApiParameter>
@@ -210,6 +242,8 @@
     private DateTime? _noWeekendsDate;
     private DateTime? _sundayStart;
     private DateTime? _mondayStart;
+    private DateTime? _autoFocusDate;
+    private bool _showAutoFocusCalendar;
 
     private DateTime _minDate = DateTime.Today;
     private DateTime _maxDate = DateTime.Today.AddDays(30);

--- a/src/BlazorBlueprint.Components/Components/Calendar/BbCalendar.razor
+++ b/src/BlazorBlueprint.Components/Components/Calendar/BbCalendar.razor
@@ -226,6 +226,17 @@
     public bool ShowMonthYearDropdowns { get; set; } = true;
 
     /// <summary>
+    /// Whether to move keyboard focus to the active day when the calendar first renders,
+    /// so arrow-key navigation works immediately. Best for calendars that become visible
+    /// on demand (e.g. revealed inline). For calendars inside a portal-based popover or
+    /// dialog, call <see cref="FocusActiveDayAsync"/> from the container's content-ready
+    /// event instead, since first render happens before the overlay is positioned.
+    /// Leave false for always-visible inline calendars to avoid stealing focus on load.
+    /// </summary>
+    [Parameter]
+    public bool AutoFocus { get; set; }
+
+    /// <summary>
     /// Additional CSS classes to apply to the calendar.
     /// </summary>
     [Parameter]
@@ -301,6 +312,30 @@
             _cachedShowOutsideDays = ShowOutsideDays;
             _cachedWeeks = null;
         }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // When requested, move focus to the active day on first render so an inline
+        // calendar is immediately keyboard-navigable. Calendars rendered inside a
+        // portal-based popover/dialog should instead call FocusActiveDayAsync() once
+        // their container reports it is ready (the date picker does this).
+        if (firstRender && AutoFocus)
+        {
+            await FocusActiveDayAsync();
+        }
+    }
+
+    /// <summary>
+    /// Moves keyboard focus to the currently active day so the calendar is ready for
+    /// arrow-key navigation. Call this after the calendar has become visible — for
+    /// example from a popover's content-ready callback when embedding the calendar in
+    /// your own overlay.
+    /// </summary>
+    public async Task FocusActiveDayAsync()
+    {
+        _focusedDate ??= GetFirstEnabledDayOfMonth();
+        await FocusCurrentButton();
     }
 
     private void InitializeFocusedDate()

--- a/src/BlazorBlueprint.Components/Components/Calendar/BbCalendar.razor
+++ b/src/BlazorBlueprint.Components/Components/Calendar/BbCalendar.razor
@@ -86,7 +86,8 @@
                             @foreach (var day in week)
                             {
                                 var isSelected = day.HasValue && Selected.HasValue && day.Value.Date == Selected.Value.Date;
-                                var isDisabled = day.HasValue && (IsDisabled(day.Value) || day.Value.Month != DisplayDate.Month);
+                                var isOutside = day.HasValue && (day.Value.Month != DisplayDate.Month || day.Value.Year != DisplayDate.Year);
+                                var isDisabled = day.HasValue && IsDisabled(day.Value);
                                 var isFocused = day.HasValue && _focusedDate.HasValue && day.Value.Date == _focusedDate.Value.Date;
                                 <td class="@GetCellClasses(day, isSelected)"
                                     role="gridcell"
@@ -95,7 +96,7 @@
                                     {
                                         <button type="button"
                                                 id="@GetDayId(day.Value)"
-                                                class="@GetDayClasses(day.Value, isSelected, isDisabled, isFocused)"
+                                                class="@GetDayClasses(day.Value, isSelected, isDisabled, isFocused, isOutside)"
                                                 disabled="@isDisabled"
                                                 tabindex="@(isFocused ? 0 : -1)"
                                                 @onclick="@(() => SelectDate(day.Value))"
@@ -574,6 +575,8 @@
     private const string DaySelectedClasses = "inline-flex h-9 w-9 items-center justify-center rounded-md text-sm font-normal ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground";
     private const string DayTodayClasses = "inline-flex h-9 w-9 items-center justify-center rounded-md text-sm font-normal ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground bg-accent text-accent-foreground";
     private const string DayDisabledClasses = "inline-flex h-9 w-9 items-center justify-center rounded-md text-sm font-normal ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground text-muted-foreground opacity-50";
+    // Outside (previous/next month) days: muted like disabled, but still interactive/clickable.
+    private const string DayOutsideClasses = "inline-flex h-9 w-9 items-center justify-center rounded-md text-sm font-normal ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground text-muted-foreground opacity-50";
 
     private string GetMonthName(int month) => MonthNames is { Length: 12 }
         ? MonthNames[month - 1]
@@ -610,6 +613,13 @@
         // Reset keyboard navigation mode on click selection
         _isKeyboardNavigating = false;
         _focusedDate = date;
+
+        // When an outside (previous/next month) day is selected, bring it into view
+        // by navigating the displayed month to match the selected date.
+        if (date.Month != DisplayDate.Month || date.Year != DisplayDate.Year)
+        {
+            DisplayDate = new DateTime(date.Year, date.Month, 1);
+        }
 
         Selected = date;
         await SelectedChanged.InvokeAsync(date);
@@ -688,13 +698,15 @@
         return string.IsNullOrEmpty(CellClass) ? baseClass : ClassNames.cn(baseClass, CellClass);
     }
 
-    private string GetDayClasses(DateTime date, bool isSelected, bool isDisabled, bool isFocused)
+    private string GetDayClasses(DateTime date, bool isSelected, bool isDisabled, bool isFocused, bool isOutside)
     {
         string baseClass;
         if (isSelected)
             baseClass = DaySelectedClasses;
         else if (isDisabled)
             baseClass = DayDisabledClasses;
+        else if (isOutside)
+            baseClass = DayOutsideClasses;
         else if (date.Date == DateTime.Today)
             baseClass = DayTodayClasses;
         else

--- a/src/BlazorBlueprint.Components/Components/DatePicker/BbDatePicker.razor
+++ b/src/BlazorBlueprint.Components/Components/DatePicker/BbDatePicker.razor
@@ -8,7 +8,7 @@
     Date Picker component - combines a button trigger with a calendar popover.
 *@
 
-<BbPopover @bind-Open="_isOpen">
+<BbPopover Open="_isOpen" OpenChanged="HandleOpenChanged">
     <BbPopoverTrigger AsChild="true">
         <BbButton Variant="ButtonVariant.Outline"
                 Class="@ButtonCssClass"
@@ -24,8 +24,9 @@
             }
         </BbButton>
     </BbPopoverTrigger>
-    <BbPopoverContent Class="w-auto p-0" Align="PopoverAlign.Start">
-        <BbCalendar Selected="@Value"
+    <BbPopoverContent Class="w-auto p-0" Align="PopoverAlign.Start" OnContentReady="@HandleContentReady">
+        <BbCalendar @ref="_calendar"
+                  Selected="@Value"
                   SelectedChanged="@HandleDateSelected"
                   MinDate="@MinDate"
                   MaxDate="@MaxDate"
@@ -36,6 +37,8 @@
 
 @code {
     private bool _isOpen;
+    private BbCalendar? _calendar;
+    private bool _focusDone;
     private FieldIdentifier _fieldIdentifier;
     private EditContext? _editContext;
 
@@ -145,6 +148,33 @@
         }
 
         _isOpen = false;
+    }
+
+    private void HandleOpenChanged(bool isOpen)
+    {
+        _isOpen = isOpen;
+
+        // Re-arm focus-on-open every time the popover opens, so the active day is
+        // focused again on the next open regardless of how the previous one closed
+        // (selecting a date closes via _isOpen directly, bypassing this callback).
+        if (isOpen)
+        {
+            _focusDone = false;
+        }
+    }
+
+    private async Task HandleContentReady()
+    {
+        // Move focus into the calendar once the popover is positioned, so the active
+        // day is focused and arrow-key navigation works immediately on open. Guard so
+        // a repositioning re-fire doesn't yank focus back from where the user navigated.
+        if (_focusDone || _calendar is null)
+        {
+            return;
+        }
+
+        _focusDone = true;
+        await _calendar.FocusActiveDayAsync();
     }
 
     /// <summary>

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -246,6 +246,7 @@
 
 ### BbCalendar (BlazorBlueprint.Components)
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
+  - AutoFocus : Boolean
   - CellClass : String
   - Class : String
   - CustomDayNames : String[]


### PR DESCRIPTION
## Summary

Two related Calendar enhancements:

### 1. Clickable previous/next-month days
Outside-month days were rendered `disabled` purely for belonging to another month, which blocked selection. They now keep their muted styling but are **selectable** — clicking one selects that date and navigates the displayed month to bring it into view. Genuinely disabled dates (`MinDate`/`MaxDate`/`DisabledDates`) remain non-interactive.

### 2. Keyboard navigation works when the calendar opens
The grid's keydown handler only fires when a day has focus, but nothing focused a day when the calendar appeared — so in a date-picker popover, focus stayed on the trigger and arrow keys just scrolled the page.

- Added an opt-in `AutoFocus` parameter that focuses the active day on first render (for inline/revealed calendars).
- Added a public `FocusActiveDayAsync()` method for overlays whose content positions asynchronously.
- Wired `BbDatePicker` to call it from the popover's content-ready callback, re-arming on each open so reopening refocuses the active day.

## Testing
- `dotnet test` — 67/67 pass (API surface baseline updated for the new `AutoFocus` parameter).
- Verified in-browser (Server demo):
  - Clicking a muted next-month day selects it and navigates to that month.
  - Opening the date picker focuses today's date in the grid; arrow keys navigate without scrolling the page; Enter selects and closes; reopening refocuses the selected day.
  - Inline `AutoFocus` reveal focuses the active day.

## Demo / docs
- New "Auto Focus" example on the Calendar demo page (live toggle + `auto-focus.txt` snippet + API Reference entry).

_(Supersedes #369, which GitHub auto-closed when its head branch was renamed.)_