### PR TITLE
feat(event-calendar): add BbEventCalendar with month, week, and agenda views

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/EventCalendar/basic.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/EventCalendar/basic.txt
@@ -1,0 +1,19 @@
+<BbEventCalendar Items="events"
+                 EventStart="e => e.Start"
+                 EventEnd="e => e.End"
+                 EventTitle="e => e.Title" />
+
+@code {
+    private sealed record DemoEvent(string Title, DateTime Start, DateTime? End, string Category);
+
+    private static readonly DateTime today = DateTime.Today;
+
+    private readonly List<DemoEvent> events = new()
+    {
+        new("Standup", today.AddHours(9), today.AddHours(9.25), "meeting"),
+        new("Sprint planning", today.AddHours(10), today.AddHours(11.5), "meeting"),
+        new("Design review", today.AddDays(1).AddHours(13), today.AddDays(1).AddHours(14), "meeting"),
+        new("Release v3.13", today.AddDays(3), null, "release"),
+        new("DotNet Conf", today.AddDays(7), today.AddDays(9), "travel"),
+    };
+}

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/EventCalendar/colors.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/EventCalendar/colors.txt
@@ -1,0 +1,16 @@
+<BbEventCalendar Items="events"
+                 EventStart="e => e.Start"
+                 EventEnd="e => e.End"
+                 EventTitle="e => e.Title"
+                 EventClass="GetCategoryClass" />
+
+@code {
+    private string? GetCategoryClass(DemoEvent e) => e.Category switch
+    {
+        "meeting" => "bg-sky-500/15 text-sky-700 hover:bg-sky-500/25 dark:text-sky-400",
+        "release" => "bg-emerald-500/15 text-emerald-700 hover:bg-emerald-500/25 dark:text-emerald-400",
+        "travel" => "bg-amber-500/15 text-amber-700 hover:bg-amber-500/25 dark:text-amber-400",
+        "personal" => "bg-violet-500/15 text-violet-700 hover:bg-violet-500/25 dark:text-violet-400",
+        _ => null,
+    };
+}

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/EventCalendar/event-click.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/EventCalendar/event-click.txt
@@ -1,0 +1,28 @@
+<BbEventCalendar Items="events"
+                 EventStart="e => e.Start"
+                 EventEnd="e => e.End"
+                 EventTitle="e => e.Title"
+                 OnEventClick="(DemoEvent e) => selectedEvent = e" />
+
+@if (selectedEvent is not null)
+{
+    <BbCard>
+        <BbCardHeader>
+            <BbCardTitle>@selectedEvent.Title</BbCardTitle>
+            <BbCardDescription>
+                @selectedEvent.Start.ToString("f")
+                @if (selectedEvent.End is not null)
+                {
+                    <text> – @selectedEvent.End.Value.ToString("f")</text>
+                }
+            </BbCardDescription>
+        </BbCardHeader>
+        <BbCardContent>
+            <BbBadge Variant="BadgeVariant.Outline">@selectedEvent.Category</BbBadge>
+        </BbCardContent>
+    </BbCard>
+}
+
+@code {
+    private DemoEvent? selectedEvent;
+}

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/EventCalendar/template.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/EventCalendar/template.txt
@@ -1,0 +1,23 @@
+<BbEventCalendar Items="events"
+                 EventStart="e => e.Start"
+                 EventEnd="e => e.End"
+                 EventTitle="e => e.Title"
+                 EventClass="GetCategoryClass">
+    <EventTemplate>
+        <span class="flex items-center gap-1 px-1.5 py-0.5">
+            <LucideIcon Name="@GetCategoryIcon(context)" Size="12" Class="shrink-0" />
+            <span class="truncate text-xs font-medium">@context.Title</span>
+        </span>
+    </EventTemplate>
+</BbEventCalendar>
+
+@code {
+    private string GetCategoryIcon(DemoEvent e) => e.Category switch
+    {
+        "meeting" => "users",
+        "release" => "rocket",
+        "travel" => "plane",
+        "personal" => "heart",
+        _ => "calendar",
+    };
+}

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/EventCalendar/views.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/EventCalendar/views.txt
@@ -1,0 +1,18 @@
+<BbEventCalendar Items="events"
+                 EventStart="e => e.Start"
+                 EventEnd="e => e.End"
+                 EventTitle="e => e.Title"
+                 @bind-View="currentView"
+                 @bind-CurrentDate="currentDate"
+                 OnDateClick="d => lastClickedDate = d"
+                 OnViewRangeChanged="r => visibleRange = r" />
+
+<p>Active view: @currentView</p>
+<p>Visible range: @visibleRange.Start.ToShortDateString() – @visibleRange.End.ToShortDateString()</p>
+
+@code {
+    private EventCalendarView currentView = EventCalendarView.Week;
+    private DateTime currentDate = DateTime.Today;
+    private DateTime? lastClickedDate;
+    private EventCalendarRange visibleRange;
+}

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/EventCalendarDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/EventCalendarDemo.razor
@@ -1,0 +1,301 @@
+@page "/components/event-calendar"
+
+<PageTitle>Event Calendar Component - Blazor Blueprint</PageTitle>
+
+<div class="space-y-8 max-w-5xl">
+    <div>
+        <div class="space-y-3">
+            <h1 class="text-4xl font-bold tracking-tight">Event Calendar Component</h1>
+            <p class="text-xl text-muted-foreground">
+                Displays events in a month grid, week columns, or a chronological agenda.
+                Generic over your own event type — map it with accessor delegates instead of adapting your model.
+            </p>
+        </div>
+    </div>
+
+    <!-- Basic Month View -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Basic Month View</h2>
+            <p class="text-sm text-muted-foreground">
+                Pass your events via <code class="bg-muted px-1 py-0.5 rounded">Items</code> and map them with
+                <code class="bg-muted px-1 py-0.5 rounded">EventStart</code>, <code class="bg-muted px-1 py-0.5 rounded">EventEnd</code>,
+                and <code class="bg-muted px-1 py-0.5 rounded">EventTitle</code>. Days show up to
+                <code class="bg-muted px-1 py-0.5 rounded">MaxEventsPerDay</code> chips; the localized "+x more" button
+                jumps to that day in the agenda view. Multi-day events render a chip on each spanned day.
+            </p>
+        </div>
+        <div class="border rounded-lg p-6">
+            <BbEventCalendar Items="events"
+                             EventStart="e => e.Start"
+                             EventEnd="e => e.End"
+                             EventTitle="e => e.Title" />
+        </div>
+        <CodeBlock Source="Components/EventCalendar/basic.txt" />
+    </div>
+
+    <!-- Per-Event Colors -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Per-Event Colors</h2>
+            <p class="text-sm text-muted-foreground">
+                Use <code class="bg-muted px-1 py-0.5 rounded">EventClass</code> to return extra CSS classes per event —
+                for example to color chips by category. Classes are merged with the built-in chip styling.
+            </p>
+        </div>
+        <div class="border rounded-lg p-6">
+            <BbEventCalendar Items="events"
+                             EventStart="e => e.Start"
+                             EventEnd="e => e.End"
+                             EventTitle="e => e.Title"
+                             EventClass="GetCategoryClass" />
+        </div>
+        <CodeBlock Source="Components/EventCalendar/colors.txt" />
+    </div>
+
+    <!-- Custom Event Template -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Custom Event Template</h2>
+            <p class="text-sm text-muted-foreground">
+                <code class="bg-muted px-1 py-0.5 rounded">EventTemplate</code> replaces the built-in chip content entirely;
+                only minimal layout and focus classes remain on the chip button. Combine with
+                <code class="bg-muted px-1 py-0.5 rounded">EventClass</code> for chip-level styling.
+            </p>
+        </div>
+        <div class="border rounded-lg p-6">
+            <BbEventCalendar Items="events"
+                             EventStart="e => e.Start"
+                             EventEnd="e => e.End"
+                             EventTitle="e => e.Title"
+                             EventClass="GetCategoryClass">
+                <EventTemplate>
+                    <span class="flex items-center gap-1 px-1.5 py-0.5">
+                        <LucideIcon Name="@GetCategoryIcon(context)" Size="12" Class="shrink-0" />
+                        <span class="truncate text-xs font-medium">@context.Title</span>
+                    </span>
+                </EventTemplate>
+            </BbEventCalendar>
+        </div>
+        <CodeBlock Source="Components/EventCalendar/template.txt" />
+    </div>
+
+    <!-- Views & Navigation -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Views &amp; Navigation</h2>
+            <p class="text-sm text-muted-foreground">
+                Bind the active view with <code class="bg-muted px-1 py-0.5 rounded">@@bind-View</code> and the visible period with
+                <code class="bg-muted px-1 py-0.5 rounded">@@bind-CurrentDate</code>. The week view stacks each day's events in start
+                order (no hour grid in v1), and the agenda view lists the current month chronologically.
+                <code class="bg-muted px-1 py-0.5 rounded">OnViewRangeChanged</code> reports the visible range — useful for loading
+                events on demand.
+            </p>
+        </div>
+        <div class="border rounded-lg p-6 space-y-4">
+            <BbEventCalendar Items="events"
+                             EventStart="e => e.Start"
+                             EventEnd="e => e.End"
+                             EventTitle="e => e.Title"
+                             EventClass="GetCategoryClass"
+                             @bind-View="currentView"
+                             @bind-CurrentDate="currentDate"
+                             OnDateClick="d => lastClickedDate = d"
+                             OnViewRangeChanged="r => visibleRange = r" />
+            <div class="text-sm text-muted-foreground space-y-1">
+                <p>Active view: <span class="font-medium text-foreground">@currentView</span></p>
+                <p>Visible range: <span class="font-medium text-foreground">@visibleRange.Start.ToShortDateString() – @visibleRange.End.ToShortDateString()</span></p>
+                @if (lastClickedDate is not null)
+                {
+                    <p>Last clicked date: <span class="font-medium text-foreground">@lastClickedDate.Value.ToLongDateString()</span></p>
+                }
+            </div>
+        </div>
+        <CodeBlock Source="Components/EventCalendar/views.txt" />
+    </div>
+
+    <!-- Handling Event Clicks -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Handling Event Clicks</h2>
+            <p class="text-sm text-muted-foreground">
+                <code class="bg-muted px-1 py-0.5 rounded">OnEventClick</code> receives the clicked event — your own model,
+                not a wrapper — so you can open a details panel, dialog, or navigate.
+            </p>
+        </div>
+        <div class="border rounded-lg p-6 space-y-4">
+            <BbEventCalendar Items="events"
+                             EventStart="e => e.Start"
+                             EventEnd="e => e.End"
+                             EventTitle="e => e.Title"
+                             EventClass="GetCategoryClass"
+                             OnEventClick="(DemoEvent e) => selectedEvent = e" />
+            @if (selectedEvent is not null)
+            {
+                <BbCard>
+                    <BbCardHeader>
+                        <BbCardTitle>@selectedEvent.Title</BbCardTitle>
+                        <BbCardDescription>
+                            @selectedEvent.Start.ToString("f")
+                            @if (selectedEvent.End is not null)
+                            {
+                                <text> – @selectedEvent.End.Value.ToString("f")</text>
+                            }
+                        </BbCardDescription>
+                    </BbCardHeader>
+                    <BbCardContent>
+                        <BbBadge Variant="BadgeVariant.Outline">@selectedEvent.Category</BbBadge>
+                    </BbCardContent>
+                </BbCard>
+            }
+        </div>
+        <CodeBlock Source="Components/EventCalendar/event-click.txt" />
+    </div>
+
+    <!-- v1 Notes -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Notes &amp; Limitations</h2>
+            <ul class="list-disc pl-6 text-sm text-muted-foreground space-y-1">
+                <li>Multi-day events render a chip on each spanned day — true spanning bars across cells are not supported yet.</li>
+                <li>The week view is a stacked per-day list ordered by start time; there is no hour grid or drag-to-create.</li>
+                <li>An event is treated as all-day when its start (and end, if any) fall exactly on midnight.</li>
+                <li>Events are reached in tab order; arrow-key grid navigation is not implemented yet.</li>
+            </ul>
+        </div>
+    </div>
+
+    <AccessibilityList>
+        <AriaAttributes>
+            <AccessibilityItem>The month and week views use role="grid" with role="row", role="columnheader", and role="gridcell"</AccessibilityItem>
+            <AccessibilityItem>Day cells and day buttons carry aria-label with the full localized date</AccessibilityItem>
+            <AccessibilityItem>Every event is a real button — clickable and keyboard reachable via tab order</AccessibilityItem>
+            <AccessibilityItem>Navigation buttons have localized aria-labels; view switcher buttons expose aria-pressed</AccessibilityItem>
+            <AccessibilityItem>The header title uses aria-live="polite" so period changes are announced</AccessibilityItem>
+        </AriaAttributes>
+        <KeyboardNavigation>
+            <KeyboardShortcutItem Description="Move through navigation controls, day buttons, and event chips">
+                <BbKbd>Tab</BbKbd> / <BbKbd>Shift+Tab</BbKbd>
+            </KeyboardShortcutItem>
+            <KeyboardShortcutItem Description="Activate the focused button (navigate, switch view, or raise event/date callbacks)">
+                <BbKbd>Enter</BbKbd> / <BbKbd>Space</BbKbd>
+            </KeyboardShortcutItem>
+        </KeyboardNavigation>
+    </AccessibilityList>
+
+    <LocalizationSection
+        Description="All Event Calendar chrome strings — view names, navigation labels, and the overflow/empty-state text — are configurable."
+        Labels="@(new LocalizationSection.LabelInfo[]
+        {
+            new("Today", "Today", "Label for the today button"),
+            new("Month", "Month", "Month view switcher label"),
+            new("Week", "Week", "Week view switcher label"),
+            new("Agenda", "Agenda", "Agenda view switcher label"),
+            new("PreviousPeriod", "Go to previous period", "Aria label for the previous button"),
+            new("NextPeriod", "Go to next period", "Aria label for the next button"),
+            new("ViewSwitcher", "Calendar view", "Aria label for the view switcher group"),
+            new("MoreEvents", "+{0} more", "Overflow button label; {0} is the hidden event count"),
+            new("NoEvents", "No events to display.", "Agenda view empty state"),
+            new("AllDay", "All day", "Time label for all-day events"),
+        })"
+        CultureAware="true"
+        CultureDescription="Month/day names, date headers, and time labels are derived from CultureInfo.CurrentCulture. The first day of the week follows the culture unless overridden with FirstDayOfWeek."
+        CodeExample="@(@"services.AddBlazorBlueprintComponents(localizer =>
+{
+    localizer.Set(""EventCalendar.Today"", ""Heute"");
+    localizer.Set(""EventCalendar.MoreEvents"", ""+{0} weitere"");
+});")" />
+
+    <!-- API Reference -->
+    <div class="space-y-4">
+        <ApiReference ComponentName="EventCalendar">
+            <ApiParameter Name="Items" Type="IEnumerable&lt;TEvent&gt;?" Default="null">
+                The events to display. TEvent is your own model type.
+            </ApiParameter>
+            <ApiParameter Name="EventStart" Type="Func&lt;TEvent, DateTime&gt;" Default="required">
+                Returns the start date/time of an event.
+            </ApiParameter>
+            <ApiParameter Name="EventEnd" Type="Func&lt;TEvent, DateTime?&gt;?" Default="null">
+                Returns the end date/time of an event, or null for a point-in-time event. When the delegate itself is null, all events are point-in-time. Events ending on a later day render a chip on each spanned day.
+            </ApiParameter>
+            <ApiParameter Name="EventTitle" Type="Func&lt;TEvent, string&gt;" Default="required">
+                Returns the display title of an event.
+            </ApiParameter>
+            <ApiParameter Name="EventClass" Type="Func&lt;TEvent, string?&gt;?" Default="null">
+                Returns additional CSS classes for a specific event's chip, merged with the built-in chip classes. Use for per-event coloring.
+            </ApiParameter>
+            <ApiParameter Name="EventTemplate" Type="RenderFragment&lt;TEvent&gt;?" Default="null">
+                Template that fully replaces the built-in event chip content. Only minimal layout/focus classes remain on the chip button.
+            </ApiParameter>
+            <ApiParameter Name="View" Type="EventCalendarView" Default="EventCalendarView.Month">
+                The active view (Month, Week, or Agenda). Use @@bind-View for two-way binding.
+            </ApiParameter>
+            <ApiParameter Name="CurrentDate" Type="DateTime" Default="DateTime.Today">
+                The date that controls the visible period (the month or week containing it). Use @@bind-CurrentDate for two-way binding.
+            </ApiParameter>
+            <ApiParameter Name="FirstDayOfWeek" Type="DayOfWeek?" Default="null">
+                The first day of the week. Defaults to the current culture's first day of the week.
+            </ApiParameter>
+            <ApiParameter Name="MaxEventsPerDay" Type="int" Default="3">
+                Maximum event chips per day in the month view before the "+x more" overflow button appears. Clicking the overflow navigates to that day in the agenda view.
+            </ApiParameter>
+            <ApiParameter Name="OnEventClick" Type="EventCallback&lt;TEvent&gt;">
+                Callback when an event chip is clicked.
+            </ApiParameter>
+            <ApiParameter Name="OnDateClick" Type="EventCallback&lt;DateTime&gt;">
+                Callback when a day number (month view) or day header (week view) is clicked.
+            </ApiParameter>
+            <ApiParameter Name="OnViewRangeChanged" Type="EventCallback&lt;EventCalendarRange&gt;">
+                Callback when the visible date range changes, including the initial range. EventCalendarRange exposes inclusive Start and End dates.
+            </ApiParameter>
+            <ApiParameter Name="Class" Type="string?" Default="null">
+                Additional CSS classes for the root element.
+            </ApiParameter>
+        </ApiReference>
+    </div>
+</div>
+
+@code {
+    private sealed record DemoEvent(string Title, DateTime Start, DateTime? End, string Category);
+
+    private static readonly DateTime today = DateTime.Today;
+
+    private readonly List<DemoEvent> events = new()
+    {
+        new("Standup", today.AddHours(9), today.AddHours(9.25), "meeting"),
+        new("Sprint planning", today.AddHours(10), today.AddHours(11.5), "meeting"),
+        new("Marketing sync", today.AddHours(13), today.AddHours(13.75), "meeting"),
+        new("Retro", today.AddHours(16), today.AddHours(17), "meeting"),
+        new("Demo prep", today.AddHours(17), null, "release"),
+        new("1:1 with Sam", today.AddDays(-2).AddHours(15), today.AddDays(-2).AddHours(15.5), "meeting"),
+        new("Design review", today.AddDays(1).AddHours(13), today.AddDays(1).AddHours(14), "meeting"),
+        new("Dentist", today.AddDays(1).AddHours(8.5), null, "personal"),
+        new("Release v3.13", today.AddDays(3), null, "release"),
+        new("Code freeze", today.AddDays(5), null, "release"),
+        new("DotNet Conf", today.AddDays(7), today.AddDays(9), "travel"),
+    };
+
+    private EventCalendarView currentView = EventCalendarView.Week;
+    private DateTime currentDate = today;
+    private DateTime? lastClickedDate;
+    private EventCalendarRange visibleRange;
+    private DemoEvent? selectedEvent;
+
+    private string? GetCategoryClass(DemoEvent e) => e.Category switch
+    {
+        "meeting" => "bg-sky-500/15 text-sky-700 hover:bg-sky-500/25 dark:text-sky-400",
+        "release" => "bg-emerald-500/15 text-emerald-700 hover:bg-emerald-500/25 dark:text-emerald-400",
+        "travel" => "bg-amber-500/15 text-amber-700 hover:bg-amber-500/25 dark:text-amber-400",
+        "personal" => "bg-violet-500/15 text-violet-700 hover:bg-violet-500/25 dark:text-violet-400",
+        _ => null,
+    };
+
+    private string GetCategoryIcon(DemoEvent e) => e.Category switch
+    {
+        "meeting" => "users",
+        "release" => "rocket",
+        "travel" => "plane",
+        "personal" => "heart",
+        _ => "calendar",
+    };
+}

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/Index.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/Index.razor
@@ -323,6 +323,14 @@
                     </p>
                 </a>
 
