### PR TITLE
feat(datetime-picker): add BbDateTimePicker and BbFormFieldDateTimePicker

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DateTimePicker/24-hour.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DateTimePicker/24-hour.txt
@@ -1,0 +1,1 @@
+<BbDateTimePicker @bind-Value="_hour24Value" TimeFormat="TimeFormat.Hour24" />

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DateTimePicker/basic.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DateTimePicker/basic.txt
@@ -1,0 +1,1 @@
+<BbDateTimePicker @bind-Value="_basicValue" />

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DateTimePicker/constraints.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DateTimePicker/constraints.txt
@@ -1,0 +1,14 @@
+<!-- Next 30 days only -->
+<BbDateTimePicker @bind-Value="_rangeValue"
+                  MinDate="@DateTime.Today"
+                  MaxDate="@DateTime.Today.AddDays(30)" />
+
+<!-- No weekends -->
+<BbDateTimePicker @bind-Value="_noWeekendsValue" DisabledDates="@IsWeekend" />
+
+@code {
+    private bool IsWeekend(DateTime date)
+    {
+        return date.DayOfWeek == DayOfWeek.Saturday || date.DayOfWeek == DayOfWeek.Sunday;
+    }
+}

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DateTimePicker/custom-format.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DateTimePicker/custom-format.txt
@@ -1,0 +1,3 @@
+<BbDateTimePicker @bind-Value="_formatValue"
+                  DateTimeFormat="MMMM d, yyyy 'at' h:mm tt"
+                  Placeholder="Schedule meeting" />

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DateTimePicker/minute-step.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DateTimePicker/minute-step.txt
@@ -1,0 +1,2 @@
+<BbDateTimePicker @bind-Value="_step5Value" MinuteStep="5" />
+<BbDateTimePicker @bind-Value="_step15Value" MinuteStep="15" />

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DateTimePicker/with-seconds.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DateTimePicker/with-seconds.txt
@@ -1,0 +1,1 @@
+<BbDateTimePicker @bind-Value="_secondsValue" ShowSeconds="true" />

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/FormFieldDateTimePicker/basic.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/FormFieldDateTimePicker/basic.txt
@@ -1,0 +1,3 @@
+<BbFormFieldDateTimePicker @bind-Value="appointment"
+                          Label="Appointment"
+                          HelperText="When should we meet?" />

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/FormFieldDateTimePicker/constraints.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/FormFieldDateTimePicker/constraints.txt
@@ -1,0 +1,6 @@
+<BbFormFieldDateTimePicker @bind-Value="deliverySlot"
+                          Label="Delivery slot"
+                          HelperText="Select a slot within the next 14 days."
+                          MinDate="DateTime.Today"
+                          MaxDate="DateTime.Today.AddDays(14)"
+                          MinuteStep="15" />

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/FormFieldDateTimePicker/disabled.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/FormFieldDateTimePicker/disabled.txt
@@ -1,0 +1,4 @@
+<BbFormFieldDateTimePicker Value="DateTime.Now"
+                          Label="Locked appointment"
+                          HelperText="This appointment cannot be changed."
+                          Disabled="true" />

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/FormFieldDateTimePicker/editform.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/FormFieldDateTimePicker/editform.txt
@@ -1,0 +1,7 @@
+<EditForm Model="formModel" OnValidSubmit="HandleFormSubmit">
+    <DataAnnotationsValidator />
+    <BbFormFieldDateTimePicker @bind-Value="formModel.Appointment"
+                              Label="Appointment"
+                              Placeholder="Pick a date and time..." />
+    <BbButton Type="ButtonType.Submit">Submit</BbButton>
+</EditForm>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DateTimePickerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DateTimePickerDemo.razor
@@ -1,0 +1,307 @@
+@page "/components/date-time-picker"
+@using System.ComponentModel.DataAnnotations
+
+<PageTitle>Date Time Picker Component - Blazor Blueprint</PageTitle>
+
+<div class="space-y-8 max-w-4xl">
+    <div>
+        <div class="space-y-3">
+            <h1 class="text-4xl font-bold tracking-tight">Date Time Picker Component</h1>
+            <p class="text-xl text-muted-foreground">
+                A combined date and time picker with a popover calendar and time selectors.
+            </p>
+        </div>
+    </div>
+
+    <!-- Basic Example -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Basic Example</h2>
+            <p class="text-sm text-muted-foreground">
+                Click the button to open the popover. Selecting a date keeps the time portion,
+                and adjusting the time keeps the date. The popover stays open so both can be set
+                in one go — click outside or press Escape to close.
+            </p>
+        </div>
+        <BbDateTimePicker @bind-Value="_basicValue" />
+        <p class="text-sm text-muted-foreground">
+            Selected: @(_basicValue?.ToString("g") ?? "None")
+        </p>
+        <CodeBlock Source="Components/DateTimePicker/basic.txt" />
+    </div>
+
+    <!-- 24-Hour Format -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">24-Hour Format</h2>
+            <p class="text-sm text-muted-foreground">
+                Use <code class="text-xs bg-muted px-1 py-0.5 rounded">TimeFormat="TimeFormat.Hour24"</code>
+                to hide the AM/PM toggle and cycle hours from 00 to 23.
+            </p>
+        </div>
+        <BbDateTimePicker @bind-Value="_hour24Value" TimeFormat="TimeFormat.Hour24" />
+        <CodeBlock Source="Components/DateTimePicker/24-hour.txt" />
+    </div>
+
+    <!-- With Seconds -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">With Seconds</h2>
+            <p class="text-sm text-muted-foreground">
+                Enable the seconds selector with <code class="text-xs bg-muted px-1 py-0.5 rounded">ShowSeconds</code>.
+                The trigger display switches to the culture-aware "G" format automatically.
+            </p>
+        </div>
+        <BbDateTimePicker @bind-Value="_secondsValue" ShowSeconds="true" />
+        <CodeBlock Source="Components/DateTimePicker/with-seconds.txt" />
+    </div>
+
+    <!-- Minute Step -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Minute Intervals</h2>
+            <p class="text-sm text-muted-foreground">
+                Use <code class="text-xs bg-muted px-1 py-0.5 rounded">MinuteStep</code> to increment
+                minutes in fixed intervals.
+            </p>
+        </div>
+        <div class="flex flex-wrap gap-4">
+            <div>
+                <p class="text-sm mb-2">5-minute intervals:</p>
+                <BbDateTimePicker @bind-Value="_step5Value" MinuteStep="5" />
+            </div>
+            <div>
+                <p class="text-sm mb-2">15-minute intervals:</p>
+                <BbDateTimePicker @bind-Value="_step15Value" MinuteStep="15" />
+            </div>
+        </div>
+        <CodeBlock Source="Components/DateTimePicker/minute-step.txt" />
+    </div>
+
+    <!-- Custom Format & Placeholder -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Custom Format &amp; Placeholder</h2>
+            <p class="text-sm text-muted-foreground">
+                Customize the trigger display with <code class="text-xs bg-muted px-1 py-0.5 rounded">DateTimeFormat</code>
+                and the empty-state text with <code class="text-xs bg-muted px-1 py-0.5 rounded">Placeholder</code>.
+            </p>
+        </div>
+        <BbDateTimePicker @bind-Value="_formatValue"
+                          DateTimeFormat="MMMM d, yyyy 'at' h:mm tt"
+                          Placeholder="Schedule meeting" />
+        <CodeBlock Source="Components/DateTimePicker/custom-format.txt" />
+    </div>
+
+    <!-- Date Constraints -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Date Constraints</h2>
+            <p class="text-sm text-muted-foreground">
+                Limit the selectable date range with <code class="text-xs bg-muted px-1 py-0.5 rounded">MinDate</code> /
+                <code class="text-xs bg-muted px-1 py-0.5 rounded">MaxDate</code>, or disable specific dates
+                (e.g. weekends) with <code class="text-xs bg-muted px-1 py-0.5 rounded">DisabledDates</code>.
+            </p>
+        </div>
+        <div class="space-y-4">
+            <div>
+                <p class="text-sm mb-2">Next 30 days only:</p>
+                <BbDateTimePicker @bind-Value="_rangeValue" MinDate="@DateTime.Today" MaxDate="@DateTime.Today.AddDays(30)" />
+            </div>
+            <div>
+                <p class="text-sm mb-2">No weekends:</p>
+                <BbDateTimePicker @bind-Value="_noWeekendsValue" DisabledDates="@IsWeekend" />
+            </div>
+        </div>
+        <CodeBlock Source="Components/DateTimePicker/constraints.txt" />
+    </div>
+
+    <!-- Form Validation with EditForm -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Form Validation</h2>
+            <p class="text-sm text-muted-foreground">
+                DateTimePicker integrates with Blazor's EditForm and EditContext for model validation.
+                Use <code class="text-xs bg-muted px-1 py-0.5 rounded">@@bind-Value</code> within an EditForm and
+                validation errors will automatically apply error styling via <code class="text-xs bg-muted px-1 py-0.5 rounded">aria-invalid</code>.
+            </p>
+        </div>
+        <EditForm Model="_formModel" OnValidSubmit="HandleFormSubmit" class="max-w-md space-y-4">
+            <DataAnnotationsValidator />
+
+            <div class="space-y-2">
+                <label class="text-sm font-medium">Appointment</label>
+                <BbDateTimePicker @bind-Value="_formModel.Appointment" Placeholder="Select appointment time" />
+                <ValidationMessage For="@(() => _formModel.Appointment)" class="text-sm text-destructive" />
+            </div>
+
+            <div class="flex gap-4">
+                <BbButton Type="ButtonType.Submit" Variant="ButtonVariant.Default">Submit</BbButton>
+                <BbButton Type="ButtonType.Button" Variant="ButtonVariant.Outline" OnClick="ResetForm">Reset</BbButton>
+            </div>
+
+            @if (!string.IsNullOrEmpty(_formMessage))
+            {
+                <div class="p-4 bg-card rounded-lg border">
+                    <p class="text-sm">@_formMessage</p>
+                </div>
+            }
+        </EditForm>
+    </div>
+
+    <!-- Accessibility Notes -->
+    <AccessibilityList>
+        <AriaAttributes>
+            <AccessibilityItem>
+                Trigger button includes <code class="text-xs bg-muted px-1 py-0.5 rounded">aria-haspopup</code> and <code class="text-xs bg-muted px-1 py-0.5 rounded">aria-expanded</code> via the Popover primitive
+            </AccessibilityItem>
+            <AccessibilityItem>
+                Calendar uses <code class="text-xs bg-muted px-1 py-0.5 rounded">role="grid"</code> with <code class="text-xs bg-muted px-1 py-0.5 rounded">role="gridcell"</code> on each day
+            </AccessibilityItem>
+            <AccessibilityItem>
+                <code class="text-xs bg-muted px-1 py-0.5 rounded">aria-selected</code> indicates the currently selected date
+            </AccessibilityItem>
+            <AccessibilityItem>
+                Time stepper buttons include descriptive <code class="text-xs bg-muted px-1 py-0.5 rounded">aria-label</code> ("Increment hour", "Decrement minute", etc.)
+            </AccessibilityItem>
+            <AccessibilityItem>
+                Disabled dates have the <code class="text-xs bg-muted px-1 py-0.5 rounded">disabled</code> attribute on day buttons
+            </AccessibilityItem>
+        </AriaAttributes>
+        <KeyboardNavigation>
+            <KeyboardShortcutItem Description="Move to the previous/next day">
+                <BbKbd>ArrowLeft</BbKbd> / <BbKbd>ArrowRight</BbKbd>
+            </KeyboardShortcutItem>
+            <KeyboardShortcutItem Description="Move to the same day in the previous/next week">
+                <BbKbd>ArrowUp</BbKbd> / <BbKbd>ArrowDown</BbKbd>
+            </KeyboardShortcutItem>
+            <KeyboardShortcutItem Description="Jump to the first/last day of the month">
+                <BbKbd>Home</BbKbd> / <BbKbd>End</BbKbd>
+            </KeyboardShortcutItem>
+            <KeyboardShortcutItem Description="Go to the previous/next month (or year with Shift)">
+                <BbKbd>PageUp</BbKbd> / <BbKbd>PageDown</BbKbd>
+            </KeyboardShortcutItem>
+            <KeyboardShortcutItem Description="Select the focused date">
+                <BbKbd>Enter</BbKbd> / <BbKbd>Space</BbKbd>
+            </KeyboardShortcutItem>
+            <KeyboardShortcutItem Description="Move between the time stepper buttons">
+                <BbKbd>Tab</BbKbd>
+            </KeyboardShortcutItem>
+            <KeyboardShortcutItem Description="Close the popover">
+                <BbKbd>Escape</BbKbd>
+            </KeyboardShortcutItem>
+        </KeyboardNavigation>
+    </AccessibilityList>
+
+    <!-- API Reference -->
+    <section class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">API Reference</h2>
+            <p class="text-muted-foreground">Component properties and parameters.</p>
+        </div>
+
+        <div class="space-y-4">
+            <ApiReference ComponentName="DateTimePicker">
+                <ApiParameter Name="Value" Type="DateTime?">
+                    The selected date and time. Use @@bind-Value for two-way binding.
+                </ApiParameter>
+                <ApiParameter Name="DateTimeFormat" Type="string?" Default="null">
+                    Format string for displaying the value. When null, uses "G" (with seconds) if ShowSeconds is true, otherwise "g".
+                </ApiParameter>
+                <ApiParameter Name="Placeholder" Type="string?" Default="&quot;Pick a date and time&quot;">
+                    Placeholder text when no value is selected.
+                </ApiParameter>
+                <ApiParameter Name="MinDate" Type="DateTime?">
+                    Minimum selectable date.
+                </ApiParameter>
+                <ApiParameter Name="MaxDate" Type="DateTime?">
+                    Maximum selectable date.
+                </ApiParameter>
+                <ApiParameter Name="DisabledDates" Type="Func&lt;DateTime, bool&gt;?">
+                    Function to determine if a date should be disabled.
+                </ApiParameter>
+                <ApiParameter Name="FirstDayOfWeek" Type="DayOfWeek?" Default="null">
+                    The first day of the week. Defaults to the current culture setting.
+                </ApiParameter>
+                <ApiParameter Name="DayTemplate" Type="RenderFragment&lt;CalendarDayContext&gt;?" Default="null">
+                    Template for rendering custom content inside each calendar day button. When null, the day number is rendered.
+                </ApiParameter>
+                <ApiParameter Name="DayClassFunc" Type="Func&lt;DateTime, string?&gt;?" Default="null">
+                    Function returning additional CSS classes for a specific calendar day button.
+                </ApiParameter>
+                <ApiParameter Name="TimeFormat" Type="TimeFormat" Default="Hour12">
+                    The time format for the time selectors (12-hour with AM/PM or 24-hour).
+                </ApiParameter>
+                <ApiParameter Name="ShowSeconds" Type="bool" Default="false">
+                    Whether to show the seconds selector.
+                </ApiParameter>
+                <ApiParameter Name="MinuteStep" Type="int" Default="1">
+                    The minute step interval.
+                </ApiParameter>
+                <ApiParameter Name="Disabled" Type="bool" Default="false">
+                    Whether the date time picker is disabled.
+                </ApiParameter>
+                <ApiParameter Name="Required" Type="bool" Default="false">
+                    Whether the date time picker is required.
+                </ApiParameter>
+                <ApiParameter Name="Class" Type="string?" Default="null">
+                    Additional CSS classes for the trigger button.
+                </ApiParameter>
+            </ApiReference>
+        </div>
+    </section>
+
+    <LocalizationSection
+        Description="The date time picker placeholder, time selector labels, and action buttons are configurable."
+        Labels="@(new LocalizationSection.LabelInfo[]
+        {
+            new("Placeholder", "Pick a date and time", "Placeholder text when no value is selected"),
+            new("Hour", "Hour", "Label above the hour selector"),
+            new("Minute", "Min", "Label above the minute selector"),
+            new("Second", "Sec", "Label above the second selector"),
+            new("Now", "Now", "Button that sets the value to the current date and time"),
+            new("Clear", "Clear", "Button that clears the selected value"),
+        })"
+        CultureAware="true"
+        CultureDescription="The internal calendar uses CultureInfo.CurrentCulture for month/day names. The DateTimeFormat parameter accepts standard .NET format strings that respect the current culture."
+        CodeExample="@(@"services.AddBlazorBlueprintComponents(opts =>
+{
+    opts.Set(""DateTimePicker.Placeholder"", ""Datum und Uhrzeit auswählen"");
+});")" />
+</div>
+
+@code {
+    private DateTime? _basicValue;
+    private DateTime? _hour24Value;
+    private DateTime? _secondsValue;
+    private DateTime? _step5Value;
+    private DateTime? _step15Value;
+    private DateTime? _formatValue;
+    private DateTime? _rangeValue;
+    private DateTime? _noWeekendsValue;
+
+    private bool IsWeekend(DateTime date)
+    {
+        return date.DayOfWeek == DayOfWeek.Saturday || date.DayOfWeek == DayOfWeek.Sunday;
+    }
+
+    private DateTimeFormModel _formModel = new();
+    private string? _formMessage;
+
+    private void HandleFormSubmit()
+    {
+        _formMessage = $"Form submitted! Appointment: {_formModel.Appointment?.ToString("g")}";
+    }
+
+    private void ResetForm()
+    {
+        _formModel = new();
+        _formMessage = null;
+    }
+
+    private class DateTimeFormModel
+    {
+        [Required(ErrorMessage = "Please select an appointment time.")]
+        public DateTime? Appointment { get; set; }
+    }
+}

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldDateTimePickerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldDateTimePickerDemo.razor
@@ -1,14 +1,14 @@
-@page "/components/form-field-date-picker"
+@page "/components/form-field-date-time-picker"
 @using System.ComponentModel.DataAnnotations
 
