### PR TITLE
test: add convention guards for culture-invariant styles and focus indicators

### DIFF
--- a/tests/BlazorBlueprint.Tests/Conventions/CultureInvariantStyleTests.cs
+++ b/tests/BlazorBlueprint.Tests/Conventions/CultureInvariantStyleTests.cs
@@ -1,0 +1,96 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace BlazorBlueprint.Tests.Conventions;
+
+/// <summary>
+/// Guards against numeric values reaching an inline <c>style</c> attribute through the current
+/// culture.
+/// <para>
+/// Razor renders a bare <c>@someDouble</c> with <see cref="System.Globalization.CultureInfo.CurrentCulture"/>,
+/// so in a locale that writes decimals with a comma the markup becomes <c>left: 33,33%</c>. That is
+/// a CSS syntax error, and the browser drops the whole declaration silently — no exception, no
+/// console warning, just an element that does not move.
+/// </para>
+/// <para>
+/// This has shipped twice: <c>BbColorPicker</c> (#436) and <c>BbRangeSlider</c> (#443), a fortnight
+/// apart. The second was found only by sweeping the tree by hand after fixing the first, which is
+/// precisely the kind of check worth automating.
+/// </para>
+/// </summary>
+public class CultureInvariantStyleTests
+{
+    /// <summary>
+    /// An interpolation sitting immediately before a CSS unit — <c>@(x * 100)%</c>, <c>@Foo px</c>.
+    /// The unit must not be followed by a word character, or <c>@ItemContainerStyle</c> matches as
+    /// <c>@It</c> + the <c>em</c> unit.
+    /// </summary>
+    private const string Unit = @"(?:%|px|deg|em|rem|vh|vw|fr)(?![\w-])";
+
+    private static readonly Regex Interpolation = new(
+        @"@\((?<expr>[^()]*(?:\([^()]*\)[^()]*)*)\)" + Unit + @"|@(?<expr2>[A-Za-z_][\w.]*)" + Unit,
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void NumericValuesInStyleAttributesAreCultureInvariant()
+    {
+        var violations = new List<string>();
+
+        foreach (var file in SourceTree.ComponentSources.Where(f => f.Extension == ".razor"))
+        {
+            var lines = File.ReadAllLines(file.FullName);
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                // Only inline styles matter. The same value in a class attribute or as text content
+                // is not parsed as CSS, so a comma there is harmless.
+                if (!lines[i].Contains("style=", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                foreach (Match match in Interpolation.Matches(lines[i]))
+                {
+                    var expression = match.Groups["expr"].Success
+                        ? match.Groups["expr"].Value
+                        : match.Groups["expr2"].Value;
+
+                    if (expression.Contains("InvariantCulture", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    violations.Add(
+                        $"{SourceTree.RelativePath(file)}:{i + 1}  ->  @{expression.Trim()}");
+                }
+            }
+        }
+
+        Assert.True(violations.Count == 0, BuildMessage(violations));
+    }
+
+    private static string BuildMessage(IReadOnlyCollection<string> violations)
+    {
+        var message = new StringBuilder()
+            .AppendLine(CultureInfo.InvariantCulture,
+                $"{violations.Count} numeric value(s) reach an inline style through the current culture.")
+            .AppendLine()
+            .AppendLine("Razor renders a bare @value with CurrentCulture, so a comma-decimal locale")
+            .AppendLine("produces invalid CSS (left: 33,33%) which the browser discards in silence.")
+            .AppendLine()
+            .AppendLine("Format through InvariantCulture instead:")
+            .AppendLine("  style=\"left: @(pct.ToString(\"0.##\", CultureInfo.InvariantCulture))%\"")
+            .AppendLine()
+            .AppendLine("Prefer \"0.##\" over the default \"G\" format: G switches to scientific")
+            .AppendLine("notation below 1e-5, which is invalid CSS by a different route.")
+            .AppendLine();
+
+        foreach (var violation in violations)
+        {
+            message.AppendLine("  " + violation);
+        }
+
+        return message.ToString();
+    }
+}

--- a/tests/BlazorBlueprint.Tests/Conventions/FocusIndicatorTests.cs
+++ b/tests/BlazorBlueprint.Tests/Conventions/FocusIndicatorTests.cs
@@ -1,0 +1,145 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace BlazorBlueprint.Tests.Conventions;
+
+/// <summary>
+/// Guards against a component removing the browser's focus outline without drawing a replacement.
+/// <para>
+/// <c>outline-none</c> suppresses the user agent's focus ring. Without something in its place a
+/// focused control is indistinguishable from an unfocused one, which fails
+/// <see href="https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html">WCAG 2.4.7</see>.
+/// The whole text-input family shipped that way until #457 — reported in discussion #355, where
+/// three people said it decided a library choice against this one.
+/// </para>
+/// <para>
+/// The rule deliberately accepts any recognised affordance, not just a ring: menu items indicate
+/// focus with a background change, which is the correct pattern for a roving-focus list.
+/// </para>
+/// </summary>
+public class FocusIndicatorTests
+{
+    private static readonly Regex RemovesOutline =
+        new(@"(?:focus(?:-visible)?:)?outline-none", RegexOptions.Compiled);
+
+    /// <summary>
+    /// A ring, a ring-coloured border, or a background/text change on focus or on the
+    /// highlighted/selected state of a list item.
+    /// </summary>
+    private static readonly Regex HasIndicator = new(
+        @"focus(?:-visible|-within)?:(?:ring-[1-9]|border-ring|bg-|text-)"
+        + @"|data-\[(?:focused|highlighted)[^\]]*\]:(?:bg-|text-|ring-)",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Options in a listbox drive their own selected styling, so <c>aria-selected</c> is itself
+    /// evidence of an affordance.
+    /// </summary>
+    private static readonly Regex ManagesSelection =
+        new(@"aria-selected|data-\[state=selected\]", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Overlay panels are focused programmatically when they open. A ring drawn round the whole
+    /// panel on every open would be wrong, so <c>outline-none</c> is correct for these by suffix.
+    /// </summary>
+    private static readonly string[] ContainerSuffixes =
+        ["Content", "Overlay", "Portal", "Provider", "Host"];
+
+    /// <summary>
+    /// Components exempted by name, each for a stated reason. Keep this list short — an allowlist
+    /// nobody trusts is an allowlist that gets muted. Entries marked #459 are real gaps awaiting
+    /// that issue; they are listed rather than silently skipped so removing them is a visible edit.
+    /// </summary>
+    private static readonly Dictionary<string, string> Allowed = new(StringComparer.Ordinal)
+    {
+        ["BbInputGroup"] = "Wrapper element; the inner input carries the ring.",
+        ["BbSidebarInset"] = "Layout container for page content, not a control.",
+        ["BbDashboardWidget"] = "Widget shell; the focusable controls inside it carry their own.",
+        ["BbDataGrid"] = "Grid container; header cells and rows manage their own focus.",
+        ["BbAttachmentTrigger"] = "Known gap, tracked in #459.",
+        ["BbCommandInput"] = "Known gap, tracked in #459.",
+    };
+
+    [Fact]
+    public void ComponentsThatRemoveTheOutlineProvideAFocusIndicator()
+    {
+        var violations = new List<string>();
+
+        foreach (var (component, text) in SourceTree.ByComponent())
+        {
+            if (!RemovesOutline.IsMatch(text))
+            {
+                continue;
+            }
+
+            if (HasIndicator.IsMatch(text) || ManagesSelection.IsMatch(text))
+            {
+                continue;
+            }
+
+            if (ContainerSuffixes.Any(s => component.EndsWith(s, StringComparison.Ordinal)))
+            {
+                continue;
+            }
+
+            if (Allowed.ContainsKey(component))
+            {
+                continue;
+            }
+
+            violations.Add(component);
+        }
+
+        Assert.True(violations.Count == 0, BuildMessage(violations));
+    }
+
+    /// <summary>
+    /// An allowlist entry that no longer applies is worse than none: it hides a regression behind a
+    /// stale exemption. If a component here has since gained an indicator, delete its entry.
+    /// </summary>
+    [Fact]
+    public void AllowlistHasNoStaleEntries()
+    {
+        var byComponent = SourceTree.ByComponent()
+            .ToDictionary(x => x.Component, x => x.Text, StringComparer.Ordinal);
+
+        var stale = Allowed.Keys
+            .Where(c => !byComponent.TryGetValue(c, out var text)
+                        || !RemovesOutline.IsMatch(text)
+                        || HasIndicator.IsMatch(text)
+                        || ManagesSelection.IsMatch(text))
+            .ToList();
+
+        Assert.True(stale.Count == 0,
+            "These allowlist entries no longer need an exemption — the component has gained a focus "
+            + "indicator, or no longer removes the outline, or no longer exists. Remove them from "
+            + $"{nameof(Allowed)}:{Environment.NewLine}  " + string.Join($"{Environment.NewLine}  ", stale));
+    }
+
+    private static string BuildMessage(IReadOnlyCollection<string> violations)
+    {
+        var message = new StringBuilder()
+            .AppendLine(CultureInfo.InvariantCulture,
+                $"{violations.Count} component(s) remove the focus outline without replacing it.")
+            .AppendLine()
+            .AppendLine("A focused control then looks identical to an unfocused one, which fails WCAG 2.4.7.")
+            .AppendLine()
+            .AppendLine("Add the library's ring:")
+            .AppendLine("  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2")
+            .AppendLine()
+            .AppendLine("Drop ring-offset-2 for controls that sit directly under a label — form rows")
+            .AppendLine("leave a 3px gap and an offset ring extends 4px, so it overlaps the label.")
+            .AppendLine()
+            .AppendLine("A background change on focus counts too, and is the right pattern for menu items.")
+            .AppendLine("If the component genuinely needs no indicator, add it to the allowlist with a reason.")
+            .AppendLine();
+
+        foreach (var violation in violations)
+        {
+            message.AppendLine("  " + violation);
+        }
+
+        return message.ToString();
+    }
+}

--- a/tests/BlazorBlueprint.Tests/Conventions/SourceTree.cs
+++ b/tests/BlazorBlueprint.Tests/Conventions/SourceTree.cs
@@ -1,0 +1,82 @@
+using System.Reflection;
+
+namespace BlazorBlueprint.Tests.Conventions;
+
+/// <summary>
+/// Locates the repository's source directories from the test assembly's location.
+/// <para>
+/// The convention tests read component markup as text rather than exercising rendered output,
+/// because the defects they guard against are omissions in markup — a missing CSS class, a value
+/// interpolated without a culture — that a behavioural test cannot see. The logic is correct in
+/// both cases; the string is not.
+/// </para>
+/// </summary>
+internal static class SourceTree
+{
+    private static readonly Lazy<DirectoryInfo> RepoRootLazy = new(FindRepoRoot);
+
+    /// <summary>Every <c>.razor</c> and <c>.cs</c> file in the two component libraries.</summary>
+    internal static IReadOnlyList<FileInfo> ComponentSources { get; } = EnumerateSources();
+
+    private static DirectoryInfo FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!);
+
+        while (dir is not null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "src", "BlazorBlueprint.Components")))
+            {
+                return dir;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate the repository root by walking up from the test assembly. " +
+            "These tests read component source as text, so they need the working tree — " +
+            "they cannot run against packaged assemblies alone.");
+    }
+
+    private static List<FileInfo> EnumerateSources()
+    {
+        string[] roots =
+        [
+            Path.Combine("src", "BlazorBlueprint.Components", "Components"),
+            Path.Combine("src", "BlazorBlueprint.Primitives", "Primitives"),
+        ];
+
+        var files = new List<FileInfo>();
+
+        foreach (var relative in roots)
+        {
+            var root = new DirectoryInfo(Path.Combine(RepoRootLazy.Value.FullName, relative));
+            if (!root.Exists)
+            {
+                continue;
+            }
+
+            files.AddRange(root
+                .EnumerateFiles("*", SearchOption.AllDirectories)
+                .Where(f => f.Extension is ".razor" or ".cs"));
+        }
+
+        return files;
+    }
+
+    /// <summary>
+    /// Groups source files by component, so a component split across <c>Foo.razor</c> and
+    /// <c>Foo.razor.cs</c> is judged on both halves together. Markup lives in one file and the
+    /// class strings in the other, so inspecting either alone gives the wrong answer.
+    /// </summary>
+    internal static IEnumerable<(string Component, string Text)> ByComponent()
+    {
+        return ComponentSources
+            .GroupBy(f => f.Name.Split('.')[0], StringComparer.Ordinal)
+            .Select(g => (g.Key, string.Join("\n", g.Select(f => File.ReadAllText(f.FullName)))));
+    }
+
+    /// <summary>Path relative to the repository root, for readable assertion messages.</summary>
+    internal static string RelativePath(FileInfo file) =>
+        Path.GetRelativePath(RepoRootLazy.Value.FullName, file.FullName);
+}


### PR DESCRIPTION
Regression cover for #436/#443 (locale) and #457 (focus).

## Why these aren't unit tests

Every bug this session was an **omission in markup or a class string**, not a logic error. The ColorPicker locale bug was `@_hue` interpolated into a `style` attribute; a unit test on `ColorUtils.ToHslString` would have passed happily, because that function was fine. The focus bug was a missing CSS class — there is no behaviour to assert.

So conventional regression tests would have gone green while the defects remained. These scan component source as text instead.

## `CultureInvariantStyleTests`

Flags a numeric value interpolated into an inline `style` without `InvariantCulture`. Razor renders a bare `@value` with `CurrentCulture`, so a comma-decimal locale emits `left: 33,33%` — a CSS syntax error the browser discards in silence.

**This is the one that has already recurred.** `BbColorPicker` (#436) and `BbRangeSlider` (#443) shipped the same defect a fortnight apart, and the second was only found by sweeping the tree by hand after fixing the first.

## `FocusIndicatorTests`

Flags a component that removes the focus outline without drawing a replacement — WCAG 2.4.7, which the entire input family failed until #457.

Deliberately accepts **any** recognised affordance, not just a ring: menu items indicate focus with a background change, which is the correct pattern for a roving-focus list, and listbox options via `aria-selected`. Overlay panels are exempt by name suffix, since they are focused programmatically and a ring around the whole panel on open would be wrong.

A short allowlist covers the remainder, each entry carrying its reason. **A second test fails if an entry stops being needed** — a stale exemption is worse than none, because it hides a regression behind a comment nobody re-reads. That guard immediately earned its place: it caught two dead entries in my own first draft (`BbDataGridRow`, which does not exist, and `BbDataTable`, already exempt via `data-[state=selected]`).

The two `#459` entries are real gaps, listed rather than silently skipped so that fixing them is a visible deletion here.

## Verified by mutation

A convention test that passes on clean code but would not go red on the defect is worthless, so I checked both against the real bugs:

| Mutation | Result |
|---|---|
| Restore `style="left: @(tickPercent)%"` in `BbRangeSlider` | ❌ `CultureInvariantStyleTests` fails |
| Strip the ring from `BbInput` | ❌ `FocusIndicatorTests` fails, naming `BbInput` |
| Both reverted | ✅ 70/70 |

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [X] Refactoring (no functional changes) — tests only

## Testing Checklist

- [X] 70/70 pass (67 existing + 3 new)
- [X] Both guards verified by mutation, then reverted
- [X] No new dependencies — no bUnit, no analyzers
- [X] Runs in ~200ms total

## Deliberately not covered

**The #441 dispose race.** Reproducing an async interleave deterministically needs bUnit plus a way to suspend one caller mid-`await` — a new dependency and real complexity to assert one specific interleaving rather than the general property. The fix is a structural pattern (take ownership before the first `await`) that is verifiable by reading, and the reporter's production Sentry stream is a better signal than anything assertable here. Calling that out as a decision rather than leaving it an open TODO.

## Note on the one new pattern

These read the working tree, which no existing test does — the suite is Verify snapshots over reflection plus pure-function tests. `SourceTree` locates the repo root by walking up from the test assembly and throws a clear message if it cannot, so the failure mode is legible rather than a mystery empty result.