### PR TITLE
feat(inputs): expose Element and FocusAsync on input components

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Input/programmatic-focus.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Input/programmatic-focus.txt
@@ -1,0 +1,11 @@
+<BbInput @ref="_focusTarget" Type="InputType.Text" Placeholder="Click the button to focus me" />
+<BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _focusTarget!.FocusAsync())">Focus</BbButton>
+
+@code {
+    private BbInput? _focusTarget;
+
+    // FocusAsync is also available on BbTextarea, BbInputField, BbInputGroupInput,
+    // BbInputGroupTextarea, BbNumericInput, BbCurrencyInput, BbMaskedInput, BbTagInput,
+    // BbFormFieldInput, and BbFormFieldTextarea. The raw ElementReference is exposed
+    // via the Element property for advanced JS interop scenarios.
+}

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/InputDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/InputDemo.razor
@@ -320,6 +320,26 @@
         <CodeBlock Source="Components/Input/update-timing.txt" />
     </div>
 
+    <!-- Programmatic Focus -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Programmatic Focus</h2>
+            <p class="text-sm text-muted-foreground">
+                Capture the component with <code class="text-xs bg-muted px-1 py-0.5 rounded">@@ref</code> and call
+                <code class="text-xs bg-muted px-1 py-0.5 rounded">FocusAsync()</code> to focus the input without JS interop.
+                The underlying <code class="text-xs bg-muted px-1 py-0.5 rounded">ElementReference</code> is also exposed
+                via the <code class="text-xs bg-muted px-1 py-0.5 rounded">Element</code> property.
+                Available on Input, Textarea, InputField, InputGroup inputs, NumericInput, CurrencyInput, MaskedInput,
+                TagInput, and the FormFieldInput / FormFieldTextarea wrappers.
+            </p>
+        </div>
+        <div class="flex gap-4 items-start max-w-md">
+            <BbInput @ref="_focusTarget" Type="InputType.Text" Placeholder="Click the button to focus me" />
+            <BbButton Variant="ButtonVariant.Outline" OnClick="@(() => _focusTarget!.FocusAsync())">Focus</BbButton>
+        </div>
+        <CodeBlock Source="Components/Input/programmatic-focus.txt" />
+    </div>
+
     <!-- Form Validation with EditForm -->
     <div class="space-y-4">
         <div class="space-y-2">
@@ -424,12 +444,19 @@
                 <ApiParameter Name="AriaInvalid" Type="bool?" Default="null">
                     Manually sets aria-invalid. When null, automatically determined from EditContext validation state.
                 </ApiParameter>
+                <ApiParameter Name="FocusAsync()" Type="ValueTask">
+                    Sets focus to the underlying input element. Capture the component with @@ref to call it.
+                </ApiParameter>
+                <ApiParameter Name="Element" Type="ElementReference">
+                    The underlying input element reference, e.g. for advanced JS interop.
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>
 </div>
 
 @code {
+    private BbInput? _focusTarget;
     private string? boundValue;
     private string? _immediateValue;
     private string? _onChangeValue;

--- a/src/BlazorBlueprint.Components/Components/CurrencyInput/BbCurrencyInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/CurrencyInput/BbCurrencyInput.razor.cs
@@ -445,6 +445,16 @@ public partial class BbCurrencyInput : ComponentBase
         return decimal.TryParse(input, NumberStyles.Number, CultureInfo.InvariantCulture, out result);
     }
 