+                <!-- Event Calendar -->
+                <a href="/components/event-calendar" class="group p-5 border rounded-lg hover:border-primary hover:bg-accent transition-colors no-underline">
+                    <h3 class="font-semibold text-lg mb-2 group-hover:text-primary">Event Calendar</h3>
+                    <p class="text-sm text-muted-foreground">
+                        Month, week, and agenda views for your own event type
+                    </p>
+                </a>
+
                 <!-- Field -->
                 <a href="/components/field" class="group p-5 border rounded-lg hover:border-primary hover:bg-accent transition-colors no-underline">
                     <h3 class="font-semibold text-lg mb-2 group-hover:text-primary">Field</h3>

--- a/demos/BlazorBlueprint.Demo.Shared/Shared/CommandSearch.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Shared/CommandSearch.razor
@@ -192,6 +192,7 @@
         new LibraryItem("Dropdown Menu", "/components/dropdown-menu", "chevron-down"),
         new LibraryItem("Drawer", "/components/drawer", "panel-bottom"),
         new LibraryItem("Empty", "/components/empty", "inbox"),
+        new LibraryItem("Event Calendar", "/components/event-calendar", "calendar-days"),
         new LibraryItem("Field", "/components/field", "pencil-line"),
         new LibraryItem("Hover Card", "/components/hovercard", "square-mouse-pointer"),
         new LibraryItem("Input", "/components/input", "text-cursor"),