-<PageTitle>FormFieldDatePicker Component - Blazor Blueprint</PageTitle>
+<PageTitle>FormFieldDateTimePicker Component - Blazor Blueprint</PageTitle>
 
 <div class="space-y-8 max-w-4xl">
     <div>
         <div class="space-y-3">
-            <h1 class="text-4xl font-bold tracking-tight">FormFieldDatePicker</h1>
+            <h1 class="text-4xl font-bold tracking-tight">FormFieldDateTimePicker</h1>
             <p class="text-xl text-muted-foreground">
-                A form field wrapper for DatePicker with built-in label, helper text, and error messages.
+                A form field wrapper for DateTimePicker with built-in label, helper text, and error messages.
             </p>
         </div>
     </div>
@@ -18,18 +18,10 @@
         <h2 class="text-lg font-semibold">Which form component?</h2>
         <div class="space-y-2 text-sm text-muted-foreground">
             <p><strong>Text input</strong> (string, int, date, etc.)? &rarr; <a href="/components/form-field-input" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldInput&lt;T&gt;</a></p>
-            <p><strong>Textarea</strong>? &rarr; <a href="/components/form-field-textarea" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldTextarea</a></p>
-            <p><strong>Numeric input</strong>? &rarr; <a href="/components/form-field-numeric-input" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldNumericInput</a></p>
-            <p><strong>Date picker</strong>? &rarr; <strong>FormFieldDatePicker</strong> (this page)</p>
+            <p><strong>Date picker</strong>? &rarr; <a href="/components/form-field-date-picker" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldDatePicker</a></p>
             <p><strong>Time picker</strong>? &rarr; <a href="/components/form-field-time-picker" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldTimePicker</a></p>