+    /// <summary>
+    /// Gets the underlying input element reference, e.g. for JS interop.
+    /// </summary>
+    public ElementReference Element => inputRef;
+
+    /// <summary>
+    /// Sets focus to the underlying input element.
+    /// </summary>
+    public ValueTask FocusAsync() => inputRef.FocusAsync();
+
     public async ValueTask DisposeAsync()
     {
         disposed = true;

--- a/src/BlazorBlueprint.Components/Components/FormFieldInput/BbFormFieldInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/FormFieldInput/BbFormFieldInput.razor.cs
@@ -159,6 +159,11 @@ public partial class BbFormFieldInput<TValue> : FormFieldBase
     /// </summary>
     public BbInputField<TValue>? InputFieldRef => _inputRef;
 
+    /// <summary>
+    /// Sets focus to the underlying input element.
+    /// </summary>
+    public ValueTask FocusAsync() => _inputRef?.FocusAsync() ?? ValueTask.CompletedTask;
+
     /// <inheritdoc />
     protected override bool IsInvalid => _hasError || base.IsInvalid;
 

--- a/src/BlazorBlueprint.Components/Components/FormFieldTextarea/BbFormFieldTextarea.razor
+++ b/src/BlazorBlueprint.Components/Components/FormFieldTextarea/BbFormFieldTextarea.razor
@@ -7,7 +7,8 @@
         <BbFieldLabel For="@ControlId">@Label</BbFieldLabel>
     }
     <BbFieldContent>
-        <BbTextarea Value="@Value"
+        <BbTextarea @ref="_textareaRef"
+                    Value="@Value"
                     ValueChanged="HandleValueChanged"
                     ValueExpression="@ValueExpression"
                     Name="@Name"

--- a/src/BlazorBlueprint.Components/Components/FormFieldTextarea/BbFormFieldTextarea.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/FormFieldTextarea/BbFormFieldTextarea.razor.cs
@@ -28,6 +28,8 @@ namespace BlazorBlueprint.Components;
 /// </example>
 public partial class BbFormFieldTextarea : FormFieldBase
 {
+    private BbTextarea? _textareaRef;
+
     // --- Textarea Pass-Through Parameters ---
 
     /// <summary>
@@ -102,6 +104,16 @@ public partial class BbFormFieldTextarea : FormFieldBase
     /// </summary>
     [Parameter]
     public string? InputClass { get; set; }
+
+    /// <summary>
+    /// Gets the underlying Textarea component reference.
+    /// </summary>
+    public BbTextarea? TextareaRef => _textareaRef;
+
+    /// <summary>
+    /// Sets focus to the underlying textarea element.
+    /// </summary>
+    public ValueTask FocusAsync() => _textareaRef?.FocusAsync() ?? ValueTask.CompletedTask;
 
     /// <inheritdoc />
     protected override LambdaExpression? GetFieldExpression() => ValueExpression;

--- a/src/BlazorBlueprint.Components/Components/Input/BbInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Input/BbInput.razor.cs
@@ -363,6 +363,16 @@ public partial class BbInput : ComponentBase
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Gets the underlying input element reference, e.g. for JS interop.
+    /// </summary>
+    public ElementReference Element => inputRef;
+
+    /// <summary>
+    /// Sets focus to the underlying input element.
+    /// </summary>
+    public ValueTask FocusAsync() => inputRef.FocusAsync();
+
     public async ValueTask DisposeAsync()
     {
         disposed = true;

--- a/src/BlazorBlueprint.Components/Components/InputField/BbInputField.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/InputField/BbInputField.razor.cs
@@ -572,6 +572,16 @@ public partial class BbInputField<TValue> : ComponentBase
         }
     }
 
