### PR TITLE
fix(RangeSlider): tick marks collapse to the left edge in comma-decimal locales

### DIFF
--- a/src/BlazorBlueprint.Components/Components/RangeSlider/BbRangeSlider.razor
+++ b/src/BlazorBlueprint.Components/Components/RangeSlider/BbRangeSlider.razor
@@ -60,7 +60,7 @@
         {
             var tickPercent = ((tick - Min) / (Max - Min)) * 100;
             <div class="absolute top-4 w-0.5 h-2 bg-muted-foreground/30"
-                 style="left: @(tickPercent)%; transform: translateX(-50%);">
+                 style="left: @(tickPercent.ToString("0.##", CultureInfo.InvariantCulture))%; transform: translateX(-50%);">
             </div>
         }
     }
@@ -184,9 +184,9 @@
     private double StartPercentage => ((StartValue - Min) / (Max - Min)) * 100;
     private double EndPercentage => ((EndValue - Min) / (Max - Min)) * 100;
 
-    private string StartPercentageValue => $"{StartPercentage.ToString(CultureInfo.InvariantCulture)}%";
-    private string EndPercentageValue => $"{EndPercentage.ToString(CultureInfo.InvariantCulture)}%";
-    private string RangePercentageValue => $"{(EndPercentage - StartPercentage).ToString(CultureInfo.InvariantCulture)}%";
+    private string StartPercentageValue => $"{StartPercentage.ToString("0.##", CultureInfo.InvariantCulture)}%";
+    private string EndPercentageValue => $"{EndPercentage.ToString("0.##", CultureInfo.InvariantCulture)}%";
+    private string RangePercentageValue => $"{(EndPercentage - StartPercentage).ToString("0.##", CultureInfo.InvariantCulture)}%";
 
     protected override void OnInitialized()
     {


### PR DESCRIPTION
## Description

Fixes #443.

`BbRangeSlider` interpolated a raw `double` into an inline `style` attribute for tick marks, so the percentage was formatted with the **current** culture. Under fr-FR/de-DE/es-ES/pt-BR this emitted invalid CSS and every tick collapsed to the left edge of the track.

```diff
- style="left: @(tickPercent)%; transform: translateX(-50%);"
+ style="left: @(tickPercent.ToString("0.##", CultureInfo.InvariantCulture))%; transform: translateX(-50%);"
```

Verified under `fr-FR`:

```
before:  left: 0%   left: 33,333333%   left: 50%   left: 66,666666%   left: 100%
after:   left: 0%   left: 33.33%       left: 50%   left: 66.67%       left: 100%
```

Same class of bug as #436 (ColorPicker), found while reviewing it. `@using System.Globalization` was already present in the file.

### Also included

`StartPercentageValue`/`EndPercentageValue`/`RangePercentageValue` were already invariant but used the default `"G"` format, which switches to scientific notation below 1e-5. A thumb just above `Min` on a large range rendered `left: 1E-07%` — also invalid CSS:

```
G     : left: 1.0000000000000001E-07%
0.##  : left: 0%
```

Switched all three to `"0.##"`, matching the fix applied to `_hue` in #436. Note this shortens the rendered value (`33.333333333333336%` → `33.33%`); sub-pixel difference, no visual change.

### Not included

`BbSliderRange.razor:32` and `BbSliderThumb.razor:47` in Primitives use the same `ToString(CultureInfo.InvariantCulture)` G-format pattern. They have no locale bug, only the same theoretical scientific-notation edge case — left alone to keep this PR scoped to #443. Happy to fold them in if preferred.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [X] Builds clean (0 warnings, `TreatWarningsAsErrors`)
- [X] Formatting verified under `fr-FR` (output above)
- [ ] No automated regression test — see note below

No public API change, so no API-surface snapshot update and no demo example needed.

**Test gap:** there is still no regression test for either this or #436. `tests/BlazorBlueprint.Tests/Utilities/` already holds behavioural tests, so a small suite pinning `CultureInfo.CurrentCulture` to `fr-FR` would cover both components and prevent this class of bug recurring. Worth a separate issue.

## Related Issues

#443