-            <p><strong>Date &amp; time picker</strong>? &rarr; <a href="/components/form-field-date-time-picker" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldDateTimePicker</a></p>
-            <p><strong>Checkbox</strong>? &rarr; <a href="/components/form-field-checkbox" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldCheckbox</a></p>
-            <p><strong>Switch</strong>? &rarr; <a href="/components/form-field-switch" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldSwitch</a></p>
-            <p><strong>Select dropdown</strong>? &rarr; <a href="/components/form-field-select" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldSelect</a></p>
-            <p><strong>Native select</strong>? &rarr; <a href="/components/form-field-native-select" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldNativeSelect</a></p>
-            <p><strong>Radio group</strong>? &rarr; <a href="/components/form-field-radio-group" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldRadioGroup</a></p>
-            <p><strong>Searchable select</strong>? &rarr; <a href="/components/form-field-combobox" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldCombobox</a></p>
-            <p><strong>Multi-select</strong>? &rarr; <a href="/components/form-field-multi-select" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldMultiSelect</a></p>
+            <p><strong>Date &amp; time picker</strong>? &rarr; <strong>FormFieldDateTimePicker</strong> (this page)</p>
+            <p><strong>Date range picker</strong>? &rarr; <a href="/components/form-field-date-range-picker" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldDateRangePicker</a></p>
         </div>
     </div>
 
@@ -38,42 +30,44 @@
         <div class="space-y-2">
             <h2 class="text-2xl font-semibold">Basic Usage</h2>
             <p class="text-sm text-muted-foreground">
-                A date picker with an auto-associated label and helper text.
+                A date time picker with an auto-associated label and helper text.
             </p>
         </div>
         <div class="max-w-md">
-            <BbFormFieldDatePicker @bind-Value="_startDate"
-                                  Label="Start date"
-                                  HelperText="When should the project begin?" />
+            <BbFormFieldDateTimePicker @bind-Value="_appointment"
+                                      Label="Appointment"
+                                      HelperText="When should we meet?" />
         </div>
         <div class="rounded-lg border p-4 bg-muted/50">
             <p class="text-sm font-medium mb-1">Selected:</p>
-            <p class="text-sm font-mono">@(_startDate?.ToString("d") ?? "(none)")</p>
+            <p class="text-sm font-mono">@(_appointment?.ToString("g") ?? "(none)")</p>
         </div>
-        <CodeBlock Source="Components/FormFieldDatePicker/basic.txt" />
+        <CodeBlock Source="Components/FormFieldDateTimePicker/basic.txt" />
     </div>
 
     <!-- With Constraints -->
     <div class="space-y-4">
         <div class="space-y-2">
-            <h2 class="text-2xl font-semibold">Date Constraints</h2>
+            <h2 class="text-2xl font-semibold">Constraints</h2>
             <p class="text-sm text-muted-foreground">
-                Use <code class="text-xs bg-muted px-1 py-0.5 rounded">MinDate</code> and
-                <code class="text-xs bg-muted px-1 py-0.5 rounded">MaxDate</code> to restrict the selectable range.
+                Use <code class="text-xs bg-muted px-1 py-0.5 rounded">MinDate</code> /
+                <code class="text-xs bg-muted px-1 py-0.5 rounded">MaxDate</code> to restrict the selectable range
+                and <code class="text-xs bg-muted px-1 py-0.5 rounded">MinuteStep</code> for fixed minute intervals.
             </p>
         </div>
         <div class="max-w-md">
-            <BbFormFieldDatePicker @bind-Value="_appointmentDate"
-                                  Label="Appointment date"
-                                  HelperText="Select a date within the next 30 days."
-                                  MinDate="DateTime.Today"
-                                  MaxDate="DateTime.Today.AddDays(30)" />
+            <BbFormFieldDateTimePicker @bind-Value="_deliverySlot"
+                                      Label="Delivery slot"
+                                      HelperText="Select a slot within the next 14 days."
+                                      MinDate="DateTime.Today"
+                                      MaxDate="DateTime.Today.AddDays(14)"
+                                      MinuteStep="15" />
         </div>
         <div class="rounded-lg border p-4 bg-muted/50">
             <p class="text-sm font-medium mb-1">Selected:</p>
-            <p class="text-sm font-mono">@(_appointmentDate?.ToString("d") ?? "(none)")</p>
+            <p class="text-sm font-mono">@(_deliverySlot?.ToString("g") ?? "(none)")</p>
         </div>
-        <CodeBlock Source="Components/FormFieldDatePicker/constraints.txt" />
+        <CodeBlock Source="Components/FormFieldDateTimePicker/constraints.txt" />
     </div>
 
     <!-- Disabled -->
@@ -81,16 +75,16 @@
         <div class="space-y-2">
             <h2 class="text-2xl font-semibold">Disabled</h2>
             <p class="text-sm text-muted-foreground">
-                A disabled date picker form field.
+                A disabled date time picker form field.
             </p>
         </div>
         <div class="max-w-md">
