### PR TITLE
feat(datagrid): add CellClassFunc for conditional per-cell styling

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/conditional-cell-formatting.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/conditional-cell-formatting.txt
@@ -1,0 +1,20 @@
+<BbDataGrid TData="Person" Items="@people" InitialPageSize="5">
+    <Columns>
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable />
+        <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" Sortable
+            CellClass="font-mono tabular-nums"
+            CellClassFunc="@(p => p.Salary >= 100000 ? "text-emerald-600 dark:text-emerald-400 font-semibold" : p.Salary < 60000 ? "text-destructive" : null)" />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Status)"
+            CellClassFunc="@(p => p.Status == "Inactive" ? "text-muted-foreground line-through" : null)" />
+    </Columns>
+</BbDataGrid>
+
+@code {
+    private List<Person> people = new();
+
+    protected override void OnInitialized()
+    {
+        people = MockDataService.GeneratePersons(50);
+    }
+}

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
@@ -1011,6 +1011,9 @@
                 <ApiParameter Name="CellClass" Type="string?">
                     Additional CSS classes applied to cells in this column.
                 </ApiParameter>
+                <ApiParameter Name="CellClassFunc" Type="Func&lt;TData, string?&gt;?">
+                    Computes additional CSS classes for a cell from the row's data item, applied in addition to CellClass. Use for conditional per-cell formatting.
+                </ApiParameter>
                 <ApiParameter Name="HeaderClass" Type="string?">
                     Additional CSS classes applied to the header cell of this column.
                 </ApiParameter>
@@ -1073,6 +1076,9 @@
                 </ApiParameter>
                 <ApiParameter Name="CellClass" Type="string?">
                     Additional CSS classes applied to cells in this column.
+                </ApiParameter>
+                <ApiParameter Name="CellClassFunc" Type="Func&lt;TData, string?&gt;?">
+                    Computes additional CSS classes for a cell from the row's data item, applied in addition to CellClass. Use for conditional per-cell formatting.
                 </ApiParameter>
                 <ApiParameter Name="HeaderClass" Type="string?">
                     Additional CSS classes applied to the header cell of this column.

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridStylingDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridStylingDemo.razor
@@ -121,6 +121,31 @@
         <CodeBlock Source="Components/DataGrid/row-column-styling.txt" />
     </div>
 
+    <!-- ── Conditional Cell Formatting ─────────────────────────────── -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Conditional Cell Formatting</h2>
+            <p class="text-sm text-muted-foreground">
+                Use <code class="bg-muted px-1 py-0.5 rounded">CellClassFunc</code> to compute
+                cell classes from the row's data item — style individual cells without replacing
+                their content via <code class="bg-muted px-1 py-0.5 rounded">CellTemplate</code>.
+                Combines with the static <code class="bg-muted px-1 py-0.5 rounded">CellClass</code>.
+            </p>
+        </div>
+        <BbDataGrid TData="Person" Items="@people" InitialPageSize="5">
+            <Columns>
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable />
+                <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" Sortable
+                    CellClass="font-mono tabular-nums"
+                    CellClassFunc="@(p => p.Salary >= 100000 ? "text-emerald-600 dark:text-emerald-400 font-semibold" : p.Salary < 60000 ? "text-destructive" : null)" />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Status)"
+                    CellClassFunc="@(p => p.Status == "Inactive" ? "text-muted-foreground line-through" : null)" />
+            </Columns>
+        </BbDataGrid>
+        <CodeBlock Source="Components/DataGrid/conditional-cell-formatting.txt" />
+    </div>
+
     <!-- ── Custom Styling Showcase ────────────────────────────────── -->
     <div class="space-y-8">
         <div class="space-y-2">

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor
@@ -423,7 +423,7 @@
 
                 <BlazorBlueprint.Primitives.DataGrid.BbDataGridCell
                     @key="@column.ColumnId"
-                    Class="@GetCellClass(column, isSelectColumn, isExpandColumn, isLastLeft, isFirstRight)"
+                    Class="@GetCellClass(column, isSelectColumn, isExpandColumn, isLastLeft, isFirstRight, item)"
                     style="@pinnedStyle"
                     data-pinned="@(column.Pinned != ColumnPinning.None ? "true" : null)">
                     @if (isExpandColumn)
@@ -608,7 +608,7 @@
 
                 <BlazorBlueprint.Primitives.DataGrid.BbDataGridCell
                     @key="@column.ColumnId"
-                    Class="@GetCellClass(column, isSelectColumn, isExpandColumn, isLastLeft, isFirstRight)"
+                    Class="@GetCellClass(column, isSelectColumn, isExpandColumn, isLastLeft, isFirstRight, item)"
                     style="@pinnedStyle"
                     data-pinned="@(column.Pinned != ColumnPinning.None ? "true" : null)">
                     @if (isSelectColumn)

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
@@ -2939,7 +2939,7 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     }
 
     private string GetCellClass(IDataGridColumn<TData> column, bool isSelectColumn,
-        bool isExpandColumn, bool isLastLeft, bool isFirstRight)
+        bool isExpandColumn, bool isLastLeft, bool isFirstRight, TData? item = null)
     {
         var baseClass = "p-4 align-middle transition-colors";
 
@@ -2967,11 +2967,12 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
         }
 
         var cellClass = column.CellClass;
+        var perItemClass = item != null ? column.CellClassFunc?.Invoke(item) : null;
 
         var overflowClass = HasTableFixed() ? "overflow-hidden" : "";
         var noWrapClass = column.NoWrap ? "whitespace-nowrap overflow-hidden text-ellipsis" : "";
 
-        return ClassNames.cn(baseClass, cellClass, overflowClass, noWrapClass, pinnedClass, separatorClass);
+        return ClassNames.cn(baseClass, cellClass, perItemClass, overflowClass, noWrapClass, pinnedClass, separatorClass);
     }
 
     private string? GetColumnWidthStyle(IDataGridColumn<TData> column)

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridHierarchyColumn.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridHierarchyColumn.razor.cs
@@ -93,6 +93,14 @@ public partial class BbDataGridHierarchyColumn<TData, TProp> : ComponentBase, ID
     public string? CellClass { get; set; }
 
     /// <summary>
+    /// Computes additional CSS classes for a cell from the row's data item,
+    /// applied in addition to <see cref="CellClass"/>. Use for conditional
+    /// per-cell formatting, e.g. <c>CellClassFunc="@(o => o.Total &lt; 0 ? "text-destructive" : null)"</c>.
+    /// </summary>
+    [Parameter]
+    public Func<TData, string?>? CellClassFunc { get; set; }
+
+    /// <summary>
     /// Additional CSS classes for the header cell.
     /// </summary>
     [Parameter]
@@ -155,6 +163,8 @@ public partial class BbDataGridHierarchyColumn<TData, TProp> : ComponentBase, ID
     ColumnPinning IDataGridColumn<TData>.Pinned => Pinned;
     RenderFragment<DataGridHeaderContext<TData>>? IDataGridColumn<TData>.HeaderTemplate => null;
     string? IDataGridColumn<TData>.CellClass => CellClass;
+
+    Func<TData, string?>? IDataGridColumn<TData>.CellClassFunc => CellClassFunc;
     string? IDataGridColumn<TData>.HeaderClass => HeaderClass;
     bool IDataGridColumn<TData>.NoWrap => NoWrap;
     AggregateFunction IDataGridColumn<TData>.Aggregate => AggregateFunction.None;

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridPropertyColumn.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridPropertyColumn.razor.cs
@@ -97,6 +97,14 @@ public partial class BbDataGridPropertyColumn<TData, TProp> : ComponentBase, IDa
     public string? CellClass { get; set; }
 
     /// <summary>
+    /// Computes additional CSS classes for a cell from the row's data item,
+    /// applied in addition to <see cref="CellClass"/>. Use for conditional
+    /// per-cell formatting, e.g. <c>CellClassFunc="@(o => o.Total &lt; 0 ? "text-destructive" : null)"</c>.
+    /// </summary>
+    [Parameter]
+    public Func<TData, string?>? CellClassFunc { get; set; }
+
+    /// <summary>
     /// Additional CSS classes for the header cell.
     /// </summary>
     [Parameter]
@@ -185,6 +193,8 @@ public partial class BbDataGridPropertyColumn<TData, TProp> : ComponentBase, IDa
     RenderFragment<DataGridHeaderContext<TData>>? IDataGridColumn<TData>.HeaderTemplate => null;
 
     string? IDataGridColumn<TData>.CellClass => CellClass;
