### PR TITLE
fix: swallow JSException on JS-interop dispose paths (WebView2 page reloads)

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Chart/Core/BbChartBase.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Chart/Core/BbChartBase.razor.cs
@@ -265,7 +265,7 @@ public abstract partial class BbChartBase : ComponentBase, IAsyncDisposable
                 await jsModule.InvokeVoidAsync("dispose", chartId);
                 await jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Circuit disconnected, ignore
             }

--- a/src/BlazorBlueprint.Components/Components/CurrencyInput/BbCurrencyInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/CurrencyInput/BbCurrencyInput.razor.cs
@@ -456,7 +456,7 @@ public partial class BbCurrencyInput : ComponentBase
                 await jsModule.InvokeVoidAsync("dispose", instanceId);
                 await jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
@@ -3123,7 +3123,7 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
             {
                 await columnsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }
@@ -3137,7 +3137,7 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
             {
                 await clipboardModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Components/Components/DataView/BbDataView.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataView/BbDataView.razor.cs
@@ -845,7 +845,7 @@ public partial class BbDataView<TItem> : ComponentBase, IAsyncDisposable where T
             {
                 await _jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Circuit disconnected during navigation — safe to ignore
             }

--- a/src/BlazorBlueprint.Components/Components/Input/BbInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Input/BbInput.razor.cs
@@ -374,7 +374,7 @@ public partial class BbInput : ComponentBase
                 await jsModule.InvokeVoidAsync("dispose", instanceId);
                 await jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Components/Components/InputField/BbInputField.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/InputField/BbInputField.razor.cs
@@ -588,7 +588,7 @@ public partial class BbInputField<TValue> : ComponentBase
                 await jsModule.InvokeVoidAsync("dispose", instanceId);
                 await jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Components/Components/InputGroup/BbInputGroupInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/InputGroup/BbInputGroupInput.razor.cs
@@ -309,7 +309,7 @@ public partial class BbInputGroupInput : ComponentBase
                 await jsModule.InvokeVoidAsync("dispose", instanceId);
                 await jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Components/Components/InputGroup/BbInputGroupTextarea.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/InputGroup/BbInputGroupTextarea.razor.cs
@@ -287,7 +287,7 @@ public partial class BbInputGroupTextarea : ComponentBase
                 await jsModule.InvokeVoidAsync("dispose", instanceId);
                 await jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Components/Components/MarkdownEditor/BbMarkdownEditor.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/MarkdownEditor/BbMarkdownEditor.razor.cs
@@ -426,13 +426,9 @@ public partial class BbMarkdownEditor : ComponentBase, IAsyncDisposable
                 await _module.InvokeVoidAsync("disposeListContinuation", _textareaRef);
                 await _module.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Circuit disconnected, ignore
-            }
-            catch (JSException)
-            {
-                // JS error during cleanup, ignore
             }
         }
 

--- a/src/BlazorBlueprint.Components/Components/MaskedInput/BbMaskedInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/MaskedInput/BbMaskedInput.razor.cs
@@ -424,7 +424,7 @@ public partial class BbMaskedInput : ComponentBase, IAsyncDisposable
             {
                 await _jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/MultiSelect/BbMultiSelect.razor.cs
@@ -765,7 +765,7 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
             {
                 await _multiSelectModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }
@@ -778,7 +778,7 @@ public partial class BbMultiSelect<TValue> : ComponentBase, IAsyncDisposable
             {
                 await _elementUtilsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Components/Components/NumericInput/BbNumericInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/NumericInput/BbNumericInput.razor.cs
@@ -491,7 +491,7 @@ public partial class BbNumericInput<TValue> : ComponentBase where TValue : struc
                 await jsModule.InvokeVoidAsync("dispose", instanceId);
                 await jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Components/Components/ResponsiveNav/BbResponsiveNavProvider.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/ResponsiveNav/BbResponsiveNavProvider.razor.cs
@@ -79,7 +79,7 @@ public partial class BbResponsiveNavProvider
                 await _module.InvokeVoidAsync("cleanup");
                 await _module.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Circuit disconnected, ignore
             }

--- a/src/BlazorBlueprint.Components/Components/RichTextEditor/BbRichTextEditor.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/RichTextEditor/BbRichTextEditor.razor.cs
@@ -771,7 +771,7 @@ public partial class BbRichTextEditor : ComponentBase, IAsyncDisposable
                 await _jsModule.InvokeVoidAsync("disposeEditor", _editorId);
                 await _jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect in Blazor Server - safe to ignore
             }

--- a/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarInset.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarInset.razor.cs
@@ -149,7 +149,7 @@ public partial class BbSidebarInset : IAsyncDisposable
             {
                 await module.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Circuit disconnected
             }

--- a/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarProvider.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarProvider.razor.cs
@@ -138,7 +138,7 @@ public partial class BbSidebarProvider
                 await _module.InvokeVoidAsync("cleanup");
                 await _module.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Circuit disconnected, ignore
             }

--- a/src/BlazorBlueprint.Components/Components/Tabs/BbTabsList.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Tabs/BbTabsList.razor.cs
@@ -136,7 +136,7 @@ public partial class BbTabsList : IAsyncDisposable
                 await _jsModule.InvokeVoidAsync("dispose", _componentId);
                 await _jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Circuit disconnected, ignore
             }

--- a/src/BlazorBlueprint.Components/Components/TagInput/BbTagInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/TagInput/BbTagInput.razor.cs
@@ -660,7 +660,7 @@ public partial class BbTagInput : ComponentBase, IAsyncDisposable
                 await _jsModule.InvokeVoidAsync("dispose", _instanceId);
                 await _jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Components/Components/Textarea/BbTextarea.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Textarea/BbTextarea.razor.cs
@@ -374,7 +374,7 @@ public partial class BbTextarea : ComponentBase
                 await jsModule.InvokeVoidAsync("dispose", instanceId);
                 await jsModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Components/Components/TreeView/BbTreeView.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/TreeView/BbTreeView.razor.cs
@@ -913,7 +913,7 @@ public partial class BbTreeView<TItem> : ComponentBase, IAsyncDisposable
                 await dragDropModule.InvokeVoidAsync("disposeDragDrop", instanceId);
                 await dragDropModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Circuit disconnected, ignore
             }

--- a/src/BlazorBlueprint.Primitives/Primitives/Sortable/BbSortable.razor.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/Sortable/BbSortable.razor.cs
@@ -252,7 +252,7 @@ public partial class BbSortable<TItem> : ComponentBase, IAsyncDisposable
                 await _module.InvokeVoidAsync("destroy", Id);
                 await _module.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Primitives/Primitives/TreeView/BbTreeView.razor.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/TreeView/BbTreeView.razor.cs
@@ -475,7 +475,7 @@ public partial class BbTreeView : IAsyncDisposable
                 await keyboardModule.InvokeVoidAsync("dispose", context.Id);
                 await keyboardModule.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Circuit disconnected, ignore
             }

--- a/src/BlazorBlueprint.Primitives/Services/FocusManager.cs
+++ b/src/BlazorBlueprint.Primitives/Services/FocusManager.cs
@@ -100,7 +100,7 @@ public class FocusManager : IFocusManager, IAsyncDisposable
             {
                 await _module.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }

--- a/src/BlazorBlueprint.Primitives/Services/PositioningService.cs
+++ b/src/BlazorBlueprint.Primitives/Services/PositioningService.cs
@@ -132,7 +132,7 @@ public class PositioningService : IPositioningService, IAsyncDisposable
             {
                 await _module.DisposeAsync();
             }
-            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {
                 // Expected during circuit disconnect
             }


### PR DESCRIPTION
## Description

Reloading a page hosting Blazor Blueprint components in a standalone WebView2 / MAUI Hybrid app crashes with `JSException: JS object instance with ID N does not exist (has it been disposed?)`. WebView2 tears the JS runtime down on reload before Blazor gets to dispose components, so any module cleanup call (`InvokeVoidAsync("dispose", ...)`, `module.DisposeAsync()`) made from `DisposeAsync` hits a JS object that is already gone. This is a known upstream issue (dotnet/maui#31942) with no ETA for a fix.

This PR handles it the same way #232 already did for most of the Primitives project: extend the existing dispose-path catch filter to the canonical form

```csharp
catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
```

rather than adding a second catch that sniffs the exception message (`ex.Message.Contains("does not exist")`) — message text is not a stable contract, varies across runtime versions/locales, and misses other JSException flavours thrown during teardown (e.g. `window is undefined` mid-navigation). On a dispose path there is nothing actionable to do with *any* JS error, so the type-based filter is both simpler and more robust.

**Coverage** (all JS-interop dispose/teardown catch sites that were missing `JSException`):

- **BlazorBlueprint.Components** — 22 sites across 20 files, all in `DisposeAsync` (Chart, CurrencyInput, DataGrid ×2, DataView, Input, InputField, InputGroupInput, InputGroupTextarea, MarkdownEditor, MaskedInput, MultiSelect ×2, NumericInput, ResponsiveNavProvider, RichTextEditor, SidebarInset, SidebarProvider, TabsList, TagInput, Textarea, TreeView)
- **BlazorBlueprint.Primitives** — 4 sites missed by #232: `BbTreeView`, `BbSortable`, `FocusManager`, `PositioningService`
- `BbMarkdownEditor` had a separate `catch (JSException)` block stacked after the filter; folded into the canonical filter

Initialization paths (`OnAfterRenderAsync` module loading) and runtime event handlers are deliberately **not** touched — a `JSException` there indicates a real bug (missing module export, bad argument) and must keep surfacing during development.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [x] Full solution builds with 0 warnings (TreatWarningsAsErrors)
- [x] `dotnet test` — 67/67 pass, API surface snapshots unchanged (no public API touched)
- [ ] Blazor Server
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)

## Related Issues

Supersedes #278 — thanks to @SimonDD7 for the report and the initial fix. This variant applies the established #232 filter pattern instead of message matching, and covers the remaining dispose sites (#278 covered ~32 of them via a stacked message-sniffing catch and also added a catch to an init path in `BbTabsList.OnAfterRenderAsync`, which would hide genuine JS errors).