### PR TITLE
fix(floating): render portal position with invariant culture

### DIFF
--- a/src/BlazorBlueprint.Primitives/Primitives/Floating/BbFloatingPortal.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Floating/BbFloatingPortal.razor
@@ -406,7 +406,10 @@
 
         // After positioning, include stored position so it survives Blazor re-renders
         // This prevents the content from "closing" when parent components re-render
-        return $"position: {Strategy.ToValue()}; z-index: {ZIndex}; left: {_positionLeft}px; top: {_positionTop}px; opacity: 1; visibility: visible;";
+        // Invariant culture so decimal coordinates always use a dot — locales with a
+        // decimal comma (e.g. de-DE) would otherwise produce invalid CSS (issue #374)
+        return FormattableString.Invariant(
+            $"position: {Strategy.ToValue()}; z-index: {ZIndex}; left: {_positionLeft}px; top: {_positionTop}px; opacity: 1; visibility: visible;");
     }
 
     private string GetMergedStyle()


### PR DESCRIPTION
## Description

`BbFloatingPortal` interpolated its `double` left/top coordinates into the inline style using the current culture. Under locales with a decimal comma (e.g. German), this produced invalid CSS values like `left: 123,45px`, causing floating content (popovers, tooltips, dropdowns) to stick to the top/left edge of the screen.

The position style is now rendered with `FormattableString.Invariant`, matching the invariant-culture formatting already used by the slider and resizable components.

Audited the rest of `src/` for the same pattern — all other CSS interpolations use integers or already format with `CultureInfo.InvariantCulture`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #374