### PR TITLE
chore(ci): auto-remove "working on it" label when an issue closes

### DIFF
--- a/.github/workflows/remove-working-on-it-label.yml
+++ b/.github/workflows/remove-working-on-it-label.yml
@@ -1,0 +1,21 @@
+name: Remove "working on it" label on close
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  remove-label:
+    if: contains(github.event.issue.labels.*.name, 'working on it')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove the label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label "working on it"


### PR DESCRIPTION
## Description

Adds a GitHub Action that removes the `working on it` label automatically when an issue is closed.

The label was being applied when work started but never cleared on close, so it accumulated on closed issues and stopped being a reliable signal of in-flight work. 11 closed issues had it removed by hand (#301, #299, #293, #275, #242, #222, #203, #202, #201, #155, #143); this prevents the drift from recurring.

Notes on the implementation:

- The job-level `if` reads the label from the event payload, so issues without the label finish immediately without an API call.
- Permissions are scoped to `issues: write`, using `GITHUB_TOKEN` rather than a PAT.
- Validated locally with `actionlint` (clean).

**This won't take effect on merge to `develop`.** Issue-triggered workflows always run the copy of the file on the default branch, so it stays dormant until `develop` reaches `main`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / repo automation

## Testing Checklist

Not applicable — repo automation only, no library or runtime surface is touched.

- [ ] Blazor Server
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility
- [ ] Dark mode

## Related Issues

None — follow-up to an ad-hoc label cleanup.
