### PR TITLE
fix(css): restore border colour utilities defeated by bb layer (#398)

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/wwwroot/css/app-input.css
+++ b/demos/BlazorBlueprint.Demo.Shared/wwwroot/css/app-input.css
@@ -4,12 +4,19 @@
 /* Import new OKLCH single-theme file */
 @import '../styles/theme.css';
 
-/* Configure source paths for scanning Razor files */
+/* Configure source paths for scanning Razor files.
+   Paths are relative to this file (demos/<Demo.Shared>/wwwroot/css), so reaching the
+   repo-root `src` takes four levels, not three. The three-level form silently
+   resolved to a non-existent `demos/src` — Tailwind does not error on a missing
+   @source, it just scans nothing — so the library sources were never scanned here.
+   The icon packages are deliberately absent: they are split per-icon-set
+   (Icons.Lucide/.Feather/.Heroicons/.FontAwesome), so the old bare `Icons` path
+   never existed either, and their only literal utility (text-destructive) is
+   already emitted from Components. */
 @source "../../Pages";
 @source "../../Shared";
-@source "../../../src/BlazorBlueprint.Components";
-@source "../../../src/BlazorBlueprint.Primitives";
-@source "../../../src/BlazorBlueprint.Icons";
+@source "../../../../src/BlazorBlueprint.Components";
+@source "../../../../src/BlazorBlueprint.Primitives";
 
 /* Component structural variables (not part of replaceable theme) */
 @layer base {

--- a/src/BlazorBlueprint.Components/wwwroot/css/blazorblueprint-input.css
+++ b/src/BlazorBlueprint.Components/wwwroot/css/blazorblueprint-input.css
@@ -214,6 +214,24 @@
   --tracking-widest: calc(var(--tracking-normal) + 0.1em);
 }
 
+/* Global theme defaults. These are resets rather than overrides, so they belong in
+   `base` where border/background utilities beat them normally on specificity. They
+   must stay OUT of `@layer bb`: as `bb.utilities` the universal `*` selector
+   outranked every border-* utility (layer priority ignores specificity), flattening
+   all border colours to --border — see #398. */
+@layer base {
+  * {
+    border-color: var(--border);
+  }
+
+  body {
+    background-color: var(--background);
+    color: var(--foreground);
+    font-family: var(--font-sans);
+    letter-spacing: var(--tracking-normal, 0);
+  }
+}
+
 /* All component utility/component layer blocks live inside `@layer bb` so they win
    the cascade-layer parity against consumer Tailwind output. The inner @layer
    declarations (base/components/utilities) become sublayers of bb. */
@@ -473,19 +491,7 @@
 
 
 
-/* Global theme overrides - utilities layer ensures these override Tailwind's reset */
 @layer utilities {
-  * {
-    border-color: var(--border);
-  }
-
-  body {
-    background-color: var(--background);
-    color: var(--foreground);
-    font-family: var(--font-sans);
-    letter-spacing: var(--tracking-normal, 0);
-  }
-
   /* Grid animation utilities for Accordion/Collapsible */
   .grid-rows-\[0fr\] {
     grid-template-rows: 0fr;


### PR DESCRIPTION
## Description

Fixes #398. The report was "Alert variants no longer presenting associated colors", but the actual scope is wider: **every `border-*` colour utility in the library has been dead since v3.10.1**. Alert was just the most visible symptom.

### Root cause

The shadcn-style reset `* { border-color: var(--border) }` sat inside `@layer bb`, so it resolved to the `bb.utilities` sublayer. `bb` is declared last and is therefore the highest-priority layer — and **cascade layer priority beats specificity unconditionally**. A universal `*` selector in `bb.utilities` therefore defeated every `.border-*` class in the plain `utilities` layer.

It only became a bug when c82039ef (the #318 grid fix) dropped `layer(bb)` from the Tailwind import:

| version | Tailwind's utilities | the `*` reset | result |
|---|---|---|---|
| ≤ 3.10.0 | `bb.utilities` | `bb.utilities` | same layer → specificity decides → class wins ✅ |
| 3.10.1+ | `utilities` | `bb.utilities` | reset in higher layer → wins → **all borders neutral** ❌ |

Everything else moved out of `bb`; the hand-authored reset was left behind.

Note the regression actually shipped in **3.10.1**, not 3.11 — so the reporter's "bumped 3.10 → 3.13" was 3.10.0 (good) → 3.13 (broken).

### The fix

Move the two global rules (`*` and `body`) out of `bb` into `base`. They are resets, not overrides — defaults that utilities are meant to beat — which is exactly where the demo's own `app.css` has always put them. The authored component rules that genuinely need layer priority (the #308/#318 sidebar selectors) stay in `bb`.

`body` moved too, not just `*`. Same latent bug class: inside `bb` it meant a consumer could not override body background/font. That is a deliberate behaviour change slightly beyond the literal issue — happy to narrow it to `*` only if preferred.

### Also included

The demo's `@source` paths were off by one level (`../../../src/...` → `demos/src/...`, which does not exist), so the demo's Tailwind **never scanned the library sources**. Tailwind does not error on a missing `@source`, it just scans nothing — which is why this went unnoticed. It was masked because the demo also loads the prebuilt `blazorblueprint.css`. The bare `Icons` path never existed either (icon packages are split per set), and its only literal utility (`text-destructive`) is already emitted from Components, so that line is dropped rather than repointed. Demo `app.css` goes 72.8KB → 142.7KB as a result.

Unchanged since the v4 migration and independent of #398, but fixed here since it was found in the same investigation.

### Verification

Checked computed styles in the browser against the running Alert demo, not just the CSS text:

- All five variants resolve **distinct** border colours in **both light and dark** mode (before: all five identical to `--border`).
- `border-primary` works again (before: neutral).
- The reset still does its job — an unstyled `border` element still gets `--border`, not `currentColor`.
- Sidebar mobile/desktop split still correct (`display: flex` at 1200px), so #308/#318 are not regressed.
- 67/67 tests pass. No public API change, so no API-surface snapshot churn and no demo example needed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [x] Blazor Server (verified in browser on the Alert demo)
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility (not applicable — CSS cascade only)
- [x] Dark mode

## Related Issues

Closes #398. Regression from c82039ef (#318); related to #308.