+    /// <summary>
+    /// Gets the underlying input element reference, e.g. for JS interop.
+    /// </summary>
+    public ElementReference Element => inputRef;
+
+    /// <summary>
+    /// Sets focus to the underlying input element.
+    /// </summary>
+    public ValueTask FocusAsync() => inputRef.FocusAsync();
+
     public async ValueTask DisposeAsync()
     {
         disposed = true;

--- a/src/BlazorBlueprint.Components/Components/InputGroup/BbInputGroupInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/InputGroup/BbInputGroupInput.razor.cs
@@ -298,6 +298,16 @@ public partial class BbInputGroupInput : ComponentBase
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Gets the underlying input element reference, e.g. for JS interop.
+    /// </summary>
+    public ElementReference Element => inputRef;
+
+    /// <summary>
+    /// Sets focus to the underlying input element.
+    /// </summary>
+    public ValueTask FocusAsync() => inputRef.FocusAsync();
+
     public async ValueTask DisposeAsync()
     {
         disposed = true;

--- a/src/BlazorBlueprint.Components/Components/InputGroup/BbInputGroupTextarea.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/InputGroup/BbInputGroupTextarea.razor.cs
@@ -276,6 +276,16 @@ public partial class BbInputGroupTextarea : ComponentBase
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Gets the underlying textarea element reference, e.g. for JS interop.
+    /// </summary>
+    public ElementReference Element => inputRef;
+
+    /// <summary>
+    /// Sets focus to the underlying textarea element.
+    /// </summary>
+    public ValueTask FocusAsync() => inputRef.FocusAsync();
+
     public async ValueTask DisposeAsync()
     {
         disposed = true;

--- a/src/BlazorBlueprint.Components/Components/MaskedInput/BbMaskedInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/MaskedInput/BbMaskedInput.razor.cs
@@ -415,6 +415,16 @@ public partial class BbMaskedInput : ComponentBase, IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Gets the underlying input element reference, e.g. for JS interop.
+    /// </summary>
+    public ElementReference Element => _inputRef;
+
+    /// <summary>
+    /// Sets focus to the underlying input element.
+    /// </summary>
+    public ValueTask FocusAsync() => _inputRef.FocusAsync();
+
     public async ValueTask DisposeAsync()
     {
         GC.SuppressFinalize(this);

--- a/src/BlazorBlueprint.Components/Components/NumericInput/BbNumericInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/NumericInput/BbNumericInput.razor.cs
@@ -480,6 +480,16 @@ public partial class BbNumericInput<TValue> : ComponentBase where TValue : struc
         return TValue.TryParse(input, CultureInfo.InvariantCulture, out result);
     }
 
+    /// <summary>
+    /// Gets the underlying input element reference, e.g. for JS interop.
+    /// </summary>
+    public ElementReference Element => inputRef;
+
+    /// <summary>
+    /// Sets focus to the underlying input element.
+    /// </summary>
+    public ValueTask FocusAsync() => inputRef.FocusAsync();
+
     public async ValueTask DisposeAsync()
     {
         disposed = true;

--- a/src/BlazorBlueprint.Components/Components/TagInput/BbTagInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/TagInput/BbTagInput.razor.cs
@@ -640,6 +640,16 @@ public partial class BbTagInput : ComponentBase, IAsyncDisposable
     // IAsyncDisposable
     // ══════════════════════════════════════════════════════════════════
 
+    /// <summary>
+    /// Gets the underlying tag entry input element reference, e.g. for JS interop.
+    /// </summary>
+    public ElementReference Element => _inputRef;
+
+    /// <summary>
+    /// Sets focus to the underlying tag entry input element.
+    /// </summary>
+    public ValueTask FocusAsync() => _inputRef.FocusAsync();
+
     public async ValueTask DisposeAsync()
     {
         _disposed = true;

--- a/src/BlazorBlueprint.Components/Components/Textarea/BbTextarea.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Textarea/BbTextarea.razor.cs
@@ -363,6 +363,16 @@ public partial class BbTextarea : ComponentBase
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Gets the underlying textarea element reference, e.g. for JS interop.
+    /// </summary>
+    public ElementReference Element => inputRef;
+
+    /// <summary>
+    /// Sets focus to the underlying textarea element.
+    /// </summary>
+    public ValueTask FocusAsync() => inputRef.FocusAsync();
+
     public async ValueTask DisposeAsync()
     {
         disposed = true;


### PR DESCRIPTION
## Description

Input components previously kept their `ElementReference` private, so setting focus programmatically required custom JS interop (#266).

This adds a consistent public surface to the text-entry components:

- `FocusAsync()` — focuses the underlying input/textarea element
- `Element` — the raw `ElementReference` for advanced JS interop

Covered: `BbInput`, `BbTextarea`, `BbInputField`, `BbInputGroupInput`, `BbInputGroupTextarea`, `BbNumericInput`, `BbCurrencyInput`, `BbMaskedInput`, `BbTagInput`; `BbFormFieldInput` and `BbFormFieldTextarea` forward `FocusAsync()` to their inner control (the latter gains a `TextareaRef` accessor to match `InputFieldRef`).

Demo: new "Programmatic Focus" section on the Input page + snippet + API Reference entries.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing Checklist

- [x] Blazor Server
- [x] Blazor WebAssembly

## Related Issues

Closes #266