-            <BbFormFieldDatePicker Value="DateTime.Today"
-                                  Label="Locked date"
-                                  HelperText="This date cannot be changed."
-                                  Disabled="true" />
+            <BbFormFieldDateTimePicker Value="DateTime.Now"
+                                      Label="Locked appointment"
+                                      HelperText="This appointment cannot be changed."
+                                      Disabled="true" />
         </div>
-        <CodeBlock Source="Components/FormFieldDatePicker/disabled.txt" />
+        <CodeBlock Source="Components/FormFieldDateTimePicker/disabled.txt" />
     </div>
 
     <!-- EditForm Integration -->
@@ -99,16 +93,16 @@
             <h2 class="text-2xl font-semibold">EditForm Integration</h2>
             <p class="text-sm text-muted-foreground">
                 Validation errors display automatically inside an EditForm.
-                Try submitting without selecting a date.
+                Try submitting without selecting a date and time.
             </p>
         </div>
         <div class="max-w-md">
             <EditForm Model="_formModel" OnValidSubmit="HandleFormSubmit">
                 <DataAnnotationsValidator />
                 <div class="space-y-4">
-                    <BbFormFieldDatePicker @bind-Value="_formModel.EventDate"
-                                          Label="Event date"
-                                          Placeholder="Pick a date..." />
+                    <BbFormFieldDateTimePicker @bind-Value="_formModel.Appointment"
+                                              Label="Appointment"
+                                              Placeholder="Pick a date and time..." />
                     <BbButton Type="ButtonType.Submit">Submit</BbButton>
                 </div>
             </EditForm>
@@ -116,17 +110,17 @@
             {
                 <div class="mt-4 rounded-lg border border-green-200 bg-green-50 dark:bg-green-950 dark:border-green-800 p-4">
                     <p class="text-sm font-medium text-green-800 dark:text-green-200">
-                        Submitted: @_formModel.EventDate?.ToString("d")
+                        Submitted: @_formModel.Appointment?.ToString("g")
                     </p>
                 </div>
             }
         </div>
-        <CodeBlock Source="Components/FormFieldDatePicker/editform.txt" />
+        <CodeBlock Source="Components/FormFieldDateTimePicker/editform.txt" />
     </div>
 
     <AccessibilityList>
         <AriaAttributes>
-            <AccessibilityItem>Label visually associated with the date picker trigger</AccessibilityItem>
+            <AccessibilityItem>Label visually associated with the date time picker trigger</AccessibilityItem>
             <AccessibilityItem>Description linked via aria-describedby</AccessibilityItem>
             <AccessibilityItem>Validation errors displayed with aria-invalid</AccessibilityItem>
         </AriaAttributes>
@@ -139,12 +133,12 @@
             <p class="text-muted-foreground">Component properties and parameters.</p>
         </div>
         <div class="space-y-4">
-            <ApiReference ComponentName="FormFieldDatePicker">
+            <ApiReference ComponentName="FormFieldDateTimePicker">
                 <ApiParameter Name="Label" Type="string?" Default="null">
-                    The label text displayed above the date picker.
+                    The label text displayed above the date time picker.
                 </ApiParameter>
                 <ApiParameter Name="HelperText" Type="string?" Default="null">
-                    Helper text displayed below the date picker. Hidden during error state.
+                    Helper text displayed below the date time picker. Hidden during error state.
                 </ApiParameter>
                 <ApiParameter Name="ErrorText" Type="string?" Default="null">
                     Manual error text override. When the field is invalid and this is set, replaces auto-generated messages.
@@ -153,16 +147,16 @@
                     Layout orientation of the field.
                 </ApiParameter>
                 <ApiParameter Name="Value" Type="DateTime?" Default="null">
-                    The selected date value. Use @@bind-Value for two-way binding.
+                    The selected date and time value. Use @@bind-Value for two-way binding.
                 </ApiParameter>
                 <ApiParameter Name="ValueChanged" Type="EventCallback&lt;DateTime?&gt;">
-                    Callback invoked when the selected date changes.
+                    Callback invoked when the selected date and time changes.
                 </ApiParameter>
-                <ApiParameter Name="DateFormat" Type="string" Default="&quot;d&quot;">
-                    The date format to display (culture-aware short date pattern by default).
+                <ApiParameter Name="DateTimeFormat" Type="string?" Default="null">
+                    The date and time format to display. When null, uses "G" (with seconds) if ShowSeconds is true, otherwise "g".
                 </ApiParameter>
                 <ApiParameter Name="Placeholder" Type="string?" Default="null">
-                    Placeholder text when no date is selected.
+                    Placeholder text when no date and time is selected.
                 </ApiParameter>
                 <ApiParameter Name="MinDate" Type="DateTime?" Default="null">
                     The minimum selectable date.
@@ -176,14 +170,23 @@
                 <ApiParameter Name="FirstDayOfWeek" Type="DayOfWeek?" Default="null">
                     The first day of the week. Defaults to current culture setting.
                 </ApiParameter>
+                <ApiParameter Name="TimeFormat" Type="TimeFormat" Default="Hour12">
+                    The time format for the time selectors (12-hour with AM/PM or 24-hour).
+                </ApiParameter>
+                <ApiParameter Name="ShowSeconds" Type="bool" Default="false">
+                    Whether to show the seconds selector.
+                </ApiParameter>
+                <ApiParameter Name="MinuteStep" Type="int" Default="1">
+                    The minute step interval.
+                </ApiParameter>
                 <ApiParameter Name="Disabled" Type="bool" Default="false">
-                    Whether the date picker is disabled.
+                    Whether the date time picker is disabled.
                 </ApiParameter>
                 <ApiParameter Name="Required" Type="bool" Default="false">
-                    Whether the date picker is required.
+                    Whether the date time picker is required.
                 </ApiParameter>
                 <ApiParameter Name="InputClass" Type="string?" Default="null">
-                    Additional CSS classes applied to the inner DatePicker trigger button.
+                    Additional CSS classes applied to the inner DateTimePicker trigger button.
                 </ApiParameter>
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes applied to the outer Field container.
@@ -197,19 +200,19 @@
 </div>
 
 @code {
-    private DateTime? _startDate;
-    private DateTime? _appointmentDate;
+    private DateTime? _appointment;
+    private DateTime? _deliverySlot;
     private bool _formSubmitted;
-    private DatePickerFormModel _formModel = new();
+    private DateTimePickerFormModel _formModel = new();
 
     private void HandleFormSubmit()
     {
         _formSubmitted = true;
     }
 
-    private class DatePickerFormModel
+    private class DateTimePickerFormModel
     {
-        [Required(ErrorMessage = "Please select an event date.")]
-        public DateTime? EventDate { get; set; }
+        [Required(ErrorMessage = "Please select an appointment time.")]
+        public DateTime? Appointment { get; set; }
     }
 }

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldTimePickerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldTimePickerDemo.razor
@@ -22,6 +22,7 @@
             <p><strong>Numeric input</strong>? &rarr; <a href="/components/form-field-numeric-input" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldNumericInput</a></p>
             <p><strong>Date picker</strong>? &rarr; <a href="/components/form-field-date-picker" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldDatePicker</a></p>
             <p><strong>Time picker</strong>? &rarr; <strong>FormFieldTimePicker</strong> (this page)</p>
+            <p><strong>Date &amp; time picker</strong>? &rarr; <a href="/components/form-field-date-time-picker" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldDateTimePicker</a></p>
             <p><strong>Checkbox</strong>? &rarr; <a href="/components/form-field-checkbox" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldCheckbox</a></p>
             <p><strong>Switch</strong>? &rarr; <a href="/components/form-field-switch" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldSwitch</a></p>
             <p><strong>Select dropdown</strong>? &rarr; <a href="/components/form-field-select" class="text-primary underline underline-offset-4 hover:text-primary/80">FormFieldSelect</a></p>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/Index.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/Index.razor
@@ -275,6 +275,14 @@
                     </p>
                 </a>
 
+                <!-- Date Time Picker -->
+                <a href="/components/date-time-picker" class="group p-5 border rounded-lg hover:border-primary hover:bg-accent transition-colors no-underline">
+                    <h3 class="font-semibold text-lg mb-2 group-hover:text-primary">Date Time Picker</h3>
+                    <p class="text-sm text-muted-foreground">
+                        Combined date and time selection with calendar popover
+                    </p>
+                </a>
+
                 <!-- Dialog -->
                 <a href="/components/dialog" class="group p-5 border rounded-lg hover:border-primary hover:bg-accent transition-colors no-underline">
                     <h3 class="font-semibold text-lg mb-2 group-hover:text-primary">Dialog</h3>