+
+    Func<TData, string?>? IDataGridColumn<TData>.CellClassFunc => CellClassFunc;
 
     string? IDataGridColumn<TData>.HeaderClass => HeaderClass;
 

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridTemplateColumn.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridTemplateColumn.razor.cs
@@ -98,6 +98,14 @@ public partial class BbDataGridTemplateColumn<TData> : ComponentBase, IDataGridC
     public string? CellClass { get; set; }
 
     /// <summary>
+    /// Computes additional CSS classes for a cell from the row's data item,
+    /// applied in addition to <see cref="CellClass"/>. Use for conditional
+    /// per-cell formatting, e.g. <c>CellClassFunc="@(o => o.Total &lt; 0 ? "text-destructive" : null)"</c>.
+    /// </summary>
+    [Parameter]
+    public Func<TData, string?>? CellClassFunc { get; set; }
+
+    /// <summary>
     /// Additional CSS classes for the header cell.
     /// </summary>
     [Parameter]
@@ -189,6 +197,8 @@ public partial class BbDataGridTemplateColumn<TData> : ComponentBase, IDataGridC
             : null;
 
     string? IDataGridColumn<TData>.CellClass => CellClass;
+
+    Func<TData, string?>? IDataGridColumn<TData>.CellClassFunc => CellClassFunc;
 
     string? IDataGridColumn<TData>.HeaderClass => HeaderClass;
 

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/IDataGridColumn.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/IDataGridColumn.cs
@@ -118,6 +118,13 @@ public interface IDataGridColumn<TData> where TData : class
     public string? CellClass { get; }
 
     /// <summary>
+    /// Gets a callback that computes additional CSS classes for a cell based on the row's
+    /// data item. Applied in addition to <see cref="CellClass"/>, so static and per-row
+    /// classes can be combined. Returns null when no per-row styling is needed.
+    /// </summary>
+    public Func<TData, string?>? CellClassFunc => null;
+
+    /// <summary>
     /// Gets additional CSS classes for the header cell.
     /// </summary>
     public string? HeaderClass { get; }

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -738,6 +738,7 @@
 
 ### BbDataGridHierarchyColumn`2 (BlazorBlueprint.Components)
   - CellClass : String
+  - CellClassFunc : Func<TData, String>
   - CellTemplate : RenderFragment<DataGridCellContext<TData>>
   - FilterOptions : IEnumerable<SelectOption<String>>
   - FilterType : FilterFieldType?
@@ -762,6 +763,7 @@
   - Aggregate : AggregateFunction
   - AggregateFormat : String
   - CellClass : String
+  - CellClassFunc : Func<TData, String>
   - CellTemplate : RenderFragment<TData>
   - FilterOptions : IEnumerable<SelectOption<String>>
   - FilterType : FilterFieldType?
@@ -793,6 +795,7 @@
   - Aggregate : AggregateFunction
   - AggregateFormat : String
   - CellClass : String
+  - CellClassFunc : Func<TData, String>
   - ChildContent : RenderFragment<TData>
   - FilterBy : Expression<Func<TData, Object>>
   - FilterOptions : IEnumerable<SelectOption<String>>

--- a/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
@@ -1108,6 +1108,7 @@
   - Aggregate : AggregateFunction { get; }
   - AggregateFormat : String { get; }
   - CellClass : String { get; }
+  - CellClassFunc : Func<TData, String> { get; }
   - CellTemplate : RenderFragment<DataGridCellContext<TData>> { get; }
   - ColumnId : String { get; }
   - Filterable : Boolean { get; }


### PR DESCRIPTION
## Description

Adds a `CellClassFunc` parameter (`Func<TData, string?>`) to `BbDataGridPropertyColumn`, `BbDataGridTemplateColumn`, and `BbDataGridHierarchyColumn`. The delegate receives the row's data item and returns extra CSS classes for that cell, composed with the static `CellClass` via tailwind-merge — so cells can be conditionally formatted (e.g. negative totals in red) without replacing their content with a `CellTemplate`.

- New demo section "Conditional Cell Formatting" on the DataGrid Styling page + code snippet
- API Reference rows for PropertyColumn and TemplateColumn
- API surface snapshots updated (Components + Primitives)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing Checklist

- [x] Blazor Server
- [x] Blazor WebAssembly

## Related Issues

Closes #353