--- a/demos/BlazorBlueprint.Demo.Shared/Shared/DemoSidebar.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Shared/DemoSidebar.razor
@@ -433,6 +433,11 @@
                                     </BbSidebarMenuSubButton>
                                 </BbSidebarMenuSubItem>
                                 <BbSidebarMenuSubItem>
+                                    <BbSidebarMenuSubButton AsChild="@SidebarMenuButtonElement.Anchor" Href="components/event-calendar">
+                                        <span>Event Calendar</span>
+                                    </BbSidebarMenuSubButton>
+                                </BbSidebarMenuSubItem>
+                                <BbSidebarMenuSubItem>
                                     <BbSidebarMenuSubButton AsChild="@SidebarMenuButtonElement.Anchor" Href="components/field">
                                         <span>Field</span>
                                     </BbSidebarMenuSubButton>

--- a/src/BlazorBlueprint.Components/Components/EventCalendar/BbEventCalendar.razor
+++ b/src/BlazorBlueprint.Components/Components/EventCalendar/BbEventCalendar.razor
@@ -1,0 +1,203 @@
+@namespace BlazorBlueprint.Components
+@typeparam TEvent
+@using BlazorBlueprint.Icons.Lucide.Components
+@inject IBbLocalizer Localizer
+
+@*
+    Event calendar - displays events in a month grid, week columns, or an agenda list.
+*@
+
+<div class="@CssClass" @attributes="AdditionalAttributes">
+    @* Header: navigation, title, view switcher *@
+    <div class="flex flex-wrap items-center justify-between gap-2 pb-4">
+        <div class="flex items-center gap-1">
+            <BbButton Variant="ButtonVariant.Outline"
+                      Size="ButtonSize.Icon"
+                      Class="h-8 w-8"
+                      OnClick="@NavigatePreviousAsync"
+                      AriaLabel="@Localizer["EventCalendar.PreviousPeriod"]">
+                <LucideIcon Name="chevron-left" Class="h-4 w-4" />
+            </BbButton>
+            <BbButton Variant="ButtonVariant.Outline"
+                      Size="ButtonSize.Small"
+                      Class="h-8"
+                      OnClick="@NavigateTodayAsync">
+                @Localizer["EventCalendar.Today"]
+            </BbButton>
+            <BbButton Variant="ButtonVariant.Outline"
+                      Size="ButtonSize.Icon"
+                      Class="h-8 w-8"
+                      OnClick="@NavigateNextAsync"
+                      AriaLabel="@Localizer["EventCalendar.NextPeriod"]">
+                <LucideIcon Name="chevron-right" Class="h-4 w-4" />
+            </BbButton>
+        </div>
+        <div class="text-base font-semibold" aria-live="polite">@HeaderTitle</div>
+        <div class="inline-flex items-center gap-0.5 rounded-md border border-border bg-card p-0.5"
+             role="group"
+             aria-label="@Localizer["EventCalendar.ViewSwitcher"]">
+            <button type="button"
+                    class="@GetViewSwitchClasses(EventCalendarView.Month)"
+                    aria-pressed="@(View == EventCalendarView.Month ? "true" : "false")"
+                    @onclick="@(() => SetViewAsync(EventCalendarView.Month))">
+                @Localizer["EventCalendar.Month"]
+            </button>
+            <button type="button"
+                    class="@GetViewSwitchClasses(EventCalendarView.Week)"
+                    aria-pressed="@(View == EventCalendarView.Week ? "true" : "false")"
+                    @onclick="@(() => SetViewAsync(EventCalendarView.Week))">
+                @Localizer["EventCalendar.Week"]
+            </button>
+            <button type="button"
+                    class="@GetViewSwitchClasses(EventCalendarView.Agenda)"
+                    aria-pressed="@(View == EventCalendarView.Agenda ? "true" : "false")"
+                    @onclick="@(() => SetViewAsync(EventCalendarView.Agenda))">
+                @Localizer["EventCalendar.Agenda"]
+            </button>
+        </div>
+    </div>
+
+    @if (View == EventCalendarView.Month)
+    {
+        @* Month view: six-week grid with event chips per day *@
+        <div role="grid" aria-label="@HeaderTitle" class="grid gap-px overflow-hidden rounded-lg border border-border bg-border">
+            <div role="row" class="grid grid-cols-7 gap-px">
+                @foreach (var dayName in DayNames)
+                {
+                    <div role="columnheader" class="bg-card px-2 py-1.5 text-center text-xs font-medium text-muted-foreground">
+                        @dayName
+                    </div>
+                }
+            </div>
+            @foreach (var week in MonthWeeks)
+            {
+                <div role="row" class="grid grid-cols-7 gap-px">
+                    @foreach (var day in week)
+                    {
+                        var dayEvents = GetEventsForDay(day);
+                        var hiddenCount = dayEvents.Count - MaxEventsPerDay;
+                        <div role="gridcell" aria-label="@day.ToString("D", culture)" class="@GetMonthCellClasses(day)">
+                            <button type="button"
+                                    class="@GetDayNumberClasses(day)"
+                                    aria-label="@day.ToString("D", culture)"
+                                    @onclick="@(() => HandleDateClick(day))">
+                                @day.Day
+                            </button>
+                            @if (dayEvents.Count > 0)
+                            {
+                                <div class="mt-1 space-y-0.5">
+                                    @foreach (var item in dayEvents.Take(MaxEventsPerDay))
+                                    {
+                                        <button type="button"
+                                                class="@GetEventChipClasses(item)"
+                                                title="@EventTitle(item)"
+                                                @onclick="@(() => HandleEventClick(item))">
+                                            @if (EventTemplate is not null)
+                                            {
+                                                @EventTemplate(item)
+                                            }
+                                            else
+                                            {
+                                                <span class="block truncate">@EventTitle(item)</span>
+                                            }
+                                        </button>
+                                    }
+                                    @if (hiddenCount > 0)
+                                    {
+                                        <button type="button"
+                                                class="block w-full truncate rounded px-1.5 py-0.5 text-left text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                                @onclick="@(() => ShowMoreAsync(day))">
+                                            @Localizer["EventCalendar.MoreEvents", hiddenCount]
+                                        </button>
+                                    }
+                                </div>
+                            }
+                        </div>
+                    }
+                </div>
+            }
+        </div>
+    }
+    else if (View == EventCalendarView.Week)
+    {
+        @* Week view: seven day columns with stacked events in start order *@
+        <div role="grid" aria-label="@HeaderTitle" class="grid gap-px overflow-hidden rounded-lg border border-border bg-border">
+            <div role="row" class="grid grid-cols-7 gap-px">
+                @foreach (var day in WeekDays)
+                {
+                    <div role="columnheader" class="bg-card p-2 text-center">
+                        <button type="button"
+                                class="mx-auto flex flex-col items-center gap-0.5 rounded-md px-2 py-0.5 hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                aria-label="@day.ToString("D", culture)"
+                                @onclick="@(() => HandleDateClick(day))">
+                            <span class="text-xs font-medium text-muted-foreground">@culture.DateTimeFormat.GetAbbreviatedDayName(day.DayOfWeek)</span>
+                            <span class="@GetDayNumberClasses(day)">@day.Day</span>
+                        </button>
+                    </div>
+                }
+            </div>
+            <div role="row" class="grid grid-cols-7 gap-px">
+                @foreach (var day in WeekDays)
+                {
+                    <div role="gridcell" aria-label="@day.ToString("D", culture)" class="min-h-48 space-y-1 bg-card p-1.5">
+                        @foreach (var item in GetEventsForDay(day))
+                        {
+                            <button type="button"
+                                    class="@GetEventChipClasses(item)"
+                                    title="@EventTitle(item)"
+                                    @onclick="@(() => HandleEventClick(item))">
+                                @if (EventTemplate is not null)
+                                {
+                                    @EventTemplate(item)
+                                }
+                                else
+                                {
+                                    <span class="block text-[10px] leading-tight opacity-75">@GetEventTimeLabel(item)</span>
+                                    <span class="block truncate">@EventTitle(item)</span>
+                                }
+                            </button>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    }
+    else
+    {
+        @* Agenda view: the current month's events grouped chronologically by day *@
+        <div class="divide-y divide-border overflow-hidden rounded-lg border border-border bg-card text-card-foreground">
+            @if (!AgendaDays.Any())
+            {
+                <p class="p-6 text-center text-sm text-muted-foreground">@Localizer["EventCalendar.NoEvents"]</p>
+            }
+            @foreach (var day in AgendaDays)
+            {
+                <div class="p-4">
+                    <h3 class="@(day == DateTime.Today ? "text-sm font-semibold text-primary" : "text-sm font-semibold")">
+                        @day.ToString("D", culture)
+                    </h3>
+                    <ul class="mt-2 space-y-1" role="list">
+                        @foreach (var item in GetEventsForDay(day))
+                        {
+                            <li>
+                                <button type="button"
+                                        class="@ClassNames.cn("flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring", EventClass?.Invoke(item))"
+                                        @onclick="@(() => HandleEventClick(item))">
+                                    <span class="w-28 shrink-0 text-xs text-muted-foreground">@GetEventTimeLabel(item)</span>
+                                    @if (EventTemplate is not null)
+                                    {
+                                        @EventTemplate(item)
+                                    }
+                                    else
+                                    {
+                                        <span class="truncate font-medium">@EventTitle(item)</span>
+                                    }
+                                </button>
+                            </li>
+                        }
+                    </ul>
+                </div>
+            }
+        </div>
+    }
+</div>

--- a/src/BlazorBlueprint.Components/Components/EventCalendar/BbEventCalendar.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/EventCalendar/BbEventCalendar.razor.cs
@@ -1,0 +1,439 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// An event calendar with month, week, and agenda views, generic over the consumer's event type.
+/// </summary>
+/// <typeparam name="TEvent">The consumer's event type. Accessor delegates map it to start/end dates and a title.</typeparam>
+public partial class BbEventCalendar<TEvent> : ComponentBase
+{
+    private CultureInfo culture = CultureInfo.CurrentCulture;
+    private Dictionary<DateTime, List<TEvent>> eventsByDay = new();
+    private EventCalendarRange? lastNotifiedRange;
+    private string[]? cachedDayNames;
+    private DayOfWeek cachedFirstDayOfWeek;
+
+    /// <summary>
+    /// The events to display.
+    /// </summary>
+    [Parameter]
+    public IEnumerable<TEvent>? Items { get; set; }
+
+    /// <summary>
+    /// Returns the start date/time of an event.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public Func<TEvent, DateTime> EventStart { get; set; } = default!;
+
+    /// <summary>
+    /// Returns the end date/time of an event, or null for a point-in-time event.
+    /// When the delegate itself is null, all events are treated as point-in-time.
+    /// Events whose end date falls on a later day than their start render a chip on each spanned day.
+    /// </summary>
+    [Parameter]
+    public Func<TEvent, DateTime?>? EventEnd { get; set; }
+
+    /// <summary>
+    /// Returns the display title of an event.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public Func<TEvent, string> EventTitle { get; set; } = default!;
+
+    /// <summary>
+    /// Returns additional CSS classes for a specific event's chip, merged with the built-in chip classes.
+    /// Use this for per-event coloring (e.g. by category).
+    /// </summary>
+    [Parameter]
+    public Func<TEvent, string?>? EventClass { get; set; }
+
+    /// <summary>
+    /// Optional template that fully replaces the built-in event chip content.
+    /// When set, only minimal layout/focus classes are applied to the chip button;
+    /// combine with <see cref="EventClass"/> for chip-level styling.
+    /// </summary>
+    [Parameter]
+    public RenderFragment<TEvent>? EventTemplate { get; set; }
+
+    /// <summary>
+    /// The active view. Use @bind-View for two-way binding.
+    /// </summary>
+    [Parameter]
+    public EventCalendarView View { get; set; } = EventCalendarView.Month;
+
+    /// <summary>
+    /// Callback when the active view changes.
+    /// </summary>
+    [Parameter]
+    public EventCallback<EventCalendarView> ViewChanged { get; set; }
+
+    /// <summary>
+    /// The date that controls the visible period (the month or week containing it).
+    /// Use @bind-CurrentDate for two-way binding. Defaults to today.
+    /// </summary>
+    [Parameter]
+    public DateTime CurrentDate { get; set; } = DateTime.Today;
+
+    /// <summary>
+    /// Callback when the current date changes through navigation.
+    /// </summary>
+    [Parameter]
+    public EventCallback<DateTime> CurrentDateChanged { get; set; }
+
+    /// <summary>
+    /// The first day of the week. Defaults to the current culture's first day of the week.
+    /// </summary>
+    [Parameter]
+    public DayOfWeek? FirstDayOfWeek { get; set; }
+
+    /// <summary>
+    /// The maximum number of event chips shown per day in the month view before
+    /// the overflow "+x more" button appears. Defaults to 3.
+    /// </summary>
+    [Parameter]
+    public int MaxEventsPerDay { get; set; } = 3;
+
+    /// <summary>
+    /// Callback when an event chip is clicked.
+    /// </summary>
+    [Parameter]
+    public EventCallback<TEvent> OnEventClick { get; set; }
+
+    /// <summary>
+    /// Callback when a day number (month view) or day header (week view) is clicked.
+    /// </summary>
+    [Parameter]
+    public EventCallback<DateTime> OnDateClick { get; set; }
+
+    /// <summary>
+    /// Callback when the visible date range changes (including the initial range).
+    /// Useful for loading events on demand.
+    /// </summary>
+    [Parameter]
+    public EventCallback<EventCalendarRange> OnViewRangeChanged { get; set; }
+
+    /// <summary>
+    /// Additional CSS classes to apply to the root element.
+    /// </summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    /// <summary>
+    /// Additional attributes to apply to the root element.
+    /// </summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private DayOfWeek EffectiveFirstDayOfWeek => FirstDayOfWeek ?? culture.DateTimeFormat.FirstDayOfWeek;
+
+    private string CssClass => ClassNames.cn("w-full", Class);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        var currentCulture = CultureInfo.CurrentCulture;
+        if (!ReferenceEquals(culture, currentCulture) && culture.Name != currentCulture.Name)
+        {
+            culture = currentCulture;
+            cachedDayNames = null;
+        }
+
+        if (cachedFirstDayOfWeek != EffectiveFirstDayOfWeek)
+        {
+            cachedFirstDayOfWeek = EffectiveFirstDayOfWeek;
+            cachedDayNames = null;
+        }
+
+        await RefreshAsync();
+    }
+
+    #region Range & lookup
+
+    private EventCalendarRange GetVisibleRange()
+    {
+        switch (View)
+        {
+            case EventCalendarView.Week:
+                var weekStart = StartOfWeek(CurrentDate);
+                return new EventCalendarRange(weekStart, weekStart.AddDays(6));
+            case EventCalendarView.Agenda:
+                var agendaStart = new DateTime(CurrentDate.Year, CurrentDate.Month, 1);
+                return new EventCalendarRange(agendaStart, agendaStart.AddMonths(1).AddDays(-1));
+            default:
+                var firstOfMonth = new DateTime(CurrentDate.Year, CurrentDate.Month, 1);
+                var gridStart = StartOfWeek(firstOfMonth);
+                return new EventCalendarRange(gridStart, gridStart.AddDays(41));
+        }
+    }
+
+    private DateTime StartOfWeek(DateTime date)
+    {
+        var diff = ((int)date.DayOfWeek - (int)EffectiveFirstDayOfWeek + 7) % 7;
+        return date.Date.AddDays(-diff);
+    }
+
+    /// <summary>
+    /// Rebuilds the per-day event lookup for the visible range and raises
+    /// <see cref="OnViewRangeChanged"/> when the range has changed.
+    /// </summary>
+    private async Task RefreshAsync()
+    {
+        RebuildEventLookup();
+
+        var range = GetVisibleRange();
+        if (lastNotifiedRange == range)
+        {
+            return;
+        }
+
+        lastNotifiedRange = range;
+        if (OnViewRangeChanged.HasDelegate)
+        {
+            await OnViewRangeChanged.InvokeAsync(range);
+        }
+    }
+
+    private void RebuildEventLookup()
+    {
+        eventsByDay = new Dictionary<DateTime, List<TEvent>>();
+        if (Items is null || EventStart is null)
+        {
+            return;
+        }
+
+        var range = GetVisibleRange();
+        foreach (var item in Items)
+        {
+            var startDay = EventStart(item).Date;
+            var endDay = (EventEnd?.Invoke(item) ?? EventStart(item)).Date;
+            if (endDay < startDay)
+            {
+                endDay = startDay;
+            }
+
+            var from = startDay < range.Start ? range.Start : startDay;
+            var to = endDay > range.End ? range.End : endDay;
+            for (var day = from; day <= to; day = day.AddDays(1))
+            {
+                if (!eventsByDay.TryGetValue(day, out var list))
+                {
+                    list = new List<TEvent>();
+                    eventsByDay[day] = list;
+                }
+                list.Add(item);
+            }
+        }
+
+        foreach (var list in eventsByDay.Values)
+        {
+            list.Sort(CompareEvents);
+        }
+    }
+
+    private int CompareEvents(TEvent a, TEvent b)
+    {
+        // All-day events first, then by start, then by title for a stable order.
+        var allDayCompare = IsAllDay(b).CompareTo(IsAllDay(a));
+        if (allDayCompare != 0)
+        {
+            return allDayCompare;
+        }
+
+        var startCompare = EventStart(a).CompareTo(EventStart(b));
+        if (startCompare != 0)
+        {
+            return startCompare;
+        }
+
+        return string.Compare(EventTitle(a), EventTitle(b), StringComparison.Ordinal);
+    }
+
+    private IReadOnlyList<TEvent> GetEventsForDay(DateTime day) =>
+        eventsByDay.TryGetValue(day.Date, out var list) ? list : Array.Empty<TEvent>();
+
+    #endregion
+
+    #region View data
+
+    private string[] DayNames => cachedDayNames ??= BuildDayNames();
+
+    private string[] BuildDayNames()
+    {
+        var cultureNames = culture.DateTimeFormat.AbbreviatedDayNames;
+        var start = (int)EffectiveFirstDayOfWeek;
+        var names = new string[7];
+        for (var i = 0; i < 7; i++)
+        {
+            names[i] = cultureNames[(start + i) % 7];
+        }
+        return names;
+    }
+
+    private IEnumerable<DateTime[]> MonthWeeks
+    {
+        get
+        {
+            var start = GetVisibleRange().Start;
+            for (var week = 0; week < 6; week++)
+            {
+                var days = new DateTime[7];
+                for (var i = 0; i < 7; i++)
+                {
+                    days[i] = start.AddDays((week * 7) + i);
+                }
+                yield return days;
+            }
+        }
+    }
+
+    private DateTime[] WeekDays
+    {
+        get
+        {
+            var start = StartOfWeek(CurrentDate);
+            var days = new DateTime[7];
+            for (var i = 0; i < 7; i++)
+            {
+                days[i] = start.AddDays(i);
+            }
+            return days;
+        }
+    }
+
+    private IEnumerable<DateTime> AgendaDays => eventsByDay.Keys.OrderBy(d => d);
+
+    private string HeaderTitle
+    {
+        get
+        {
+            if (View == EventCalendarView.Week)
+            {
+                var range = GetVisibleRange();
+                return string.Format(
+                    culture,
+                    "{0} – {1}, {2}",
+                    range.Start.ToString("M", culture),
+                    range.End.ToString("M", culture),
+                    range.End.Year);
+            }
+
+            return CurrentDate.ToString("Y", culture);
+        }
+    }
+
+    private bool IsAllDay(TEvent item)
+    {
+        var start = EventStart(item);
+        if (start.TimeOfDay != TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        var end = EventEnd?.Invoke(item);
+        if (end is null)
+        {
+            return true;
+        }
+
+        return end.Value.TimeOfDay == TimeSpan.Zero;
+    }
+
+    private string GetEventTimeLabel(TEvent item)
+    {
+        if (IsAllDay(item))
+        {
+            return Localizer["EventCalendar.AllDay"];
+        }
+
+        var start = EventStart(item);
+        var end = EventEnd?.Invoke(item);
+        if (end is null || end.Value == start)
+        {
+            return start.ToString("t", culture);
+        }
+
+        return string.Format(
+            culture,
+            "{0} – {1}",
+            start.ToString("t", culture),
+            end.Value.ToString("t", culture));
+    }
+
+    #endregion
+
+    #region Navigation & interaction
+
+    private async Task SetViewAsync(EventCalendarView view)
+    {
+        if (View == view)
+        {
+            return;
+        }
+
+        View = view;
+        await ViewChanged.InvokeAsync(view);
+        await RefreshAsync();
+    }
+
+    private async Task SetCurrentDateAsync(DateTime date)
+    {
+        CurrentDate = date.Date;
+        await CurrentDateChanged.InvokeAsync(CurrentDate);
+        await RefreshAsync();
+    }
+
+    private Task NavigatePreviousAsync() =>
+        SetCurrentDateAsync(View == EventCalendarView.Week ? CurrentDate.AddDays(-7) : CurrentDate.AddMonths(-1));
+
+    private Task NavigateNextAsync() =>
+        SetCurrentDateAsync(View == EventCalendarView.Week ? CurrentDate.AddDays(7) : CurrentDate.AddMonths(1));
+
+    private Task NavigateTodayAsync() => SetCurrentDateAsync(DateTime.Today);
+
+    private Task HandleEventClick(TEvent item) => OnEventClick.InvokeAsync(item);
+
+    private Task HandleDateClick(DateTime day) => OnDateClick.InvokeAsync(day.Date);
+
+    /// <summary>
+    /// The "+x more" overflow: navigates to the clicked day in the agenda view.
+    /// </summary>
+    private async Task ShowMoreAsync(DateTime day)
+    {
+        await SetViewAsync(EventCalendarView.Agenda);
+        await SetCurrentDateAsync(day);
+    }
+
+    #endregion
+
+    #region Styling
+
+    private const string ChipBaseClasses = "block w-full rounded px-1.5 py-0.5 text-left text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+    private const string ChipTemplateClasses = "block w-full rounded text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+    private const string DayNumberBaseClasses = "flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+    private const string DayNumberTodayClasses = "flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+    private string GetEventChipClasses(TEvent item)
+    {
+        var baseClasses = EventTemplate is not null ? ChipTemplateClasses : ChipBaseClasses;
+        var customClass = EventClass?.Invoke(item);
+        return string.IsNullOrEmpty(customClass) ? baseClasses : ClassNames.cn(baseClasses, customClass);
+    }
+
+    private string GetMonthCellClasses(DateTime day)
+    {
+        var isOutside = day.Month != CurrentDate.Month || day.Year != CurrentDate.Year;
+        return isOutside
+            ? "min-h-28 bg-card p-1.5 text-muted-foreground"
+            : "min-h-28 bg-card p-1.5";
+    }
+
+    private static string GetDayNumberClasses(DateTime day) =>
+        day.Date == DateTime.Today ? DayNumberTodayClasses : DayNumberBaseClasses;
+
+    private string GetViewSwitchClasses(EventCalendarView view) =>
+        View == view
+            ? "rounded-sm px-3 py-1 text-sm font-medium bg-primary text-primary-foreground"
+            : "rounded-sm px-3 py-1 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+    #endregion
+}

--- a/src/BlazorBlueprint.Components/Components/EventCalendar/EventCalendarRange.cs
+++ b/src/BlazorBlueprint.Components/Components/EventCalendar/EventCalendarRange.cs
@@ -1,0 +1,8 @@
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// The inclusive date range currently visible in a <see cref="BbEventCalendar{TEvent}"/> view.
+/// </summary>
+/// <param name="Start">The first visible day (date component only).</param>
+/// <param name="End">The last visible day (date component only).</param>
+public readonly record struct EventCalendarRange(DateTime Start, DateTime End);

--- a/src/BlazorBlueprint.Components/Components/EventCalendar/EventCalendarView.cs
+++ b/src/BlazorBlueprint.Components/Components/EventCalendar/EventCalendarView.cs
@@ -1,0 +1,22 @@
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// The available views for <see cref="BbEventCalendar{TEvent}"/>.
+/// </summary>
+public enum EventCalendarView
+{
+    /// <summary>
+    /// A six-week month grid with event chips per day.
+    /// </summary>
+    Month,
+
+    /// <summary>
+    /// Seven day columns listing the week's events per day in start order.
+    /// </summary>
+    Week,
+
+    /// <summary>
+    /// A chronological list of the current month's events grouped by day.
+    /// </summary>
+    Agenda
+}

--- a/src/BlazorBlueprint.Components/Localization/DefaultBbLocalizer.cs
+++ b/src/BlazorBlueprint.Components/Localization/DefaultBbLocalizer.cs
@@ -157,6 +157,18 @@ public class DefaultBbLocalizer : IBbLocalizer
         ["Dock.RestorePanelGroup"] = "Restore panel group",
         ["Dock.NoPanelsOpen"] = "No panels are open.",
 
+        // EventCalendar
+        ["EventCalendar.Today"] = "Today",
+        ["EventCalendar.Month"] = "Month",
+        ["EventCalendar.Week"] = "Week",
+        ["EventCalendar.Agenda"] = "Agenda",
+        ["EventCalendar.PreviousPeriod"] = "Go to previous period",
+        ["EventCalendar.NextPeriod"] = "Go to next period",
+        ["EventCalendar.ViewSwitcher"] = "Calendar view",
+        ["EventCalendar.MoreEvents"] = "+{0} more",
+        ["EventCalendar.NoEvents"] = "No events to display.",
+        ["EventCalendar.AllDay"] = "All day",
+
         // FilterBuilder
         ["FilterBuilder.FilterBuilderAriaLabel"] = "Filter builder",
         ["FilterBuilder.SelectField"] = "Select field...",

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -1342,6 +1342,25 @@
   - Size : EmptySize
   - Title : String
 
+### BbEventCalendar`1 (BlazorBlueprint.Components)
+  - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
+  - Class : String
+  - CurrentDate : DateTime
+  - CurrentDateChanged : EventCallback<DateTime>
+  - EventClass : Func<TEvent, String>
+  - EventEnd : Func<TEvent, DateTime?>
+  - EventStart : Func<TEvent, DateTime> [EditorRequired]
+  - EventTemplate : RenderFragment<TEvent>
+  - EventTitle : Func<TEvent, String> [EditorRequired]
+  - FirstDayOfWeek : DayOfWeek?
+  - Items : IEnumerable<TEvent>
+  - MaxEventsPerDay : Int32
+  - OnDateClick : EventCallback<DateTime>
+  - OnEventClick : EventCallback<TEvent>
+  - OnViewRangeChanged : EventCallback<EventCalendarRange>
+  - View : EventCalendarView
+  - ViewChanged : EventCallback<EventCalendarView>
+
 ### BbField (BlazorBlueprint.Components)
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
   - ChildContent : RenderFragment
@@ -3870,6 +3889,11 @@
   - Small = 0
   - Default = 1
   - Large = 2
+
+### EventCalendarView (BlazorBlueprint.Components)
+  - Month = 0
+  - Week = 1
+  - Agenda = 2
 
 ### FieldGroupOrientation (BlazorBlueprint.Components)
   - Vertical = 0


### PR DESCRIPTION
## Description

Adds `BbEventCalendar<TEvent>`, an agenda/event calendar component (issue #307). It is generic over the consumer's own event type — no wrapper model required — mapped via accessor delegates:

- **Data**: `Items`, `EventStart`, `EventEnd` (`Func<TEvent, DateTime?>?` — null delegate *or* null return = point-in-time), `EventTitle`
- **Styling/customization**: `EventClass` (per-event chip classes, e.g. category colors), `EventTemplate` (fully replaces chip content)
- **Views**: `EventCalendarView { Month, Week, Agenda }` with `@bind-View`; built-in header with previous/today/next navigation and a localized view switcher
- **Period**: `@bind-CurrentDate`; `FirstDayOfWeek` defaults to the current culture (same as `BbCalendar`)
- **Month view**: fixed six-week grid, up to `MaxEventsPerDay` chips per day (default 3) with a localized "+x more" overflow that navigates to that day in the agenda view; today highlighted; outside-month days muted; multi-day events render a chip on each spanned day
- **Week view**: seven columns with each day's events stacked in start order (all-day events first)
- **Agenda view**: current month's events grouped chronologically by day, with a localized empty state
- **Callbacks**: `OnEventClick`, `OnDateClick`, `OnViewRangeChanged` (with new `EventCalendarRange` record for on-demand loading)
- **Localization**: new `EventCalendar.*` keys in `DefaultBbLocalizer`; date/time formats and day names are culture-aware
- **Accessibility**: `role="grid"`/`row`/`columnheader`/`gridcell` semantics, aria-labels with full localized dates, real buttons for every event/day (tab reachable), `aria-pressed` on the view switcher, `aria-live` period title
- Zero JS interop

Demo page (`/components/event-calendar`) includes basic month view, per-event colors, custom template, view switching/navigation with range display, and event-click handling, plus code snippets, API reference, accessibility, and localization sections. Sidebar, components index, and command search entries added.

### v1 limitations (documented on the demo page)

- Multi-day events render a chip per spanned day (no true spanning bars)
- Week view is a stacked per-day list (no hour grid)
- Events are keyboard reachable via tab order; arrow-key grid navigation is not implemented yet

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [x] Blazor Server
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [x] Keyboard navigation / accessibility
- [x] Dark mode

## Related Issues

Part of #307