@@ -392,6 +400,14 @@
                     <h3 class="font-semibold text-lg mb-2 group-hover:text-primary">Form Field Date Range Picker</h3>
                     <p class="text-sm text-muted-foreground">
                         Date range picker with built-in label, helper text, and error messages
+                    </p>
+                </a>
+
+                <!-- Form Field Date Time Picker -->
+                <a href="/components/form-field-date-time-picker" class="group p-5 border rounded-lg hover:border-primary hover:bg-accent transition-colors no-underline">
+                    <h3 class="font-semibold text-lg mb-2 group-hover:text-primary">Form Field Date Time Picker</h3>
+                    <p class="text-sm text-muted-foreground">
+                        Date time picker with built-in label, helper text, and error messages
                     </p>
                 </a>
 

--- a/demos/BlazorBlueprint.Demo.Shared/Shared/CommandSearch.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Shared/CommandSearch.razor
@@ -188,6 +188,7 @@
         new LibraryItem("Data View", "/components/dataview", "layout-list"),
         new LibraryItem("Filter Builder", "/components/filterbuilder", "filter"),
         new LibraryItem("Date Picker", "/components/date-picker", "calendar-days"),
+        new LibraryItem("Date Time Picker", "/components/date-time-picker", "calendar-clock"),
         new LibraryItem("Dialog", "/components/dialog", "app-window"),
         new LibraryItem("Dropdown Menu", "/components/dropdown-menu", "chevron-down"),
         new LibraryItem("Drawer", "/components/drawer", "panel-bottom"),

--- a/demos/BlazorBlueprint.Demo.Shared/Shared/DemoSidebar.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Shared/DemoSidebar.razor
@@ -403,6 +403,11 @@
                                     </BbSidebarMenuSubButton>
                                 </BbSidebarMenuSubItem>
                                 <BbSidebarMenuSubItem>
+                                    <BbSidebarMenuSubButton AsChild="@SidebarMenuButtonElement.Anchor" Href="components/date-time-picker">
+                                        <span>Date Time Picker</span>
+                                    </BbSidebarMenuSubButton>
+                                </BbSidebarMenuSubItem>
+                                <BbSidebarMenuSubItem>
                                     <BbSidebarMenuSubButton AsChild="@SidebarMenuButtonElement.Anchor" Href="components/dialog">
                                         <span>Dialog</span>
                                     </BbSidebarMenuSubButton>
@@ -475,6 +480,11 @@
                                 <BbSidebarMenuSubItem>
                                     <BbSidebarMenuSubButton AsChild="@SidebarMenuButtonElement.Anchor" Href="components/form-field-date-range-picker">
                                         <span>Form Field Date Range Picker</span>
+                                    </BbSidebarMenuSubButton>
+                                </BbSidebarMenuSubItem>
+                                <BbSidebarMenuSubItem>
+                                    <BbSidebarMenuSubButton AsChild="@SidebarMenuButtonElement.Anchor" Href="components/form-field-date-time-picker">
+                                        <span>Form Field Date Time Picker</span>
                                     </BbSidebarMenuSubButton>
                                 </BbSidebarMenuSubItem>
                                 <BbSidebarMenuSubItem>

--- a/src/BlazorBlueprint.Components/Components/DateTimePicker/BbDateTimePicker.razor
+++ b/src/BlazorBlueprint.Components/Components/DateTimePicker/BbDateTimePicker.razor
@@ -1,0 +1,160 @@
+@namespace BlazorBlueprint.Components
+@using BlazorBlueprint.Icons.Lucide.Components
+
+@*
+    Date Time Picker component - combines a button trigger with a popover containing
+    a calendar for date selection and hour/minute (and optional second / AM-PM) selectors.
+*@
+
+<BbPopover Open="_isOpen" OpenChanged="HandleOpenChanged">
+    <BbPopoverTrigger AsChild="true">
+        <BbButton Variant="ButtonVariant.Outline"
+                Class="@ButtonCssClass"
+                Disabled="@Disabled"
+                aria-required="@(Required ? "true" : null)"
+                @attributes="AdditionalAttributes">
+            <LucideIcon Name="calendar-clock" Class="mr-2 h-4 w-4" />
+            @if (Value.HasValue)
+            {
+                <span>@Value.Value.ToString(EffectiveFormat)</span>
+            }
+            else
+            {
+                <span class="text-muted-foreground">@EffectivePlaceholder</span>
+            }
+        </BbButton>
+    </BbPopoverTrigger>
+    <BbPopoverContent Class="w-auto p-0" Align="PopoverAlign.Start" OnContentReady="@HandleContentReady">
+        <BbCalendar @ref="_calendar"
+                  Selected="@Value"
+                  SelectedChanged="@HandleDateSelected"
+                  MinDate="@MinDate"
+                  MaxDate="@MaxDate"
+                  DisabledDates="@DisabledDates"
+                  FirstDayOfWeek="@FirstDayOfWeek"
+                  DayClassFunc="@DayClassFunc"
+                  DayTemplate="@DayTemplate" />
+        <div class="flex flex-col gap-3 border-t p-3">
+            <div class="flex items-center justify-center gap-2">
+                <!-- Hour Column -->
+                <div class="flex flex-col items-center">
+                    <span class="text-xs text-muted-foreground mb-1">@Localizer["DateTimePicker.Hour"]</span>
+                    <div class="flex flex-col items-center border rounded-md">
+                        <button type="button"
+                                class="@ScrollButtonClass"
+                                aria-label="@Localizer["DateTimePicker.IncrementHour"]"
+                                @onclick="IncrementHour"
+                                disabled="@Disabled">
+                            <LucideIcon Name="chevron-up" Class="h-4 w-4" />
+                        </button>
+                        <span class="w-12 h-10 flex items-center justify-center text-lg font-medium tabular-nums">
+                            @DisplayHour.ToString("D2")
+                        </span>
+                        <button type="button"
+                                class="@ScrollButtonClass"
+                                aria-label="@Localizer["DateTimePicker.DecrementHour"]"
+                                @onclick="DecrementHour"
+                                disabled="@Disabled">
+                            <LucideIcon Name="chevron-down" Class="h-4 w-4" />
+                        </button>
+                    </div>
+                </div>
+
+                <span class="text-2xl font-medium mt-5">:</span>
+
+                <!-- Minute Column -->
+                <div class="flex flex-col items-center">
+                    <span class="text-xs text-muted-foreground mb-1">@Localizer["DateTimePicker.Minute"]</span>
+                    <div class="flex flex-col items-center border rounded-md">
+                        <button type="button"
+                                class="@ScrollButtonClass"
+                                aria-label="@Localizer["DateTimePicker.IncrementMinute"]"
+                                @onclick="IncrementMinute"
+                                disabled="@Disabled">
+                            <LucideIcon Name="chevron-up" Class="h-4 w-4" />
+                        </button>
+                        <span class="w-12 h-10 flex items-center justify-center text-lg font-medium tabular-nums">
+                            @CurrentMinute.ToString("D2")
+                        </span>
+                        <button type="button"
+                                class="@ScrollButtonClass"
+                                aria-label="@Localizer["DateTimePicker.DecrementMinute"]"
+                                @onclick="DecrementMinute"
+                                disabled="@Disabled">
+                            <LucideIcon Name="chevron-down" Class="h-4 w-4" />
+                        </button>
+                    </div>
+                </div>
+
+                @if (ShowSeconds)
+                {
+                    <span class="text-2xl font-medium mt-5">:</span>
+
+                    <!-- Second Column -->
+                    <div class="flex flex-col items-center">
+                        <span class="text-xs text-muted-foreground mb-1">@Localizer["DateTimePicker.Second"]</span>
+                        <div class="flex flex-col items-center border rounded-md">
+                            <button type="button"
+                                    class="@ScrollButtonClass"
+                                    aria-label="@Localizer["DateTimePicker.IncrementSecond"]"
+                                    @onclick="IncrementSecond"
+                                    disabled="@Disabled">
+                                <LucideIcon Name="chevron-up" Class="h-4 w-4" />
+                            </button>
+                            <span class="w-12 h-10 flex items-center justify-center text-lg font-medium tabular-nums">
+                                @CurrentSecond.ToString("D2")
+                            </span>
+                            <button type="button"
+                                    class="@ScrollButtonClass"
+                                    aria-label="@Localizer["DateTimePicker.DecrementSecond"]"
+                                    @onclick="DecrementSecond"
+                                    disabled="@Disabled">
+                                <LucideIcon Name="chevron-down" Class="h-4 w-4" />
+                            </button>
+                        </div>
+                    </div>
+                }
+
+                @if (TimeFormat == TimeFormat.Hour12)
+                {
+                    <!-- AM/PM Toggle -->
+                    <div class="flex flex-col items-center ml-2">
+                        <span class="text-xs text-muted-foreground mb-1">&nbsp;</span>
+                        <div class="flex flex-col border rounded-md overflow-hidden">
+                            <button type="button"
+                                    class="@GetAmPmButtonClass(true)"
+                                    @onclick="() => SetAmPm(true)"
+                                    disabled="@Disabled">
+                                AM
+                            </button>
+                            <button type="button"
+                                    class="@GetAmPmButtonClass(false)"
+                                    @onclick="() => SetAmPm(false)"
+                                    disabled="@Disabled">
+                                PM
+                            </button>
+                        </div>
+                    </div>
+                }
+            </div>
+
+            <!-- Action Buttons -->
+            <div class="flex justify-between gap-2">
+                <BbButton Variant="ButtonVariant.Outline"
+                        Size="ButtonSize.Small"
+                        Class="flex-1"
+                        Disabled="@Disabled"
+                        OnClick="SetNow">
+                    @Localizer["DateTimePicker.Now"]
+                </BbButton>
+                <BbButton Variant="ButtonVariant.Outline"
+                        Size="ButtonSize.Small"
+                        Class="flex-1"
+                        Disabled="@(Disabled || !Value.HasValue)"
+                        OnClick="Clear">
+                    @Localizer["DateTimePicker.Clear"]
+                </BbButton>
+            </div>
+        </div>
+    </BbPopoverContent>
+</BbPopover>

