### PR TITLE
feat(datagrid): add HeaderTemplate to BbDataGridPropertyColumn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-07-21
+
+### Added
+
+- **BbDataGridPropertyColumn: `HeaderTemplate`** — The property column explicitly returned `null` for the column interface's header-template slot, so its header was locked to plain text from `Title` (or the name inferred from `Property`). Wanting an icon in the header — or any markup at all — meant abandoning the property column for a `BbDataGridTemplateColumn` and hand-rolling `SortBy`, `FilterBy` and the cell rendering that the property expression had been providing for free. `HeaderTemplate` now fills that slot. It replaces the **title text only**, not the whole header cell: the grid keeps rendering the sort indicator, filter icon, pin icon, `Groupable` ellipsis menu and resize handle around the supplied content, so a `Sortable`/`Groupable` column with an icon header still sorts on click, still shows its arrow and priority badge, and still offers "Group by" with nothing extra from the consumer. The parameter matches `BbDataGridTemplateColumn.HeaderTemplate` in both shape (`RenderFragment`) and behaviour, so the two column types stay consistent. For icon-only headers, keep `Title` set — the column chooser and the column menu's labels read from it — and include screen-reader text in the template, since the `<th>` carries no `aria-label` and is announced from its own content. ([#423](https://github.com/blazorblueprintui/ui/issues/423))
+
+---
+
 ## 2026-07-20
 
 ### Fixed

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/property-column-header-template.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/property-column-header-template.txt
@@ -1,0 +1,37 @@
+<BbDataGrid TData="Person" Items="@people" InitialPageSize="5">
+    <Columns>
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable>
+            <HeaderTemplate>
+                <div class="flex items-center gap-1.5">
+                    <LucideIcon Name="user" Class="h-4 w-4 text-muted-foreground" />
+                    <span>Name</span>
+                </div>
+            </HeaderTemplate>
+        </BbDataGridPropertyColumn>
+        @* Sorting and the Groupable ellipsis menu are still rendered by the grid *@
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable Groupable>
+            <HeaderTemplate>
+                <div class="flex items-center gap-1.5">
+                    <LucideIcon Name="building-2" Class="h-4 w-4 text-muted-foreground" />
+                    <span>Department</span>
+                </div>
+            </HeaderTemplate>
+        </BbDataGridPropertyColumn>
+        @* Icon-only header — keep Title set for the column chooser, sr-only text for screen readers *@
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Email)" Title="Email" Width="220px">
+            <HeaderTemplate>
+                <LucideIcon Name="mail" Class="h-4 w-4 text-muted-foreground" />
+                <span class="sr-only">Email</span>
+            </HeaderTemplate>
+        </BbDataGridPropertyColumn>
+        <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" Sortable
+            CellClass="font-mono tabular-nums">
+            <HeaderTemplate>
+                <div class="flex items-center gap-1.5">
+                    <LucideIcon Name="banknote" Class="h-4 w-4 text-muted-foreground" />
+                    <span>Salary</span>
+                </div>
+            </HeaderTemplate>
+        </BbDataGridPropertyColumn>
+    </Columns>
+</BbDataGrid>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
@@ -1097,6 +1097,9 @@
                 <ApiParameter Name="CellTemplate" Type="RenderFragment&lt;TData&gt;?">
                     Custom template for rendering the cell content. Overrides the default value display.
                 </ApiParameter>
+                <ApiParameter Name="HeaderTemplate" Type="RenderFragment?">
+                    Custom header content, e.g. an icon next to (or instead of) the title. It replaces the title text only — the grid still renders the sort indicator, filter icon, pin icon, column menu and resize handle around it, so Sortable and Groupable columns keep every affordance. Keep Title set for icon-only headers, since the column chooser and column menu use it, and include sr-only text in the template — the header cell is announced from its own content.
+                </ApiParameter>
                 <ApiParameter Name="CellClass" Type="string?">
                     Additional CSS classes applied to cells in this column.
                 </ApiParameter>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridStylingDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridStylingDemo.razor
@@ -96,6 +96,60 @@
         <CodeBlock Source="Components/DataGrid/header-template.txt" />
     </div>
 
+    <!-- ── Property Column Header Template ─────────────────────────── -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Property Column Header Template</h2>
+            <p class="text-sm text-muted-foreground">
+                <code class="bg-muted px-1 py-0.5 rounded">BbDataGridPropertyColumn</code> also accepts a
+                <code class="bg-muted px-1 py-0.5 rounded">HeaderTemplate</code>, so you can put an icon or richer
+                markup in the header without giving up type-safe binding. The template replaces the title
+                <em>text only</em> — the grid keeps rendering its own sort indicator, filter icon and column menu
+                around it, so the Department column below still sorts and still offers "Group by". Keep
+                <code class="bg-muted px-1 py-0.5 rounded">Title</code> meaningful for icon-only headers — it is what
+                the column chooser and the column menu display — and add
+                <code class="bg-muted px-1 py-0.5 rounded">sr-only</code> text inside the template, since the header
+                cell is announced from its own content.
+            </p>
+        </div>
+        <BbDataGrid TData="Person" Items="@people" InitialPageSize="5">
+            <Columns>
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable>
+                    <HeaderTemplate>
+                        <div class="flex items-center gap-1.5">
+                            <LucideIcon Name="user" Class="h-4 w-4 text-muted-foreground" />
+                            <span>Name</span>
+                        </div>
+                    </HeaderTemplate>
+                </BbDataGridPropertyColumn>
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable Groupable>
+                    <HeaderTemplate>
+                        <div class="flex items-center gap-1.5">
+                            <LucideIcon Name="building-2" Class="h-4 w-4 text-muted-foreground" />
+                            <span>Department</span>
+                        </div>
+                    </HeaderTemplate>
+                </BbDataGridPropertyColumn>
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Email)" Title="Email" Width="220px">
+                    <HeaderTemplate>
+                        <LucideIcon Name="mail" Class="h-4 w-4 text-muted-foreground" />
+                        <span class="sr-only">Email</span>
+                    </HeaderTemplate>
+                </BbDataGridPropertyColumn>
+                <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" Sortable
+                    CellClass="font-mono tabular-nums">
+                    <HeaderTemplate>
+                        <div class="flex items-center gap-1.5">
+                            <LucideIcon Name="banknote" Class="h-4 w-4 text-muted-foreground" />
+                            <span>Salary</span>
+                        </div>
+                    </HeaderTemplate>
+                </BbDataGridPropertyColumn>
+            </Columns>
+        </BbDataGrid>
+        <CodeBlock Source="Components/DataGrid/property-column-header-template.txt" />
+    </div>
+
     <!-- ── Row & Column Styling ──────────────────────────────────── -->
     <div class="space-y-4">
         <div class="space-y-2">

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridPropertyColumn.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridPropertyColumn.razor.cs
@@ -165,6 +165,19 @@ public partial class BbDataGridPropertyColumn<TData, TProp> : ComponentBase, IDa
     public RenderFragment<TData>? CellTemplate { get; set; }
 
     /// <summary>
