### PR TITLE
fix(ColorPicker): fails for locales using a comma as a decimal separator (e.g., FR, DE, ES, PT)

### DIFF
--- a/src/BlazorBlueprint.Components/Components/ColorPicker/BbColorPicker.razor
+++ b/src/BlazorBlueprint.Components/Components/ColorPicker/BbColorPicker.razor
@@ -22,7 +22,7 @@
             @* Color Area (Saturation/Brightness) *@
             <div @ref="_areaRef"
                  class="relative h-[150px] w-full rounded-md cursor-crosshair overflow-hidden touch-none"
-                 style="background: linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, hsl(@_hue.ToString(CultureInfo.InvariantCulture), 100%, 50%));">
+                 style="background: linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, hsl(@_hue.ToString("0.##", CultureInfo.InvariantCulture), 100%, 50%));">
                 <div class="absolute h-4 w-4 border-2 border-white rounded-full shadow-md -translate-x-1/2 -translate-y-1/2 pointer-events-none"
                      style="left: @((_saturation * 100).ToString("0.##", CultureInfo.InvariantCulture))%; top: @(((1 - _brightness) * 100).ToString("0.##", CultureInfo.InvariantCulture))%;">
                 </div>

--- a/src/BlazorBlueprint.Components/Components/ColorPicker/BbColorPicker.razor
+++ b/src/BlazorBlueprint.Components/Components/ColorPicker/BbColorPicker.razor
@@ -1,6 +1,7 @@
 @namespace BlazorBlueprint.Components
 @using Microsoft.AspNetCore.Components.Forms
 @using System.Linq.Expressions
+@using System.Globalization
 @inject IJSRuntime JS
 @implements IAsyncDisposable
 
@@ -21,9 +22,9 @@
             @* Color Area (Saturation/Brightness) *@
             <div @ref="_areaRef"
                  class="relative h-[150px] w-full rounded-md cursor-crosshair overflow-hidden touch-none"
-                 style="background: linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, hsl(@_hue, 100%, 50%));">
+                 style="background: linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, hsl(@_hue.ToString(CultureInfo.InvariantCulture), 100%, 50%));">
                 <div class="absolute h-4 w-4 border-2 border-white rounded-full shadow-md -translate-x-1/2 -translate-y-1/2 pointer-events-none"
-                     style="left: @(_saturation * 100)%; top: @((1 - _brightness) * 100)%;">
+                     style="left: @((_saturation * 100).ToString("0.##", CultureInfo.InvariantCulture))%; top: @(((1 - _brightness) * 100).ToString("0.##", CultureInfo.InvariantCulture))%;">
                 </div>
             </div>
 
@@ -33,7 +34,7 @@
                      class="relative h-3 w-full rounded-md cursor-pointer touch-none"
                      style="background: linear-gradient(to right, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%);">
                     <div class="absolute top-1/2 h-5 w-2 bg-white border border-input rounded shadow-sm -translate-x-1/2 -translate-y-1/2 pointer-events-none"
-                         style="left: @(_hue / 360 * 100)%;">
+                         style="left: @((_hue / 360 * 100).ToString("0.##", CultureInfo.InvariantCulture))%;">
                     </div>
                 </div>
             </div>
@@ -46,7 +47,7 @@
                          class="relative h-3 w-full rounded-md cursor-pointer touch-none"
                          style="background: linear-gradient(to right, transparent, @CurrentColorWithoutAlpha), url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2216%22 height=%2216%22 fill-opacity=%22.1%22><rect x=%220%22 y=%220%22 width=%228%22 height=%228%22 fill=%22%23000%22/><rect x=%228%22 y=%228%22 width=%228%22 height=%228%22 fill=%22%23000%22/></svg>');">
                         <div class="absolute top-1/2 h-5 w-2 bg-white border border-input rounded shadow-sm -translate-x-1/2 -translate-y-1/2 pointer-events-none"
-                             style="left: @(_alpha * 100)%;">
+                             style="left: @((_alpha * 100).ToString("0.##", CultureInfo.InvariantCulture))%;">
                         </div>
                     </div>
                 </div>

--- a/src/BlazorBlueprint.Components/Components/ColorPicker/ColorUtils.cs
+++ b/src/BlazorBlueprint.Components/Components/ColorPicker/ColorUtils.cs
@@ -235,7 +235,7 @@ public static partial class ColorUtils
     {
         if (a.HasValue && a.Value < 255)
         {
-            return $"rgba({r}, {g}, {b}, {a.Value / 255.0:F2})";
+            return $"rgba({r}, {g}, {b}, {(a.Value / 255.0).ToString("F2", CultureInfo.InvariantCulture)})";
         }
         return $"rgb({r}, {g}, {b})";
     }
@@ -247,7 +247,7 @@ public static partial class ColorUtils
     {
         if (a.HasValue && a.Value < 255)
         {
-            return $"hsla({h:F0}, {s * 100:F0}%, {l * 100:F0}%, {a.Value / 255.0:F2})";
+            return $"hsla({h:F0}, {s * 100:F0}%, {l * 100:F0}%, {(a.Value / 255.0).ToString("F2", CultureInfo.InvariantCulture)})";
         }
         return $"hsl({h:F0}, {s * 100:F0}%, {l * 100:F0}%)";
     }

--- a/src/BlazorBlueprint.Components/Components/ColorPicker/ColorUtils.cs
+++ b/src/BlazorBlueprint.Components/Components/ColorPicker/ColorUtils.cs
@@ -245,10 +245,14 @@ public static partial class ColorUtils
     /// </summary>
     public static string ToHslString(double h, double s, double l, int? a = null)
     {
+        var hue = h.ToString("F0", CultureInfo.InvariantCulture);
+        var sat = (s * 100).ToString("F0", CultureInfo.InvariantCulture);
+        var lum = (l * 100).ToString("F0", CultureInfo.InvariantCulture);
+
         if (a.HasValue && a.Value < 255)
         {
-            return $"hsla({h:F0}, {s * 100:F0}%, {l * 100:F0}%, {(a.Value / 255.0).ToString("F2", CultureInfo.InvariantCulture)})";
+            return $"hsla({hue}, {sat}%, {lum}%, {(a.Value / 255.0).ToString("F2", CultureInfo.InvariantCulture)})";
         }
-        return $"hsl({h:F0}, {s * 100:F0}%, {l * 100:F0}%)";
+        return $"hsl({hue}, {sat}%, {lum}%)";
     }
 }


### PR DESCRIPTION
## Description

<img width="400" height="256" alt="ColorPicker" src="https://github.com/user-attachments/assets/b9c47a45-c87b-4b42-b7af-9325597c22b7" />

The ColorPicker was putting locale-formatted numbers directly into CSS style strings.
In locales that use a comma as decimal separator (like French fr-FR), this produces  invalid CSS like hsl(200, 100%, 50,5%) instead of hsl(200, 100%, 50.5%), breaking the  color area and sliders.

This change forces InvariantCulture everywhere we format a number for inline styles or color strings (rgb(...), hsl(...)), so it always uses a dot as decimal separator  regardless of the user's locale.

 Covers the saturation/brightness positioning, hue slider, alpha slider, and the ColorUtils helpers.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [X] Blazor Server
- [X] Blazor WebAssembly
- [X] Blazor Hybrid (MAUI)
- [X] Keyboard navigation / accessibility
- [X] Dark mode

## Related Issues

N/A