--- a/src/BlazorBlueprint.Components/Components/DateTimePicker/BbDateTimePicker.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DateTimePicker/BbDateTimePicker.razor.cs
@@ -1,0 +1,375 @@
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// A date and time picker component that combines a popover calendar with
+/// hour/minute (and optional second / AM-PM) selectors.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Selecting a date preserves the current time portion, and changing the time preserves
+/// the selected date (defaulting to today when no date has been picked yet). The popover
+/// stays open after a date is selected so the time can be adjusted; it closes when the
+/// user clicks outside or presses Escape.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// &lt;BbDateTimePicker @bind-Value="appointment" /&gt;
+/// </code>
+/// </example>
+public partial class BbDateTimePicker : ComponentBase
+{
+    private bool _isOpen;
+    private BbCalendar? _calendar;
+    private bool _focusDone;
+    private int _internalHour;
+    private int _internalMinute;
+    private int _internalSecond;
+    private FieldIdentifier _fieldIdentifier;
+    private EditContext? _editContext;
+
+    [Inject]
+    private IBbLocalizer Localizer { get; set; } = default!;
+
+    [CascadingParameter]
+    private EditContext? CascadedEditContext { get; set; }
+
+    /// <summary>
+    /// The selected date and time value.
+    /// </summary>
+    [Parameter]
+    public DateTime? Value { get; set; }
+
+    /// <summary>
+    /// Callback when the selected date and time changes.
+    /// </summary>
+    [Parameter]
+    public EventCallback<DateTime?> ValueChanged { get; set; }
+
+    /// <summary>
+    /// Gets or sets an expression that identifies the bound value.
+    /// </summary>
+    [Parameter]
+    public Expression<Func<DateTime?>>? ValueExpression { get; set; }
+
+    /// <summary>
+    /// The date and time format to display on the trigger button.
+    /// When null, defaults to "G" (culture-aware date and time with seconds) if
+    /// <see cref="ShowSeconds"/> is true, otherwise "g" (culture-aware date and time).
+    /// </summary>
+    [Parameter]
+    public string? DateTimeFormat { get; set; }
+
+    /// <summary>
+    /// Placeholder text when no date and time is selected.
+    /// </summary>
+    [Parameter]
+    public string? Placeholder { get; set; }
+
+    /// <summary>
+    /// The minimum selectable date.
+    /// </summary>
+    [Parameter]
+    public DateTime? MinDate { get; set; }
+
+    /// <summary>
+    /// The maximum selectable date.
+    /// </summary>
+    [Parameter]
+    public DateTime? MaxDate { get; set; }
+
+    /// <summary>
+    /// Function to determine if a date is disabled.
+    /// </summary>
+    [Parameter]
+    public Func<DateTime, bool>? DisabledDates { get; set; }
+
+    /// <summary>
+    /// Function returning additional CSS classes for a specific day button in the
+    /// calendar, composed with the built-in day classes.
+    /// </summary>
+    [Parameter]
+    public Func<DateTime, string?>? DayClassFunc { get; set; }
+
+    /// <summary>
+    /// Optional template for rendering custom content inside each calendar day button.
+    /// When null, the day number is rendered.
+    /// </summary>
+    [Parameter]
+    public RenderFragment<CalendarDayContext>? DayTemplate { get; set; }
+
+    /// <summary>
+    /// The first day of the week. Defaults to the current culture's first day of week.
+    /// </summary>
+    [Parameter]
+    public DayOfWeek? FirstDayOfWeek { get; set; }
+
+    /// <summary>
+    /// The time format for the time selectors (12-hour with AM/PM or 24-hour).
+    /// </summary>
+    [Parameter]
+    public TimeFormat TimeFormat { get; set; } = TimeFormat.Hour12;
+
+    /// <summary>
+    /// Whether to show the seconds selector.
+    /// </summary>
+    [Parameter]
+    public bool ShowSeconds { get; set; }
+
+    /// <summary>
+    /// The minute step interval.
+    /// </summary>
+    [Parameter]
+    public int MinuteStep { get; set; } = 1;
+
+    /// <summary>
+    /// Whether the date time picker is disabled.
+    /// </summary>
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the date time picker is required.
+    /// </summary>
+    [Parameter]
+    public bool Required { get; set; }
+
+    /// <summary>
+    /// Additional CSS classes to apply to the trigger button.
+    /// </summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    /// <summary>
+    /// Additional attributes to apply to the trigger button.
+    /// </summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string EffectivePlaceholder => Placeholder ?? Localizer["DateTimePicker.Placeholder"];
+
+    private string EffectiveFormat => DateTimeFormat ?? (ShowSeconds ? "G" : "g");
+
+    private int CurrentHour => Value?.Hour ?? _internalHour;
+
+    private int CurrentMinute => Value?.Minute ?? _internalMinute;
+
+    private int CurrentSecond => Value?.Second ?? _internalSecond;
+
+    private bool IsAm => CurrentHour < 12;
+
+    private int DisplayHour
+    {
+        get
+        {
+            if (TimeFormat == TimeFormat.Hour24)
+            {
+                return CurrentHour;
+            }
+
+            var hour = CurrentHour % 12;
+            return hour == 0 ? 12 : hour;
+        }
+    }
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        if (Value.HasValue)
+        {
+            _internalHour = Value.Value.Hour;
+            _internalMinute = Value.Value.Minute;
+            _internalSecond = Value.Value.Second;
+        }
+
+        if (CascadedEditContext != null && ValueExpression != null)
+        {
+            _editContext = CascadedEditContext;
+            _fieldIdentifier = FieldIdentifier.Create(ValueExpression);
+        }
+    }
+
+    private async Task HandleDateSelected(DateTime? date)
+    {
+        if (date.HasValue)
+        {
+            // Keep the current time portion when the date changes; the popover
+            // stays open so the user can adjust the time.
+            await SetValue(date.Value.Date.AddHours(_internalHour).AddMinutes(_internalMinute).AddSeconds(_internalSecond));
+        }
+        else
+        {
+            await SetValue(null);
+        }
+    }
+
+    private void HandleOpenChanged(bool isOpen)
+    {
+        _isOpen = isOpen;
+
+        // Re-arm focus-on-open every time the popover opens, so the active day is
+        // focused again on the next open regardless of how the previous one closed.
+        if (isOpen)
+        {
+            _focusDone = false;
+        }
+    }
+
+    private async Task HandleContentReady()
+    {
+        // Move focus into the calendar once the popover is positioned, so the active
+        // day is focused and arrow-key navigation works immediately on open. Guard so
+        // a repositioning re-fire doesn't yank focus back from where the user navigated.
+        if (_focusDone || _calendar is null)
+        {
+            return;
+        }
+
+        _focusDone = true;
+        await _calendar.FocusActiveDayAsync();
+    }
+
+    private async Task SetValue(DateTime? value)
+    {
+        Value = value;
+
+        if (value.HasValue)
+        {
+            _internalHour = value.Value.Hour;
+            _internalMinute = value.Value.Minute;
+            _internalSecond = value.Value.Second;
+        }
+
+        await ValueChanged.InvokeAsync(value);
+
+        if (_editContext != null && ValueExpression != null && _fieldIdentifier.FieldName != null)
+        {
+            _editContext.NotifyFieldChanged(_fieldIdentifier);
+        }
+    }
+
+    private async Task UpdateTime()
+    {
+        // Changing the time keeps the selected date; when no date has been
+        // picked yet, default to today.
+        var date = Value?.Date ?? DateTime.Today;
+        await SetValue(date.AddHours(_internalHour).AddMinutes(_internalMinute).AddSeconds(_internalSecond));
+    }
+
+    private async Task IncrementHour()
+    {
+        if (TimeFormat == TimeFormat.Hour24)
+        {
+            _internalHour = (_internalHour + 1) % 24;
+        }
+        else
+        {
+            // Cycle within the current AM/PM period, preserving the period.
+            var isAm = _internalHour < 12;
+            var hour12 = (_internalHour % 12 + 1) % 12;
+            _internalHour = isAm ? hour12 : hour12 + 12;
+        }
+
+        await UpdateTime();
+    }
+
+    private async Task DecrementHour()
+    {
+        if (TimeFormat == TimeFormat.Hour24)
+        {
+            _internalHour = (_internalHour - 1 + 24) % 24;
+        }
+        else
+        {
+            // Cycle within the current AM/PM period, preserving the period.
+            var isAm = _internalHour < 12;
+            var hour12 = (_internalHour % 12 - 1 + 12) % 12;
+            _internalHour = isAm ? hour12 : hour12 + 12;
+        }
+
+        await UpdateTime();
+    }
+
+    private async Task IncrementMinute()
+    {
+        _internalMinute = (_internalMinute + MinuteStep) % 60;
+        await UpdateTime();
+    }
+
+    private async Task DecrementMinute()
+    {
+        _internalMinute = (_internalMinute - MinuteStep + 60) % 60;
+        await UpdateTime();
+    }
+
+    private async Task IncrementSecond()
+    {
+        _internalSecond = (_internalSecond + 1) % 60;
+        await UpdateTime();
+    }
+
+    private async Task DecrementSecond()
+    {
+        _internalSecond = (_internalSecond - 1 + 60) % 60;
+        await UpdateTime();
+    }
+
+    private async Task SetAmPm(bool isAm)
+    {
+        if (isAm && _internalHour >= 12)
+        {
+            _internalHour -= 12;
+        }
+        else if (!isAm && _internalHour < 12)
+        {
+            _internalHour += 12;
+        }
+
+        await UpdateTime();
+    }
+
+    private async Task SetNow()
+    {
+        var now = DateTime.Now;
+        _internalHour = now.Hour;
+        _internalMinute = now.Minute / MinuteStep * MinuteStep;
+        _internalSecond = ShowSeconds ? now.Second : 0;
+        await SetValue(now.Date.AddHours(_internalHour).AddMinutes(_internalMinute).AddSeconds(_internalSecond));
+    }
+
+    private async Task Clear()
+    {
+        _internalHour = 0;
+        _internalMinute = 0;
+        _internalSecond = 0;
+        await SetValue(null);
+    }
+
+    /// <summary>
+    /// Gets the computed CSS classes for the trigger button.
+    /// </summary>
+    private string ButtonCssClass => ClassNames.cn(
+        "w-[280px] justify-start text-left font-normal",
+        !Value.HasValue ? "text-muted-foreground" : null,
+        Disabled ? "opacity-50 pointer-events-none" : null,
+        Class
+    );
+
+    private static string ScrollButtonClass => ClassNames.cn(
+        "w-12 h-8 flex items-center justify-center",
+        "hover:bg-accent hover:text-accent-foreground",
+        "transition-colors",
+        "disabled:opacity-50 disabled:cursor-not-allowed"
+    );
+
+    private string GetAmPmButtonClass(bool isAm) => ClassNames.cn(
+        "w-12 h-10 text-sm font-medium transition-colors",
+        isAm == IsAm ? "bg-primary text-primary-foreground" : "hover:bg-accent hover:text-accent-foreground",
+        "disabled:opacity-50 disabled:cursor-not-allowed"
+    );
+}

