### PR TITLE
fix(sidebar): fire OnClick when menu button renders as anchor

### DIFF
--- a/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarMenuButton.razor
+++ b/src/BlazorBlueprint.Components/Components/Sidebar/BbSidebarMenuButton.razor
@@ -155,6 +155,7 @@ else
                data-state="@(CollapsibleContext?.Open ?? false ? "open" : "closed")"
                aria-current="@(ResolvedActive ? "page" : null)"
                aria-expanded="@(CollapsibleContext?.Open ?? false)"
+               @onclick="HandleClick"
                @attributes="AdditionalAttributes">
                 @ChildContent
             </a>


### PR DESCRIPTION
## Description

`BbSidebarMenuButton` automatically renders as an `<a>` when `Href` is provided, but only the `<button>` render branch attached `@onclick="HandleClick"` — the anchor branch didn't. As a result, `OnClick` callbacks (and the collapsible toggle path) never fired for navigation items, e.g. closing the mobile sidebar after tapping a menu link in a MAUI/Blazor Hybrid app.

The anchor branch now wires the same `HandleClick` handler; navigation still proceeds normally.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing Checklist

- [x] Blazor Server
- [x] Blazor WebAssembly

## Related Issues

Fixes #378