### PR TITLE
fix(theme): restore theme when Blazor re-merges the document (#400)

### DIFF
--- a/src/BlazorBlueprint.Components/wwwroot/js/theme.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/theme.js
@@ -7,6 +7,122 @@
 const STORAGE_KEY = 'bb-theme';
 
 /**
+ * The theme state the document is meant to have.
+ *
+ * Everything below is applied to <html>, which the server never renders with these
+ * attributes — the theme is only known client-side (localStorage). Blazor's enhanced
+ * page refresh merges the freshly server-rendered document into the live DOM and
+ * syncs <html>'s attributes, so it strips class/data-base-color/--radius wholesale.
+ * `dotnet watch` triggers exactly that on every hot reload, which reset the theme to
+ * light mid-session and left the C# ThemeService state disagreeing with the DOM (#400).
+ *
+ * Tracking the intended state lets us put it back when something external clears it.
+ * @type {{ isDark: boolean, baseColor: string|null, primaryColor: string|null, radius: number|null } | null}
+ */
+let desired = null;
+
+/** @type {MutationObserver | null} */
+let guard = null;
+
+/** Whether we are mid-write, so the guard ignores our own mutations. */
+let writing = false;
+
+/**
+ * Write the desired state to the document.
+ */
+function writeToDom() {
+  if (!desired) {
+    return;
+  }
+
+  writing = true;
+  try {
+    const root = document.documentElement;
+
+    if (desired.isDark) {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+
+    if (desired.baseColor !== null) {
+      root.setAttribute('data-base-color', desired.baseColor);
+    }
+
+    if (desired.primaryColor !== null) {
+      if (desired.primaryColor === 'default') {
+        root.removeAttribute('data-primary-color');
+      } else {
+        root.setAttribute('data-primary-color', desired.primaryColor);
+      }
+    }
+
+    if (desired.radius !== null) {
+      root.style.setProperty('--radius', desired.radius + 'rem');
+    }
+  } finally {
+    writing = false;
+  }
+}
+
+/**
+ * Whether the document has drifted from the desired state.
+ * @returns {boolean}
+ */
+function hasDrifted() {
+  if (!desired) {
+    return false;
+  }
+
+  const root = document.documentElement;
+
+  if (root.classList.contains('dark') !== desired.isDark) {
+    return true;
+  }
+
+  if (desired.baseColor !== null && root.getAttribute('data-base-color') !== desired.baseColor) {
+    return true;
+  }
+
+  if (desired.primaryColor !== null) {
+    const current = root.getAttribute('data-primary-color');
+    const expected = desired.primaryColor === 'default' ? null : desired.primaryColor;
+    if (current !== expected) {
+      return true;
+    }
+  }
+
+  if (desired.radius !== null && root.style.getPropertyValue('--radius') !== desired.radius + 'rem') {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Watch <html> and restore the theme if something external resets it. Idempotent —
+ * the observer is created once per document. Re-applying only happens on genuine
+ * drift, so our own writes cannot cause a feedback loop.
+ */
+function startGuard() {
+  if (guard || typeof MutationObserver === 'undefined') {
+    return;
+  }
+
+  guard = new MutationObserver(() => {
+    if (writing || !hasDrifted()) {
+      return;
+    }
+    writeToDom();
+  });
+
+  guard.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class', 'data-base-color', 'data-primary-color', 'style']
+  });
+}
+
+/**
  * Apply the full theme to the document.
  * @param {boolean} isDark
  * @param {string} baseColor
@@ -14,10 +130,9 @@ const STORAGE_KEY = 'bb-theme';
  * @param {number} radius
  */
 export function applyTheme(isDark, baseColor, primaryColor, radius) {
-  applyDarkMode(isDark);
-  applyBaseColor(baseColor);
-  applyPrimaryColor(primaryColor);
-  applyRadius(radius);
+  desired = { isDark, baseColor, primaryColor, radius };
+  writeToDom();
+  startGuard();
 }
 
 /**
@@ -25,23 +140,21 @@ export function applyTheme(isDark, baseColor, primaryColor, radius) {
  * @param {boolean} isDark
  */
 export function applyDarkMode(isDark) {
-  const root = document.documentElement;
-  if (isDark) {
-    root.classList.add('dark');
-  } else {
-    root.classList.remove('dark');
-  }
+  desired = desired ?? { isDark, baseColor: null, primaryColor: null, radius: null };
+  desired.isDark = isDark;
+  writeToDom();
+  startGuard();
 }
 
 /**
  * Set the base color data attribute on the document element.
- * Also removes any inline --primary/--primary-foreground/--ring overrides
- * so the base color's built-in values take effect cleanly.
  * @param {string} color - Lowercase base color name (e.g., "zinc", "slate").
  */
 export function applyBaseColor(color) {
-  const root = document.documentElement;
-  root.setAttribute('data-base-color', color);
+  desired = desired ?? { isDark: document.documentElement.classList.contains('dark'), baseColor: color, primaryColor: null, radius: null };
+  desired.baseColor = color;
+  writeToDom();
+  startGuard();
 }
 
 /**
@@ -49,12 +162,10 @@ export function applyBaseColor(color) {
  * @param {string} color - Lowercase primary color name (e.g., "blue", "default").
  */
 export function applyPrimaryColor(color) {
-  const root = document.documentElement;
-  if (color === 'default') {
-    root.removeAttribute('data-primary-color');
-  } else {
-    root.setAttribute('data-primary-color', color);
-  }
+  desired = desired ?? { isDark: document.documentElement.classList.contains('dark'), baseColor: null, primaryColor: color, radius: null };
+  desired.primaryColor = color;
+  writeToDom();
+  startGuard();
 }
 
 /**
@@ -62,7 +173,10 @@ export function applyPrimaryColor(color) {
  * @param {number} radius - Border radius in rem.
  */
 export function applyRadius(radius) {
-  document.documentElement.style.setProperty('--radius', radius + 'rem');
+  desired = desired ?? { isDark: document.documentElement.classList.contains('dark'), baseColor: null, primaryColor: null, radius };
+  desired.radius = radius;
+  writeToDom();
+  startGuard();
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #400. Reproduced under `dotnet watch` and traced to Blazor's document merge, not to `ThemeService`'s state handling.

### Root cause

`ThemeService` applies the theme to `<html>` from JS only — dark mode as a `dark` class, base/primary color as data attributes, radius as an inline custom property. The server never renders any of it, since the preference lives in localStorage and is only known client-side.

Blazor's **enhanced page refresh** merges the freshly server-rendered document into the live DOM and syncs `<html>`'s attributes. The server-rendered `<html>` carries none of the theme state, so it gets stripped. Caught in the act by instrumenting the DOM:

```
removeAttribute("class") on <html>
  at http://localhost:7172/_framework/blazor.web.js:1:170184   ← Blazor's DOM merge
  at gi (blazor.web.js) → fi → pi
```

`dotnet watch` triggers that refresh on every hot reload. The document is **not** reloaded — a JS global set beforehand survives — so the circuit lives on, `isInitialized` stays `true`, `OnAfterRenderAsync(firstRender)` never fires again, and nothing puts the theme back.

Dark mode was just the visible symptom. Everything the service applies is wiped:

| | applied by JS | after hot reload |
|---|---|---|
| `class="dark"` | ✅ | wiped |
| `data-base-color="zinc"` | ✅ | wiped |
| `--radius` inline style | ✅ | wiped |

That also explains the two puzzling parts of the report. `DefaultDarkMode: true` didn't help because the C# state was never the problem — it stayed `true` while the DOM went light. The resulting desync made the toggle look broken: the first click set state to `false` and removed an already-absent class, so nothing visibly happened and a second click was needed. The preference was never lost, just never re-applied.

### The fix

`theme.js` now tracks the state the document is meant to have and restores it via a `MutationObserver` on `<html>` when something external clears it. Re-application is gated on genuine drift, so our own writes can't feedback-loop and user-initiated theme changes pass through untouched.

JS-only — no public API change, so no snapshot churn and no new demo example.

I considered the alternatives: an inline anti-FOUC script in `<head>` doesn't help (it won't re-run on a merge), and server-rendering the theme would need cookie-based persistence instead of localStorage — a much larger change. The observer is framework-agnostic and self-heals regardless of what caused the reset.

### Verification

Reproduced the original failure first, then verified the fix against real `dotnet watch` hot reloads:

- **Before:** `<html>` reverted to `lang="en" data-theme="default"` — class, base color and radius all gone, while localStorage still read `{"isDarkMode":true,...}`.
- **After:** all three survive the same hot reload, and the toggle flips on a single click again (state and DOM in sync).
- Scoped the blast radius: **enhanced navigation between pages does not take this path** — the theme already survived link clicks and normal page reloads, so this was never a production navigation bug. Confirmed both before and after.
- 67/67 tests pass.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [x] Blazor Server (reproduced and verified under `dotnet watch`)
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility (not applicable)
- [x] Dark mode (this is the fix)

## Related Issues

Closes #400.