--- a/src/BlazorBlueprint.Components/Components/FormFieldDateTimePicker/BbFormFieldDateTimePicker.razor
+++ b/src/BlazorBlueprint.Components/Components/FormFieldDateTimePicker/BbFormFieldDateTimePicker.razor
@@ -1,0 +1,38 @@
+@namespace BlazorBlueprint.Components
+@inherits FormFieldBase
+
+<BbField Orientation="@Orientation" IsInvalid="@IsInvalid" Class="@Class">
+    @if (Label is not null)
+    {
+        <BbFieldLabel>@Label</BbFieldLabel>
+    }
+    <BbFieldContent>
+        <BbDateTimePicker Value="@Value"
+                          ValueChanged="HandleValueChanged"
+                          ValueExpression="@ValueExpression"
+                          DateTimeFormat="@DateTimeFormat"
+                          Placeholder="@Placeholder"
+                          MinDate="@MinDate"
+                          MaxDate="@MaxDate"
+                          DisabledDates="@DisabledDates"
+                          FirstDayOfWeek="@FirstDayOfWeek"
+                          TimeFormat="@TimeFormat"
+                          ShowSeconds="@ShowSeconds"
+                          MinuteStep="@MinuteStep"
+                          Disabled="@Disabled"
+                          Required="@Required"
+                          Class="@InputClass" />
+        @if (!string.IsNullOrEmpty(HelperText) && !IsInvalid)
+        {
+            <BbFieldDescription Id="@DescriptionId">@HelperText</BbFieldDescription>
+        }
+        @if (IsInvalid && !string.IsNullOrEmpty(ErrorText))
+        {
+            <BbFieldError Id="@ErrorId">@ErrorText</BbFieldError>
+        }
+        else if (HasEditContextErrors)
+        {
+            <BbFieldError Id="@ErrorId" Errors="@EditContextErrors" />
+        }
+    </BbFieldContent>
+</BbField>

