### PR TITLE
fix(deps): resolve AngleSharp vulnerability (GHSA-pgww-w46g-26qg)

### DIFF
--- a/src/BlazorBlueprint.Components/BlazorBlueprint.Components.csproj
+++ b/src/BlazorBlueprint.Components/BlazorBlueprint.Components.csproj
@@ -31,7 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
+    <!-- 9.1.x-beta is used because the 9.0.x stable line hard-pins AngleSharp to the
+         vulnerable 0.17.1 (GHSA-pgww-w46g-26qg). The 9.1 beta pins AngleSharp 1.5.1,
+         which carries the fix. The Sanitize API is unchanged between the two. -->
+    <PackageReference Include="HtmlSanitizer" Version="9.1.949-beta" />
     <PackageReference Include="TailwindMerge.NET" Version="1.3.0" />
     <PackageReference Include="Markdig" Version="0.37.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.14" />


### PR DESCRIPTION
Our assemblies that reference `BlazorBlueprint.Components` have recently begun to fail to build due to a vulnerability in one of the transitive nuget packages.

HtmlSanitizer 9.0.892 hard-pins AngleSharp to exactly [0.17.1], which nuget audit flags as vulnerable (GHSA-pgww-w46g-26qg, Moderate). The exact pin means the transitive AngleSharp cannot be overridden with a direct PackageReference.

Bump HtmlSanitizer to 9.1.949-beta, whose dependency chain pins AngleSharp 1.5.1 (past the 1.0.0 fix). The Sanitize API used by `BbRichTextEditor` and `BbMarkdownEditor` is unchanged.

## Description

<!-- Briefly describe the changes in this PR. -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [ ] Blazor Server
- [ ] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility
- [ ] Dark mode