+    /// Custom header content. If provided, replaces the header title text only — the grid
+    /// still renders its own sort indicator, filter icon, pin icon, column menu and resize
+    /// handle around it, so a <see cref="Sortable"/> or <see cref="Groupable"/> column keeps
+    /// every affordance. Use it to show an icon or richer markup instead of
+    /// <see cref="Title"/>. Set <see cref="Title"/> as well when the content is icon-only, so
+    /// the column chooser and the column menu still have readable text, and include screen-reader
+    /// text (e.g. a <c>sr-only</c> span) in the template — the header cell is announced from its
+    /// own content.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? HeaderTemplate { get; set; }
+
+    /// <summary>
     /// The parent DataGrid component. Set via cascading parameter.
     /// </summary>
     [CascadingParameter]
@@ -199,7 +212,10 @@ public partial class BbDataGridPropertyColumn<TData, TProp> : ComponentBase, IDa
             ? context => CellTemplate(context.Item)
             : null;
 
-    RenderFragment<DataGridHeaderContext<TData>>? IDataGridColumn<TData>.HeaderTemplate => null;
+    RenderFragment<DataGridHeaderContext<TData>>? IDataGridColumn<TData>.HeaderTemplate =>
+        HeaderTemplate != null
+            ? _ => HeaderTemplate
+            : null;
 
     string? IDataGridColumn<TData>.CellClass => CellClass;
 

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -860,6 +860,7 @@
   - Format : String
   - Groupable : Boolean
   - HeaderClass : String
+  - HeaderTemplate : RenderFragment
   - Hideable : Boolean
   - Id : String
   - NoWrap : Boolean


### PR DESCRIPTION
Addresses #423.

## What

Adds a `HeaderTemplate` parameter to `BbDataGridPropertyColumn<TData, TProp>`, so a property column can render custom header content (an icon, say) without dropping to a `BbDataGridTemplateColumn` and losing property-driven sorting, filtering and title inference.

The plumbing already existed end to end: `IDataGridColumn<TData>` has a `HeaderTemplate` slot, the grid already renders it, and `BbDataGridTemplateColumn` already wires it. `BbDataGridPropertyColumn` was explicitly opting out with `HeaderTemplate => null`, despite already supporting `CellTemplate`. This is a pure wire-through of the existing mechanism.

## Design decision

The template replaces **the title text only**, not the whole header cell. The grid continues to render the sort indicator, filter popover, group menu, pin icon and resize handle as siblings around it — so a `Sortable`/`Groupable` column with a custom header still sorts and still shows its affordances, with no work from the consumer.

This required no grid changes: `BbDataGrid.razor` already renders `column.HeaderTemplate` into exactly the `<span>@column.Title</span>` slot.

## Verified

On the live interactive circuit (not just prerendered HTML):

- Custom icon headers render.
- A `Sortable` column with a `HeaderTemplate` still sorts on click, renders its arrow *inside* the header alongside the custom content, and reports `aria-sort="ascending"`.
- A `Groupable` column still shows its ellipsis menu, and grouping still applies.
- Browser console clean.

Build 0 warnings / 0 errors. Tests 67/67. API surface diff was exactly one line (`+ HeaderTemplate : RenderFragment`), reviewed and accepted.

## Accessibility note (pre-existing, not introduced here)

The header `<th>` sets only `aria-sort`; it has no `aria-label`, so its accessible name comes from its text content, and `Title` is not a fallback. An **icon-only** `HeaderTemplate` therefore yields an unlabelled column for screen readers unless the consumer supplies `sr-only` text.

That is documented in the parameter docs, the demo prose and the snippet, and the demo demonstrates the `sr-only` pattern. A proper fix — the grid falling back to `aria-label="@Title"` when a template is supplied — touches Primitives and was left out of scope. Worth a follow-up issue.

## Demo placement

The live example and `CodeBlock` went on `DataGridStylingDemo.razor`, beside the existing `TemplateColumn` header-template example, rather than `DataGridDemo.razor`. The API Reference entry went on `DataGridDemo.razor`, the only page carrying the `DataGridPropertyColumn` `ApiReference` block.

## Merge note

Conflicts with the other two open branches only in `CHANGELOG.md`, where all three add a `## 2026-07-21` heading. No code conflicts — verified by test-merging all three: the combined tree builds clean and passes 67/67.