--- a/src/BlazorBlueprint.Components/Components/FormFieldDateTimePicker/BbFormFieldDateTimePicker.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/FormFieldDateTimePicker/BbFormFieldDateTimePicker.razor.cs
@@ -1,0 +1,135 @@
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// A form field wrapper for <see cref="BbDateTimePicker"/> that provides
+/// automatic label, helper text, and error message display.
+/// </summary>
+/// <remarks>
+/// <para>
+/// FormFieldDateTimePicker provides a higher-level abstraction over <see cref="BbDateTimePicker"/>.
+/// It automatically handles label display, helper text, and error message rendering.
+/// </para>
+/// <para>
+/// For full control over layout and error display, use <see cref="BbDateTimePicker"/> directly
+/// with the <see cref="BbField"/> component system.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// &lt;BbFormFieldDateTimePicker @bind-Value="appointment"
+///                            Label="Appointment"
+///                            HelperText="Select a date and time"
+///                            MinDate="DateTime.Today" /&gt;
+/// </code>
+/// </example>
+public partial class BbFormFieldDateTimePicker : FormFieldBase
+{
+    // --- DateTimePicker Pass-Through Parameters ---
+
+    /// <summary>
+    /// Gets or sets the selected date and time value.
+    /// </summary>
+    [Parameter]
+    public DateTime? Value { get; set; }
+
+    /// <summary>
+    /// Gets or sets the callback invoked when the selected date and time changes.
+    /// </summary>
+    [Parameter]
+    public EventCallback<DateTime?> ValueChanged { get; set; }
+
+    /// <summary>
+    /// Gets or sets an expression that identifies the bound value for EditForm integration.
+    /// Automatically provided by <c>@bind-Value</c>.
+    /// </summary>
+    [Parameter]
+    public Expression<Func<DateTime?>>? ValueExpression { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date and time format to display.
+    /// When null, defaults to "G" (culture-aware date and time with seconds) if
+    /// <see cref="ShowSeconds"/> is true, otherwise "g" (culture-aware date and time).
+    /// </summary>
+    [Parameter]
+    public string? DateTimeFormat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the placeholder text when no date and time is selected.
+    /// </summary>
+    [Parameter]
+    public string? Placeholder { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum selectable date.
+    /// </summary>
+    [Parameter]
+    public DateTime? MinDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum selectable date.
+    /// </summary>
+    [Parameter]
+    public DateTime? MaxDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets a function to determine if a date is disabled.
+    /// </summary>
+    [Parameter]
+    public Func<DateTime, bool>? DisabledDates { get; set; }
+
+    /// <summary>
+    /// Gets or sets the first day of the week.
+    /// Defaults to the current culture's first day of week.
+    /// </summary>
+    [Parameter]
+    public DayOfWeek? FirstDayOfWeek { get; set; }
+
+    /// <summary>
+    /// Gets or sets the time format for the time selectors (12-hour with AM/PM or 24-hour).
+    /// </summary>
+    [Parameter]
+    public TimeFormat TimeFormat { get; set; } = TimeFormat.Hour12;
+
+    /// <summary>
+    /// Gets or sets whether to show the seconds selector.
+    /// </summary>
+    [Parameter]
+    public bool ShowSeconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minute step interval.
+    /// </summary>
+    [Parameter]
+    public int MinuteStep { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets whether the date time picker is disabled.
+    /// </summary>
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the date time picker is required.
+    /// </summary>
+    [Parameter]
+    public bool Required { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional CSS classes applied to the inner DateTimePicker trigger button.
+    /// </summary>
+    [Parameter]
+    public string? InputClass { get; set; }
+
+    /// <inheritdoc />
+    protected override LambdaExpression? GetFieldExpression() => ValueExpression;
+
+    private async Task HandleValueChanged(DateTime? value)
+    {
+        Value = value;
+        await ValueChanged.InvokeAsync(value);
+        NotifyFieldChanged();
+    }
+}

--- a/src/BlazorBlueprint.Components/Localization/DefaultBbLocalizer.cs
+++ b/src/BlazorBlueprint.Components/Localization/DefaultBbLocalizer.cs
@@ -141,6 +141,20 @@ public class DefaultBbLocalizer : IBbLocalizer
         ["DateRangePicker.ThisYear"] = "This year",
         ["DateRangePicker.Custom"] = "Custom",
 
+        // DateTimePicker
+        ["DateTimePicker.Placeholder"] = "Pick a date and time",
+        ["DateTimePicker.Hour"] = "Hour",
+        ["DateTimePicker.Minute"] = "Min",
+        ["DateTimePicker.Second"] = "Sec",
+        ["DateTimePicker.IncrementHour"] = "Increment hour",
+        ["DateTimePicker.DecrementHour"] = "Decrement hour",
+        ["DateTimePicker.IncrementMinute"] = "Increment minute",
+        ["DateTimePicker.DecrementMinute"] = "Decrement minute",
+        ["DateTimePicker.IncrementSecond"] = "Increment second",
+        ["DateTimePicker.DecrementSecond"] = "Decrement second",
+        ["DateTimePicker.Now"] = "Now",
+        ["DateTimePicker.Clear"] = "Clear",
+
         // Dialog
         ["Dialog.Close"] = "Close",
 

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -1109,6 +1109,27 @@
   - Value : DateRange
   - ValueChanged : EventCallback<DateRange>
 
+### BbDateTimePicker (BlazorBlueprint.Components)
+  - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
+  - Class : String
+  - DateTimeFormat : String
+  - DayClassFunc : Func<DateTime, String>
+  - DayTemplate : RenderFragment<CalendarDayContext>
+  - Disabled : Boolean
+  - DisabledDates : Func<DateTime, Boolean>
+  - FirstDayOfWeek : DayOfWeek?
+  - MaxDate : DateTime?
+  - MinDate : DateTime?
+  - MinuteStep : Int32
+  - Placeholder : String
+  - Required : Boolean
+  - ShowSeconds : Boolean
+  - TimeFormat : TimeFormat
+  - Value : DateTime?
+  - ValueChanged : EventCallback<DateTime?>
+  - ValueExpression : Expression<Func<DateTime?>>
+  - CascadedEditContext : EditContext [CascadingParameter]
+
 ### BbDialog (BlazorBlueprint.Components)
   - ChildContent : RenderFragment
   - DefaultOpen : Boolean
@@ -1572,6 +1593,29 @@
   - ShowTwoMonths : Boolean
   - Value : DateRange
   - ValueChanged : EventCallback<DateRange>
+
+### BbFormFieldDateTimePicker (BlazorBlueprint.Components)
+  - AriaLabel : String
+  - Class : String
+  - DateTimeFormat : String
+  - Disabled : Boolean
+  - DisabledDates : Func<DateTime, Boolean>
+  - ErrorText : String
+  - FirstDayOfWeek : DayOfWeek?
+  - HelperText : String
+  - InputClass : String
+  - Label : String
+  - MaxDate : DateTime?
+  - MinDate : DateTime?
+  - MinuteStep : Int32
+  - Orientation : FieldOrientation
+  - Placeholder : String
+  - Required : Boolean
+  - ShowSeconds : Boolean
+  - TimeFormat : TimeFormat
+  - Value : DateTime?
+  - ValueChanged : EventCallback<DateTime?>
+  - ValueExpression : Expression<Func<DateTime?>>
 
 ### BbFormFieldFileUpload (BlazorBlueprint.Components)
   - Accept : String


### PR DESCRIPTION
## Description

Adds a combined date and time picker component (`BbDateTimePicker`) and its form-field wrapper (`BbFormFieldDateTimePicker`), designed as a fusion of the existing `BbDatePicker` and `BbTimePicker`:

- **BbDateTimePicker** — trigger button opens a popover containing the `BbCalendar` plus hour/minute steppers (optional seconds selector and AM/PM toggle), with `Now` and `Clear` actions.
  - `DateTime? Value` with `@bind-Value` support and EditForm/EditContext integration (null = empty).
  - Selecting a date preserves the time portion; changing the time preserves the date (defaults to today when no date is picked yet). The popover stays open so both can be set in one interaction — no explicit Apply, matching DatePicker's single-click semantics.
  - Display format defaults to culture-aware `"g"` (or `"G"` when `ShowSeconds` is enabled), overridable via `DateTimeFormat`.
  - Calendar pass-throughs: `MinDate`, `MaxDate`, `DisabledDates`, `FirstDayOfWeek`, `DayTemplate`, `DayClassFunc`.
  - Time granularity: `TimeFormat` (Hour12/Hour24, matching TimePicker's convention), `ShowSeconds` (default false), `MinuteStep` (default 1).
  - Focus moves into the calendar when the popover opens so arrow-key navigation works immediately (same pattern as DatePicker); stepper buttons have localized `aria-label`s.
- **BbFormFieldDateTimePicker** — mirrors `BbFormFieldDatePicker` exactly (label/helper/error wiring via `FormFieldBase`, full parameter forwarding, `InputClass`).
- **Localization** — new `DateTimePicker.*` keys in `DefaultBbLocalizer` (placeholder, selector labels, stepper aria-labels, Now/Clear).
- **Demos** — new demo pages for both components with live examples, `CodeExamples` snippets, API Reference and Accessibility sections, plus sidebar/components-index/command-search entries and cross-links from the existing form-field picker pages.
- **API surface** — additive-only snapshot accepted (two new components).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [x] Blazor Server
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [x] Keyboard navigation / accessibility
- [ ] Dark mode

## Related Issues

Closes #310