### PR TITLE
docs: trim CLAUDE.md to what a session can't derive from the codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,20 +18,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build & Test Commands
 
 ```bash
-# Build the Components project (most common during development)
-dotnet build src/BlazorBlueprint.Components/BlazorBlueprint.Components.csproj --nologo --verbosity quiet
-
-# Build entire solution
-dotnet build
-
-# Run tests (xunit + Verify snapshot tests)
-dotnet test tests/BlazorBlueprint.Tests/BlazorBlueprint.Tests.csproj --verbosity normal
-
 # Accept new API surface snapshots after reviewing .received.txt files
 # (copy .received.txt → .verified.txt in tests/BlazorBlueprint.Tests/ApiSurface/)
 ./scripts/run-tests.sh --accept
 
-# Run demo apps
+# Demo apps — each host is pinned to its own port
 dotnet run --project demos/BlazorBlueprint.Demo.Server    # port 7172
 dotnet run --project demos/BlazorBlueprint.Demo.Wasm      # port 7173
 dotnet run --project demos/BlazorBlueprint.Demo.Auto       # port 7174
@@ -43,38 +34,13 @@ dotnet run --project demos/BlazorBlueprint.Demo.Auto       # port 7174
 
 ## Architecture
 
-**Two-layer component library** inspired by shadcn/ui and Radix UI, targeting .NET 8 Blazor (Server, WASM, and Auto render modes):
-
-### Projects
-
-| Project | Purpose |
-|---------|---------|
-| `BlazorBlueprint.Primitives` | Headless, unstyled components with accessibility/keyboard/ARIA. No CSS. |
-| `BlazorBlueprint.Components` | Styled components built on Primitives. Ships pre-built Tailwind CSS. |
-| `BlazorBlueprint.Icons.*` | Three icon packages: Lucide, Heroicons, Feather |
-| `BlazorBlueprint.Demo.Shared` | Shared demo pages/layouts (Razor Class Library) |
-| `BlazorBlueprint.Demo.Server/Wasm/Auto` | Thin host projects per render mode |
-| `BlazorBlueprint.Tests` | API surface snapshot tests (Verify + xunit) |
+**Two-layer component library** inspired by shadcn/ui and Radix UI, targeting .NET 8 Blazor (Server, WASM, and Auto render modes): `Primitives` are headless and unstyled, `Components` are styled and built on top of them.
 
 ### Dependency flow
 `Components` → `Primitives` + `Icons.Lucide` (ProjectReference locally, PackageReference when packing for NuGet).
 
 ### Component structure
-Each component lives in its own folder under `Components/` or `Primitives/` with:
-- `ComponentName.razor` — markup
-- `ComponentName.razor.cs` — code-behind (partial class)
-- Enum/type files (e.g., `ButtonVariant.cs`, `ButtonSize.cs`)
-
 Components inherit directly from `ComponentBase` (no custom base class). Text inputs (`Input`, `Textarea`, `InputGroupInput`, `InputGroupTextarea`) implement their own `Value`/`ValueChanged` pattern rather than `InputBase<T>`.
-
-### JS Interop
-- Primitives JS: `src/BlazorBlueprint.Primitives/wwwroot/js/primitives/` (focus, positioning, portal, scroll-lock, keyboard shortcuts, resize, dismiss)
-- Components JS: `src/BlazorBlueprint.Components/wwwroot/js/` (file-upload, slider, resizable, sidebar, etc.)
-
-### Services (registered via DI)
-- `AddBlazorBlueprintComponents()` — registers everything (Components + Primitives)
-- `AddBlazorBlueprintPrimitives()` — registers only Primitives services
-- Key services: `IPortalService`, `IFocusManager`, `IPositioningService`, `DropdownManagerService`, `IKeyboardShortcutService`, `ToastService`
 
 ### Overlay pattern
 Overlay components (Dialog, Sheet, Popover, Tooltip, etc.) render through `<PortalHost />` which must be placed in the root layout. Uses `IPortalService` + `FloatingPortal` + `IPositioningService` for positioning.
@@ -91,28 +57,8 @@ Tests use **Verify** (snapshot testing) to detect unintended public API changes.
 
 ---
 
-## Code Style (enforced at build — TreatWarningsAsErrors)
+## Code Style
 
-- **Braces required** on all control flow (IDE0011 enforced as error)
-- **Private fields**: `camelCase` (no underscore prefix)
-- **Public members/types**: `PascalCase`
-- **Constants**: `PascalCase`
-- **Interfaces**: `I` prefix
-- **Nullable reference types** enabled with null diagnostics as errors (CS8600-CS8625)
-- Prefer `var` when type is apparent
-- Allman-style braces (new line before `{`)
-- Indent: 4 spaces for `.cs`/`.razor`, 2 spaces for `.csproj`/`.json`/`.js`/`.css`/`.yml`
+Style is enforced mechanically by `.editorconfig` + `TreatWarningsAsErrors` — the build is the source of truth, so it isn't restated here. The one convention the config does *not* enforce:
 
----
-
-## Versioning
-
-Uses **MinVer** with git tags. Tag prefixes:
-- Components: `components/v` (e.g., `components/v3.0.0`)
-- Primitives: `primitives/v` (e.g., `primitives/v2.3.2`)
-
----
-
-## Current Branch: v3
-
-Active development branch for v3 with breaking changes. See `V3-MIGRATION-GUIDE.md` for details. Key v3 changes: namespace flattening, Combobox/MultiSelect API redesign, trigger `AsChild` defaults, and new usability parameters across components.
+- **Private fields**: `camelCase` with **no underscore prefix** (deliberately unlike the common C# `_camelCase` default)


### PR DESCRIPTION
## Description

`CLAUDE.md` loads into context on every session in this repo, so anything a session could reconstruct on its own with a few tool calls is dead weight it pays for every time. This removes that content and keeps what the codebase can't teach.

**5,424 → 3,093 chars** (~580 est. tokens saved per session).

### Removed — derivable from the repo

| Cut | Reconstructible from |
|---|---|
| Projects table (12 lines) | `ls src/ demos/ tests/` + the `.csproj` files |
| JS interop paths (3 lines) | `ls` |
| DI service list (4 lines) | grep the registration extension |
| Versioning section (5 lines) | `MinVerTagPrefix` in each `.csproj` — and the list was **incomplete**, naming only Components and Primitives while omitting the three icon packages |
| Most of Code Style (10 of 12 lines) | `.editorconfig` + `Directory.Build.props` enforce all of it as **build errors**: `csharp_prefer_braces` (138) with `TreatWarningsAsErrors`, naming rules (52–86), `indent_size` (10–32), `csharp_new_line_before_open_brace` (141), `CS8600–CS8625` (104–110), `csharp_style_var_*` (115–117) |
| Three `dotnet build`/`test` invocations | standard for the tool |
| **"Current Branch: v3"** | **stale** — the branch is `develop` and `feat: BlazorBlueprint v3` is already in history, so this was actively telling every session something false |

### Kept — not derivable

Every "Important Rules" bullet; `./scripts/run-tests.sh --accept` and the snapshot review workflow; Tailwind building during `dotnet build`; the demo host → port mapping; `ProjectReference` locally / `PackageReference` when packing; `ComponentBase` with no custom base class; text inputs implementing their own `Value`/`ValueChanged` rather than `InputBase<T>`; `PortalHost` in the root layout.

And the private-field rule — kept **because** `.editorconfig` does not enforce it (no `required_prefix` for private fields) and it differs from the common C# `_camelCase` default, so the config alone would teach the wrong pattern. That's exactly the kind of line worth its context cost.

### Verified before cutting

Every retained claim re-checked against the current tree: `run-tests.sh --accept` exists and works, ports 7172/7173/7174 match `launchSettings.json`, `TreatWarningsAsErrors` is set, and `.editorconfig` has no private-field naming rule. `V3-MIGRATION-GUIDE.md` is untouched — it just isn't described in `CLAUDE.md` any more.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

No code change — `CLAUDE.md` only. Nothing to build or test.

## Related Issues

None.