### PR TITLE
fix(input): guard IME composition across text, numeric, tag, and search inputs (#414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-07-16
+
+### Fixed
+
+- **IME composition was corrupted across every input that updates per keystroke** — Nothing in the library tracked composition, so typing `안녕` with a Korean IME produced `ㅇ안안ㄴ녕`. Assigning `element.value` mid-composition resets the IME's composition buffer *even when the assigned string matches what the element already holds*, and Blazor's renderer assigns `element.value` whenever a bound field changes — diffing against the previous render tree, never reading the DOM. So any per-keystroke C# round-trip corrupted composition. `UpdateTiming.OnChange`/`Debounced` escaped it only by making no interop call during typing. Affects `BbInput`, `BbTextarea`, `BbInputField`, `BbInputGroupInput`/`Textarea`, `BbNumericInput`, `BbCurrencyInput`, `BbTagInput`, `BbMarkdownEditor`, `BbMaskedInput`, `BbCombobox`/`BbFormFieldCombobox`, and `BbMultiSelect`/`BbFormFieldMultiSelect`. A new shared `composition-guard.js` holds interop back while composing and flushes once on `compositionend`; an interrupted composition resets on blur rather than wedging the field. `BbDatePickerInput` (binds `@onchange`) and `BbRichTextEditor` (Quill owns its DOM) were never affected. ([#415](https://github.com/blazorblueprintui/ui/pull/415))
+- **Enter, Space and Arrow keys were hijacked from the IME** — Separate from the value corruption above, and unfixed by it: Enter commits a composition and Space/Arrows drive the candidate list, but handlers bound to those keys fired while the IME still owned the keystroke. `BbCombobox` selected the focused item and closed the popover on the Enter that merely confirmed a syllable; `BbTagInput` committed a half-composed tag; `BbMarkdownEditor` continued a list; and `BbMultiSelect` was worst — a capture-phase handler with an unconditional `preventDefault` that **blocked the IME commit outright**, with Space (the Japanese conversion key) toggling a checkbox instead. All key handling now stands down while composing. ([#415](https://github.com/blazorblueprintui/ui/pull/415))
+- **BbNumericInput / BbCurrencyInput: full-width digits were silently deleted** — Input sanitizing tested digits with an ASCII range check (`ch >= '0' && ch <= '9'`), and full-width digits (`１` = U+FF11) sort above `'9'`, so a Japanese IME in 全角 mode had legitimate numeric input erased keystroke by keystroke. Reproduces without any IME composition involved. Full-width digits, decimal point and minus now fold to their ASCII equivalents (`１２３` → `123`, `－１２．５` → `-12.5`); genuine garbage is still stripped. ([#415](https://github.com/blazorblueprintui/ui/pull/415))
+
+### Changed
+
+- **BbMaskedInput: the mask is applied when the IME commits, not per keystroke** — Masking rewrites the field, which is precisely what resets a composition buffer, so a guard that skips the write is not enough — the mask itself has to wait. Raw text now sits unmasked while the IME composes and is masked once on commit. `'A'` and `'*'` mask positions accept CJK (both map to `char.IsLetter`/`char.IsLetterOrDigit`, and CJK characters are Unicode category `Lo`), so this is reachable with masks like `AAA-9999`. ASCII typing is unchanged and still masks on every keystroke. ([#415](https://github.com/blazorblueprintui/ui/pull/415))
+
+---
+
 ## 2026-07-15
 
 ### Added

--- a/src/BlazorBlueprint.Components/Components/Command/BbCommandInput.razor
+++ b/src/BlazorBlueprint.Components/Components/Command/BbCommandInput.razor
@@ -1,5 +1,6 @@
 @namespace BlazorBlueprint.Components
 @implements IDisposable
+@inject IJSRuntime JSRuntime
 
 <div class="@CssClass">
     <svg xmlns="http://www.w3.org/2000/svg"
@@ -30,6 +31,8 @@
 </div>
 
 @code {
+    private static readonly string[] GuardSuppressedEvents = ["input", "keydown"];
+
     private CancellationTokenSource? _debounceCts;
     private string _displayValue = string.Empty;
     private bool _isDebouncing;
@@ -76,6 +79,8 @@
     private ElementReference _inputRef;
     private bool _previousAutoFocus;
     private bool _shouldFocus;
+    private IJSObjectReference? _guardModule;
+    private readonly string _guardId = Guid.NewGuid().ToString("N");
 
     /// <summary>
     /// Focuses the input element.
@@ -118,6 +123,29 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            // HandleInput/HandleKeyDown are Blazor-delegated, so the guard suppresses the
+            // events at the element rather than the component checking a flag: input would
+            // otherwise write _displayValue back mid-composition, and Enter/Arrow would
+            // select a list item while the IME still owns the keystroke.
+            try
+            {
+                _guardModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import", "./_content/BlazorBlueprint.Components/js/composition-guard.js");
+                await _guardModule.InvokeVoidAsync(
+                    "attach", _inputRef, _guardId, new { suppress = GuardSuppressedEvents });
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            {
+                // Expected during circuit disconnect
+            }
+            catch (InvalidOperationException)
+            {
+                // JS interop not available during prerendering
+            }
+        }
+
         // Focus when AutoFocus becomes true (either on first render or when popover opens)
         if (_shouldFocus)
         {
@@ -198,6 +226,25 @@
     {
         _debounceCts?.Cancel();
         _debounceCts?.Dispose();
+        _ = DisposeGuardAsync();
         GC.SuppressFinalize(this);
+    }
+
+    private async Task DisposeGuardAsync()
+    {
+        if (_guardModule == null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _guardModule.InvokeVoidAsync("detach", _guardId);
+            await _guardModule.DisposeAsync();
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
+        {
+            // Expected during circuit disconnect
+        }
     }
 }

--- a/src/BlazorBlueprint.Components/Components/MaskedInput/BbMaskedInput.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/MaskedInput/BbMaskedInput.razor.cs
@@ -11,11 +11,15 @@ namespace BlazorBlueprint.Components;
 /// </summary>
 public partial class BbMaskedInput : ComponentBase, IAsyncDisposable
 {
+    private static readonly string[] GuardSuppressedEvents = ["input"];
+
     private ElementReference _inputRef;
     private MaskProcessor? _processor;
     private string _displayValue = string.Empty;
     private IJSObjectReference? _jsModule;
     private bool _jsModuleLoaded;
+    private IJSObjectReference? _guardModule;
+    private readonly string _guardId = Guid.NewGuid().ToString("N");
     private string? _generatedId;
     private readonly InputValidationBehavior validation = new();
 
@@ -212,6 +216,14 @@ public partial class BbMaskedInput : ComponentBase, IAsyncDisposable
                 _jsModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
                     "import", "./_content/BlazorBlueprint.Components/js/masked-input.js");
                 _jsModuleLoaded = true;
+
+                // Applying the mask means rewriting the element's value, which resets an
+                // in-progress IME composition. Suppressing input while composing defers the
+                // whole HandleInput pass — masking included — until the IME commits.
+                _guardModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import", "./_content/BlazorBlueprint.Components/js/composition-guard.js");
+                await _guardModule.InvokeVoidAsync(
+                    "attach", _inputRef, _guardId, new { suppress = GuardSuppressedEvents });
             }
             catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
             {
@@ -428,6 +440,18 @@ public partial class BbMaskedInput : ComponentBase, IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         GC.SuppressFinalize(this);
+        if (_guardModule != null)
+        {
+            try
+            {
+                await _guardModule.InvokeVoidAsync("detach", _guardId);
+                await _guardModule.DisposeAsync();
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
+            {
+                // Expected during circuit disconnect
+            }
+        }
         if (_jsModule != null)
         {
             try

--- a/src/BlazorBlueprint.Components/wwwroot/js/composition-guard.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/composition-guard.js
@@ -1,0 +1,135 @@
+/**
+ * IME composition guard.
+ *
+ * While an IME is composing (Korean 안녕, Japanese かんじ, Chinese pinyin) the browser
+ * fires `input` and `keydown` for every intermediate step. Acting on those events
+ * breaks composition in two distinct ways:
+ *
+ *   1. Assigning `element.value` mid-composition resets the IME's composition buffer —
+ *      even when the assigned string is identical to what the element already holds.
+ *      Blazor's renderer assigns `element.value` whenever a bound field changes, so any
+ *      per-keystroke C# round-trip corrupts composition (typing 안녕 yields ㅇ안안ㄴ녕).
+ *   2. Enter/Space/Arrow are how the user commits a composition or picks a candidate.
+ *      Handlers bound to those keys fire while the IME still owns the keystroke.
+ *
+ * Both are fixed the same way: do nothing while composing, act once on `compositionend`.
+ *
+ * Two consumers, two entry points:
+ *
+ *   - A JS module that owns its own listeners passes `onFlush` and checks `isComposing`
+ *     from inside its handlers.
+ *   - A component whose handlers are Blazor's own (`@oninput`, `@onkeydown`, `@bind`)
+ *     passes `suppress`. Blazor delegates bubbling events to a single document-level
+ *     listener, so stopping propagation at the element keeps those handlers from firing
+ *     without the component moving any logic into JS. This works for `input` and
+ *     `keydown` specifically: Blazor registers its non-bubbling set (`change`, `blur`,
+ *     `focus`, ...) with `capture: true` on `document`, which would run before us, but
+ *     `input` and `keydown` are not in that set and are listened for on the bubble phase.
+ */
+
+const instances = new Map();
+
+/**
+ * Creates a composition guard bound to an element.
+ * @param {HTMLElement} element - The element to guard.
+ * @param {object} [options] - Configuration.
+ * @param {Function} [options.onFlush] - Invoked once after composition ends. For callers
+ *   that own their listeners; do not combine with a `suppress` of the same event.
+ * @param {string[]} [options.suppress] - Event names to keep from reaching Blazor's
+ *   document-level listeners while composing. Only `input` and `keydown` are meaningful.
+ * @returns {{isComposing: boolean, dispose: Function}}
+ */
+export function createCompositionGuard(element, options = {}) {
+  if (!element) {
+    return { isComposing: false, dispose() {} };
+  }
+
+  const { onFlush, suppress = [] } = options;
+  const state = { isComposing: false };
+
+  const handleCompositionStart = () => {
+    state.isComposing = true;
+  };
+
+  const handleCompositionEnd = () => {
+    state.isComposing = false;
+
+    // Browsers disagree on whether the final `input` fires before or after
+    // `compositionend`, so the last one may have been suppressed above. Re-dispatching
+    // guarantees Blazor sees exactly one post-composition `input` under either ordering;
+    // a duplicate is harmless because the value is unchanged and the diff emits no edit.
+    if (suppress.includes('input')) {
+      element.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    if (onFlush) {
+      onFlush();
+    }
+  };
+
+  // A composition belongs to the focused element, so focus leaving it ends the composition
+  // whether or not the IME said so. Without this, an interrupted composition (tab-switch is
+  // the usual way) would latch isComposing and wedge the field for good. Normal blurs are
+  // already preceded by compositionend, so this only fires in the pathological case.
+  const handleBlur = () => {
+    if (state.isComposing) {
+      handleCompositionEnd();
+    }
+  };
+
+  // keyCode 229 is the pre-`isComposing` signal for "this keystroke belongs to the IME".
+  const shouldSuppress = (e) => state.isComposing || e.isComposing === true || e.keyCode === 229;
+
+  const handleSuppressed = (e) => {
+    if (shouldSuppress(e)) {
+      e.stopPropagation();
+    }
+  };
+
+  element.addEventListener('compositionstart', handleCompositionStart);
+  element.addEventListener('compositionend', handleCompositionEnd);
+  element.addEventListener('blur', handleBlur);
+
+  for (const name of suppress) {
+    element.addEventListener(name, handleSuppressed, true);
+  }
+
+  return {
+    get isComposing() {
+      return state.isComposing;
+    },
+    dispose() {
+      element.removeEventListener('compositionstart', handleCompositionStart);
+      element.removeEventListener('compositionend', handleCompositionEnd);
+      element.removeEventListener('blur', handleBlur);
+      for (const name of suppress) {
+        element.removeEventListener(name, handleSuppressed, true);
+      }
+    }
+  };
+}
+
+/**
+ * Attaches a guard keyed by instance id, for components that have no JS module of their
+ * own and drive this directly from C#.
+ * @param {HTMLElement} element - The element to guard.
+ * @param {string} instanceId - Unique ID for this instance.
+ * @param {object} [options] - Same shape as createCompositionGuard's options.
+ */
+export function attach(element, instanceId, options = {}) {
+  detach(instanceId);
+  const guard = createCompositionGuard(element, options);
+  instances.set(instanceId, guard);
+}
+
+/**
+ * Removes a guard previously attached with attach().
+ * @param {string} instanceId - The instance to detach.
+ */
+export function detach(instanceId) {
+  const guard = instances.get(instanceId);
+  if (guard) {
+    guard.dispose();
+    instances.delete(instanceId);
+  }
+}

--- a/src/BlazorBlueprint.Components/wwwroot/js/markdown-editor.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/markdown-editor.js
@@ -1,7 +1,12 @@
 /**
  * Markdown Editor JavaScript module
  * Handles textarea text selection, cursor positioning, text insertion, and undo/redo
+ *
+ * List continuation, undo snapshots, and the component's @oninput/@onkeydown are all held
+ * back while an IME is composing. See composition-guard.js for why.
  */
+
+import { createCompositionGuard } from './composition-guard.js';
 
 // Store references for editor data (history, dotNetRef, etc.)
 const editorMap = new WeakMap();
@@ -353,6 +358,7 @@ export function focusTextarea(textarea) {
 // Store references for cleanup
 const listenerMap = new WeakMap();
 const inputListenerMap = new WeakMap();
+const guardMap = new WeakMap();
 
 /**
  * Initialize list continuation behavior and undo/redo on textarea
@@ -375,6 +381,13 @@ export function initializeListContinuation(textarea, dotNetRef) {
     saveState(textarea);
 
     const handler = (e) => {
+        // The Enter that commits a composition must not continue a list. Chrome happens to
+        // report key "Process" mid-composition and would fall through anyway, but Firefox
+        // and Safari report "Enter" with isComposing set.
+        if (guard.isComposing || e.isComposing === true || e.keyCode === 229) {
+            return;
+        }
+
         // Intercept Ctrl+Z/Y for undo/redo (prevent browser's native undo)
         if (e.ctrlKey || e.metaKey) {
             if (e.key === 'z' || e.key === 'Z') {
@@ -470,6 +483,13 @@ export function initializeListContinuation(textarea, dotNetRef) {
 
     // Add input listener for auto-scroll and state saving on typing
     const inputHandler = () => {
+        // Snapshotting each composition step would make Ctrl+Z walk back through jamo
+        // rather than words. Scrolling to the cursor stays live.
+        if (guard.isComposing) {
+            requestAnimationFrame(() => scrollToCursor(textarea));
+            return;
+        }
+
         // Use requestAnimationFrame to ensure scroll happens after DOM update
         requestAnimationFrame(() => {
             scrollToCursor(textarea);
@@ -479,6 +499,9 @@ export function initializeListContinuation(textarea, dotNetRef) {
     };
     textarea.addEventListener('input', inputHandler);
     inputListenerMap.set(textarea, inputHandler);
+
+    const guard = createCompositionGuard(textarea, { suppress: ['input', 'keydown'] });
+    guardMap.set(textarea, guard);
 }
 
 /**
@@ -496,6 +519,11 @@ export function disposeListContinuation(textarea) {
     if (inputHandler) {
         textarea.removeEventListener('input', inputHandler);
         inputListenerMap.delete(textarea);
+    }
+    const guard = guardMap.get(textarea);
+    if (guard) {
+        guard.dispose();
+        guardMap.delete(textarea);
     }
     // Clean up editor data (history, dotNetRef)
     editorMap.delete(textarea);

--- a/src/BlazorBlueprint.Components/wwwroot/js/multiselect.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/multiselect.js
@@ -4,6 +4,11 @@
 // - Space toggles checkbox without closing
 // - Enter toggles checkbox and closes
 // - Preserves selection state on items
+//
+// Navigation keys and the search input's @bind are both held back while an IME is
+// composing. See composition-guard.js for why.
+
+import { createCompositionGuard } from './composition-guard.js';
 
 let multiSelectStates = new Map();
 
@@ -66,6 +71,14 @@ export function setupMultiSelectInput(inputElement, dotNetRef, inputId, contentI
 
     // Handle keyboard navigation
     const keyHandler = (e) => {
+        // While the IME is composing, every key below belongs to it: Space is the Japanese
+        // conversion key, Enter commits, Arrows walk the candidate list, and Escape cancels.
+        // This handler is capture-phase and preventDefaults unconditionally, so without this
+        // guard it would block the IME outright rather than merely fire alongside it.
+        if (guard.isComposing || e.isComposing === true || e.keyCode === 229) {
+            return;
+        }
+
         const options = getVisibleOptions();
 
         // Only handle keys if there are visible options
@@ -165,11 +178,14 @@ export function setupMultiSelectInput(inputElement, dotNetRef, inputId, contentI
     };
     inputElement.addEventListener('input', inputHandler);
 
+    const guard = createCompositionGuard(inputElement, { suppress: ['input'] });
+
     // Store state and handlers for cleanup
     multiSelectStates.set(inputId, {
         state,
         keyHandler,
         inputHandler,
+        guard,
         inputElement
     });
 
@@ -185,6 +201,7 @@ export function removeMultiSelectInput(inputId) {
     if (stored) {
         stored.inputElement.removeEventListener('keydown', stored.keyHandler, true);
         stored.inputElement.removeEventListener('input', stored.inputHandler);
+        stored.guard.dispose();
         multiSelectStates.delete(inputId);
     }
 }
@@ -196,6 +213,7 @@ export function disposeAll() {
     multiSelectStates.forEach((stored, inputId) => {
         stored.inputElement.removeEventListener('keydown', stored.keyHandler, true);
         stored.inputElement.removeEventListener('input', stored.inputHandler);
+        stored.guard.dispose();
     });
     multiSelectStates.clear();
 }

--- a/src/BlazorBlueprint.Components/wwwroot/js/numeric-input.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/numeric-input.js
@@ -7,9 +7,34 @@
  *   - JsOnBlur(value)    — called on blur (always)
  *   - JsOnFocus()        — called on focus (always)
  *   - JsOnKeyDown(key)   — called for step keys (ArrowUp/Down, PageUp/Down, Home/End)
+ *
+ * Sanitization and interop are held back while an IME is composing, then flushed once on
+ * compositionend. See composition-guard.js for why.
  */
 
+import { createCompositionGuard } from './composition-guard.js';
+
 const instances = new Map();
+
+/**
+ * Folds full-width forms to their ASCII equivalents, one character in one character out so
+ * cursor offsets survive. A Japanese IME in 全角 mode emits ０-９ for the digit keys, which
+ * would otherwise fail the ASCII range test below and be stripped as garbage.
+ * @param {string} ch - A single character.
+ * @returns {string} The ASCII equivalent, or the original character.
+ */
+const foldFullWidth = (ch) => {
+  const code = ch.charCodeAt(0);
+  if (code >= 0xff10 && code <= 0xff19) {
+    return String.fromCharCode(code - 0xff10 + 0x30);
+  }
+  switch (code) {
+    case 0xff0e: return '.';
+    case 0xff0c: return ',';
+    case 0xff0d: return '-';
+    default: return ch;
+  }
+};
 
 /**
  * Initializes JS event handling for a numeric input element.
@@ -52,7 +77,7 @@ export function initialize(element, dotNetRef, instanceId, config) {
     let removed = 0;
 
     for (let i = 0; i < raw.length; i++) {
-      const ch = raw[i];
+      const ch = foldFullWidth(raw[i]);
       const decSep = cfg.decimalSeparator || '.';
       if (ch >= '0' && ch <= '9') {
         sanitized += ch;
@@ -87,6 +112,12 @@ export function initialize(element, dotNetRef, instanceId, config) {
   };
 
   const handleInput = () => {
+    // sanitizeInput writes element.value, which would reset the composition buffer;
+    // guard.onFlush re-runs this once the IME commits.
+    if (guard.isComposing) {
+      return;
+    }
+
     sanitizeInput();
     const value = element.value;
 
@@ -111,11 +142,19 @@ export function initialize(element, dotNetRef, instanceId, config) {
   };
 
   const handleKeyDown = (e) => {
+    // Arrow/Home/End drive the IME candidate list while composing — stepping the value
+    // here would steal them and preventDefault the IME's own handling.
+    if (guard.isComposing || e.isComposing === true || e.keyCode === 229) {
+      return;
+    }
+
     if (stepKeySet.has(e.key)) {
       e.preventDefault();
       dotNetRef.invokeMethodAsync('JsOnKeyDown', e.key).catch(() => {});
     }
   };
+
+  const guard = createCompositionGuard(element, { onFlush: handleInput });
 
   element.addEventListener('input', handleInput);
   element.addEventListener('blur', handleBlur);
@@ -128,6 +167,7 @@ export function initialize(element, dotNetRef, instanceId, config) {
     handleBlur,
     handleFocus,
     handleKeyDown,
+    guard,
     element
   });
 }
@@ -158,6 +198,7 @@ export function dispose(instanceId) {
   stored.element.removeEventListener('blur', stored.handleBlur);
   stored.element.removeEventListener('focus', stored.handleFocus);
   stored.element.removeEventListener('keydown', stored.handleKeyDown);
+  stored.guard.dispose();
 
   if (stored.state.debounceTimer) {
     clearTimeout(stored.state.debounceTimer);

--- a/src/BlazorBlueprint.Components/wwwroot/js/tag-input.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/tag-input.js
@@ -1,7 +1,12 @@
 /**
  * Tag Input JavaScript interop module.
  * Handles trigger key preventDefault, paste event reading, and container click-to-focus.
+ *
+ * Trigger keys and the component's @oninput are both held back while an IME is composing.
+ * See composition-guard.js for why.
  */
+
+import { createCompositionGuard } from './composition-guard.js';
 
 const instances = new Map();
 
@@ -20,6 +25,13 @@ export function initialize(containerEl, inputEl, dotNetRef, instanceId, config) 
   }
 
   const handleKeyDown = (e) => {
+    // Every key below belongs to the IME while it is composing: Enter and the delimiters
+    // commit the composition, Arrows drive the candidate list, and Escape cancels it.
+    // Acting on any of them would commit a half-composed tag or fight the candidate window.
+    if (guard.isComposing || e.isComposing === true || e.keyCode === 229) {
+      return;
+    }
+
     const key = e.key;
 
     // Check if the key is a configured trigger
@@ -87,6 +99,8 @@ export function initialize(containerEl, inputEl, dotNetRef, instanceId, config) 
     inputEl.focus();
   };
 
+  const guard = createCompositionGuard(inputEl, { suppress: ['input'] });
+
   // Use capture phase for keydown to preventDefault before browser defaults
   inputEl.addEventListener('keydown', handleKeyDown, true);
   inputEl.addEventListener('paste', handlePaste);
@@ -96,6 +110,7 @@ export function initialize(containerEl, inputEl, dotNetRef, instanceId, config) 
     handleKeyDown,
     handlePaste,
     handleContainerClick,
+    guard,
     inputEl,
     containerEl
   });
@@ -125,5 +140,6 @@ export function dispose(instanceId) {
   stored.inputEl.removeEventListener('keydown', stored.handleKeyDown, true);
   stored.inputEl.removeEventListener('paste', stored.handlePaste);
   stored.containerEl.removeEventListener('click', stored.handleContainerClick);
+  stored.guard.dispose();
   instances.delete(instanceId);
 }

--- a/src/BlazorBlueprint.Components/wwwroot/js/text-input.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/text-input.js
@@ -7,7 +7,12 @@
  *                For inputs this fires on blur and Enter; for textareas it fires on blur only.
  *   - immediate: JS batches calls via requestAnimationFrame.
  *   - debounced: JS debounces calls via setTimeout.
+ *
+ * All modes hold interop back while an IME is composing, then flush once on
+ * compositionend. See composition-guard.js for why.
  */
+
+import { createCompositionGuard } from './composition-guard.js';
 
 const instances = new Map();
 
@@ -78,9 +83,16 @@ export function initialize(element, dotNetRef, instanceId, config) {
   const handleInput = () => {
     const value = element.value;
 
+    // The counter tracks the element, not the bound value, so it stays live while composing.
     updateCharacterCount();
 
     if (config.mode === 'onchange') {
+      return;
+    }
+
+    // Interop here would write the bound value back mid-composition; guard.onFlush
+    // re-runs this once the IME commits.
+    if (guard.isComposing) {
       return;
     }
 
@@ -112,6 +124,8 @@ export function initialize(element, dotNetRef, instanceId, config) {
     callOnChange(element.value);
   };
 
+  const guard = createCompositionGuard(element, { onFlush: handleInput });
+
   element.addEventListener('input', handleInput);
   element.addEventListener('change', handleChange);
 
@@ -119,6 +133,7 @@ export function initialize(element, dotNetRef, instanceId, config) {
     state,
     handleInput,
     handleChange,
+    guard,
     element
   };
 
@@ -178,6 +193,7 @@ export function dispose(instanceId) {
 
   stored.element.removeEventListener('input', stored.handleInput);
   stored.element.removeEventListener('change', stored.handleChange);
+  stored.guard.dispose();
 
   if (stored.handleBlur) {
     stored.element.removeEventListener('blur', stored.handleBlur);


### PR DESCRIPTION
## Description

Fixes #414. The report is accurate and its suggested fix is sound, but the problem is considerably wider than `text-input.js` — it affects **11 components across 6 files**, and there is a **second bug class the issue doesn't mention**.

### Root cause

Nothing in the library tracked IME composition (the only guard anywhere was `input-otp.js:34`). Assigning `element.value` while an IME is mid-composition resets its composition buffer — **even when the assigned string is identical to what the element already holds**. Blazor's renderer assigns `element.value` whenever a bound field changes, and it diffs against the *previous render tree*, never reading the DOM. So any per-keystroke C# round-trip corrupts composition: typing `안녕` produces `ㅇ안안ㄴ녕`.

`OnChange`/`Debounced` escape it only because they make no interop call during active typing.

### Scope

Two distinct bug classes:

**1. Value write-back** — a per-keystroke field update re-renders and reassigns `element.value`.

| Site | Components |
|---|---|
| `text-input.js` | BbInput, BbTextarea, BbInputField, BbInputGroupInput/Textarea |
| `numeric-input.js` | BbNumericInput, BbCurrencyInput |
| `tag-input.js` | BbTagInput |
| `multiselect.js` + razor | BbMultiSelect, BbFormFieldMultiSelect |
| `BbCommandInput.razor` | BbCombobox, BbFormFieldCombobox, BbCommand |
| `BbMarkdownEditor` | BbMarkdownEditor |
| `BbMaskedInput` | BbMaskedInput, BbFormFieldMaskedInput |

`BbDatePickerInput` is **not** affected — it binds `@onchange`, not `@oninput`, so nothing updates per keystroke. `BbRichTextEditor` is **not** affected either: Blazor renders Quill's container with zero children, so the diff never touches the editing region, and `_lastKnownValue` already suppresses the write-back round-trip.

**2. Key hijacking (not in the issue)** — Enter commits a composition, and Space/Arrows drive the candidate list, but handlers bound to them fired while the IME still owned the keystroke. Fixing class 1 does *not* fix this.

- `BbCommandInput` — Enter-to-commit also **selected the focused item and closed the combobox**. This is the reporter's exact use case; they'd have hit it immediately.
- `multiselect.js` — worst of the set: capture-phase with an unconditional `preventDefault`, which **blocked the IME commit outright**. Space is the Japanese conversion key and toggled a checkbox instead.
- `tag-input.js` — Enter committed a half-composed tag. On by default (`Enter | Comma`).
- `markdown-editor.js` — list continuation on Enter. Chrome escapes by accident (reports `key: "Process"`); Firefox/Safari don't.

Also worth noting `MaskedInput` is not digits-only as it appears: `'A'` maps to `char.IsLetter` and `'*'` to `char.IsLetterOrDigit`, and CJK characters are Unicode category `Lo`, so `char.IsLetter` returns true. The shipped demos use `Mask="AAA-9999"` and `Mask="***-****"`. The digit-only presets are effectively immune.

### The fix

`isComposing` is unreachable from C# — `ChangeEventArgs` exposes only `Value`, `KeyboardEventArgs` has no `IsComposing`, and Blazor 8 ships no composition event mapping at all. Every guard must live in JS.

New `composition-guard.js` centralises both classes, with two entry points:

- **`onFlush`** — for modules that own their listeners (`text-input`, `numeric-input`): they check `guard.isComposing` and get re-run once on commit.
- **`suppress`** — for components whose handlers are Blazor's own (`@oninput`/`@onkeydown`/`@bind`): the guard stops the event at the element and re-dispatches one synthetic `input` on `compositionend`.

The `suppress` path rests on a verified fact about the Blazor runtime: it registers its **non-bubbling** event set (`change`, `blur`, `focus`, …) with `capture: true` on `document`, but `input` and `keydown` are **not** in that set and are listened for on the bubble phase. An element-level listener therefore runs first, and `stopPropagation()` cleanly prevents the delegated handler from firing. That's what keeps `BbCommandInput`, `BbMaskedInput` and `BbMarkdownEditor` from needing any C# handler restructuring or `dotNetRef` plumbing.

The underlying principle is mechanism-independent: **if the C# field doesn't change during composition, the diff emits no attribute edit, so no write-back happens.** `value="@Value"` stays as-is everywhere.

A `blur` reset keeps an interrupted composition (one where `compositionend` never arrives — a tab-switch is the usual way) from latching the guard and wedging the field permanently.

### Behaviour changes

- **`BbMaskedInput`** necessarily changes: masking *means* rewriting the field, so it is now deferred until the IME commits rather than applied per keystroke. Raw text sits unmasked mid-composition, then masks once on commit. ASCII typing is unchanged.
- **The workaround posted in #414 will stop working.** It reads a live value from a splatted native `@oninput`; the guard suppresses `input` during composition, so it no longer sees per-jamo updates. That's the intended outcome — per-jamo values were never meaningful — but it's a change for that consumer specifically.

### Bonus fix

`numeric-input.js` tested digits with `ch >= '0' && ch <= '9'`. Full-width digits (`１` = U+FF11) sort above `'9'`, so a Japanese IME in 全角 mode had **legitimate numeric input silently deleted keystroke by keystroke**. That reproduces without any composition at all. Now folded to ASCII before the test.

### Verification

Driven in Chrome against the demo app. Every IME case has a matching non-IME control; all pass.

| Test | Result |
|---|---|
| Composing 안 (`text-input.js`) | zero interop during composition; one `JsOnInput(안)` on commit |
| **Both** event orderings (`input` before vs. after `compositionend`) | one flush, correct value under either |
| Debounced mode, 500ms pause mid-composition | silent (IME users pause to read candidates) |
| `OnChange` mode / `dispose()` | unaffected / no calls after teardown |
| Interrupted composition (no `compositionend`) | recovers on blur, flushes rather than losing text; no double-flush |
| Full-width digits | `１２３` → `123`, `－１２．５` → `-12.5`; `12abc3` → `123` still stripped |
| BbCombobox | filter doesn't run while composing; **IME Enter no longer selects and closes**; plain typing/Arrow/Enter intact |
| BbTagInput | **IME Enter no longer commits a half-composed `안`**; comma/Backspace/Arrows released; real Enter still adds `안녕` |
| BbMultiSelect | **Space no longer swallowed**; Enter/Escape/Arrows released; plain Arrow/Space still focus and toggle |
| BbMarkdownEditor | IME Enter no longer continues a list; real Enter still does |
| BbMaskedInput `AAA-9999` | stays raw `ㅇ`/`아`/`안` while composing, masks once to `안__-____`; ASCII still masks per keystroke |

JS-only guard plus two small interop hookups — no public API change, so no snapshot churn and no new demo example. Build clean, 67/67 tests pass.

### Notes

- `input-otp.js` is left alone; its existing `event.isComposing` keydown guard is already correct.
- Not verified against a real hardware IME — composition sequences were simulated. Worth a sanity check with the Microsoft Korean IME before release, and @AJ-comp has offered to test a prerelease build.