### PR TITLE
fix(charts): plot scatter, line and area against a real X value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-08-05
+
+### Fixed
+
+- **Scatter, line and area series could not plot against a real X value** — Reported in [#439](https://github.com/blazorblueprintui/ui/issues/439), where every scatter example on the docs site appeared to compare a Y value against another Y value rather than X against Y. It did, and the cause was not the demo data. `BbScatter`, `BbLine` and `BbArea` emitted a flat list of Y values, which leaves ECharts to derive each point's X from its *index*. That is right for a category axis, and it is why the ordinary categorical chart has always looked correct. It is wrong for a value axis: an axis of `Type="AxisType.Value"` ignores the `data` it is given, so the X values passed to `BbXAxis` via `DataKey` were dropped and the points were plotted against ordinal position regardless. The two halves failed in a way that hid each other — the axis looked configured, the labels came from the right property, and the plot was a Y-over-position chart wearing X's labels. There was no arrangement of the existing parameters that produced a genuine X:Y plot, which also made the answer to the reporter's follow-up question "you can't", and made the example in `BbScatter`'s own XML documentation — which advertised exactly that arrangement — wrong. The three series now take **`XDataKey`**, naming the property that holds each point's X value, and emit explicit `[x, y]` pairs. Leave it unset and nothing changes: the flat list is still emitted, categorical charts are untouched, and the composite bar-plus-scatter overlay keeps working as before. Rows missing either coordinate become a null entry rather than a partial pair, which ECharts would otherwise render against a coerced zero; the returned list stays parallel to the source data rather than being compacted, because `SymbolSizeKey` zips against it by index and a compacted list would have silently misassigned every bubble size after the first gap.
+
+### Added
+
+- **`BbXAxis.Scale`** — `BbYAxis` has carried `Scale` for some time; the X axis had no equivalent, which went unnoticed while no chart in the library used a numeric X axis. Plotting the first genuine one surfaced it immediately: a value axis includes zero by default, so heights of 160-190 occupied the last sixth of the plot and the correlation they were meant to show was squeezed into a corner. Set it to scale the axis to the data range instead. It is deliberately opt-in on both axes — suppressing zero exaggerates small differences, so it should be a decision rather than a default, and it is the wrong choice wherever the distance from zero is part of what the reader should take away.
+
+---
+
 ## 2026-08-03
 
 ### Added

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/AreaChart/numeric-x.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/AreaChart/numeric-x.txt
@@ -1,0 +1,6 @@
+<BbAreaChart Data="@data" Height="200px">
+    <BbXAxis Type="AxisType.Value" />
+    <BbYAxis />
+    <BbChartTooltip />
+    <BbArea XDataKey="elapsed" DataKey="value" Name="Load" Color="var(--chart-1)" FillOpacity="0.3" />
+</BbAreaChart>

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/LineChart/numeric-x.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/LineChart/numeric-x.txt
@@ -1,0 +1,6 @@
+<BbLineChart Data="@data" Height="200px">
+    <BbXAxis Type="AxisType.Value" />
+    <BbYAxis />
+    <BbChartTooltip />
+    <BbLine XDataKey="elapsed" DataKey="value" Name="Reading" Color="var(--chart-1)" ShowDots="true" />
+</BbLineChart>

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/bubble.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/bubble.txt
@@ -1,7 +1,7 @@
 <BbScatterChart Data="@data" Height="250px">
-    <BbXAxis DataKey="height" Type="AxisType.Category" />
-    <BbYAxis />
+    <BbXAxis Type="AxisType.Value" Scale="true" />
+    <BbYAxis Scale="true" />
     <BbChartTooltip />
-    <BbScatter DataKey="weight" Name="Weight" Color="var(--chart-5)"
+    <BbScatter XDataKey="height" DataKey="weight" Name="Weight" Color="var(--chart-5)"
                SymbolSizeKey="score" />
 </BbScatterChart>

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/categorical.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/categorical.txt
@@ -1,0 +1,6 @@
+<BbScatterChart Data="@data" Height="250px">
+    <BbXAxis DataKey="region" Type="AxisType.Category" />
+    <BbYAxis />
+    <BbChartTooltip />
+    <BbScatter DataKey="sales" Name="Sales" Color="var(--chart-2)" />
+</BbScatterChart>

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/custom-size.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/custom-size.txt
@@ -1,6 +1,6 @@
 <BbScatterChart Data="@data" Height="250px">
-    <BbXAxis DataKey="height" Type="AxisType.Category" />
-    <BbYAxis />
+    <BbXAxis Type="AxisType.Value" Scale="true" />
+    <BbYAxis Scale="true" />
     <BbChartTooltip />
-    <BbScatter DataKey="weight" Name="Weight" Color="var(--chart-3)" SymbolSize="16" />
+    <BbScatter XDataKey="height" DataKey="weight" Name="Weight" Color="var(--chart-3)" SymbolSize="16" />
 </BbScatterChart>

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/default.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/default.txt
@@ -1,6 +1,6 @@
 <BbScatterChart Data="@data" Height="250px">
-    <BbXAxis DataKey="height" Type="AxisType.Category" />
-    <BbYAxis />
+    <BbXAxis Type="AxisType.Value" Scale="true" />
+    <BbYAxis Scale="true" />
     <BbChartTooltip />
-    <BbScatter DataKey="weight" Name="Weight" Color="var(--chart-1)" />
+    <BbScatter XDataKey="height" DataKey="weight" Name="Weight" Color="var(--chart-1)" />
 </BbScatterChart>

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/labels.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/labels.txt
@@ -1,7 +1,7 @@
 <BbScatterChart Data="@data" Height="250px">
-    <BbXAxis DataKey="height" Type="AxisType.Category" />
-    <BbYAxis />
+    <BbXAxis Type="AxisType.Value" Scale="true" />
+    <BbYAxis Scale="true" />
     <BbChartTooltip />
-    <BbScatter DataKey="weight" Name="Weight" Color="var(--chart-4)"
+    <BbScatter XDataKey="height" DataKey="weight" Name="Weight" Color="var(--chart-4)"
                ShowLabel="true" LabelPosition="LabelPosition.Top" />
 </BbScatterChart>

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/multiple.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/multiple.txt
@@ -1,8 +1,8 @@
 <BbScatterChart Data="@data" Height="250px">
-    <BbXAxis DataKey="height" Type="AxisType.Category" />
-    <BbYAxis />
+    <BbXAxis Type="AxisType.Value" Scale="true" />
+    <BbYAxis Scale="true" />
     <BbChartTooltip />
     <BbChartLegend />
-    <BbScatter DataKey="weight" Name="Group A" Color="var(--chart-1)" />
-    <BbScatter DataKey="score" Name="Group B" Color="var(--chart-2)" />
+    <BbScatter XDataKey="height" DataKey="weight" Name="Group A" Color="var(--chart-1)" />
+    <BbScatter XDataKey="height" DataKey="score" Name="Group B" Color="var(--chart-2)" />
 </BbScatterChart>

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/small.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Charts/ScatterChart/small.txt
@@ -1,6 +1,6 @@
 <BbScatterChart Data="@data" Height="250px">
-    <BbXAxis DataKey="height" Type="AxisType.Category" />
-    <BbYAxis />
+    <BbXAxis Type="AxisType.Value" Scale="true" />
+    <BbYAxis Scale="true" />
     <BbChartTooltip />
-    <BbScatter DataKey="weight" Name="Weight" Color="var(--chart-1)" SymbolSize="5" />
+    <BbScatter XDataKey="height" DataKey="weight" Name="Weight" Color="var(--chart-1)" SymbolSize="5" />
 </BbScatterChart>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Charts/AreaChartDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Charts/AreaChartDemo.razor
@@ -322,6 +322,33 @@
             </div>
             <CodeBlock Source="Charts/AreaChart/axes.txt" />
         </div>
+
+        <!-- Numeric X Axis -->
+        <div>
+            <div class="rounded-xl border bg-card text-card-foreground shadow-sm">
+                <div class="flex flex-col space-y-1.5 p-6">
+                    <h3 class="font-semibold leading-none tracking-tight">Area Chart - Numeric X Axis</h3>
+                    <p class="text-sm text-muted-foreground">Load measured at irregular intervals</p>
+                </div>
+                <div class="p-6 pt-0">
+                    <BbAreaChart Data="@_readingData" Height="200px">
+                        <BbXAxis Type="AxisType.Value" />
+                        <BbYAxis />
+                        <BbChartTooltip />
+                        <BbArea XDataKey="elapsed" DataKey="value" Name="Load" Color="var(--chart-1)" FillOpacity="0.3" />
+                    </BbAreaChart>
+                </div>
+                <div class="flex flex-col gap-2 p-6 pt-0">
+                    <div class="flex gap-2 items-center font-medium leading-none">
+                        Spacing reflects the gaps between readings
+                    </div>
+                    <div class="text-sm text-muted-foreground leading-none">
+                        XDataKey plots each point at its own X coordinate
+                    </div>
+                </div>
+            </div>
+            <CodeBlock Source="Charts/AreaChart/numeric-x.txt" />
+        </div>
     </div>
 
     <!-- API Reference -->
@@ -330,6 +357,20 @@
             <h2 class="text-2xl font-semibold">API Reference</h2>
         </div>
         <div class="border rounded-lg p-6 space-y-4">
+            <div>
+                <h3 class="font-mono text-sm font-semibold mb-2">Area.XDataKey</h3>
+                <p class="text-sm text-muted-foreground mb-2">
+                    Type: <code class="text-xs bg-muted px-1 py-0.5 rounded">string?</code>
+                </p>
+                <p class="text-sm text-muted-foreground">
+                    Property name holding each point's X value, plotting it at its own coordinate on a
+                    <code class="text-xs bg-muted px-1 py-0.5 rounded">Value</code>,
+                    <code class="text-xs bg-muted px-1 py-0.5 rounded">Time</code> or
+                    <code class="text-xs bg-muted px-1 py-0.5 rounded">Log</code> axis. Leave it unset for the
+                    usual categorical area, where points are spaced evenly and the X axis supplies its own labels.
+                </p>
+            </div>
+            <BbSeparator />
             <div>
                 <h3 class="font-mono text-sm font-semibold mb-2">Area.Curve</h3>
                 <p class="text-sm text-muted-foreground mb-2">
@@ -397,6 +438,23 @@
         public int Desktop { get; set; }
         public int Mobile { get; set; }
     }
+
+    public class ReadingData
+    {
+        public int Elapsed { get; set; }
+        public int Value { get; set; }
+    }
+
+    private readonly List<ReadingData> _readingData =
+    [
+        new() { Elapsed = 0, Value = 12 },
+        new() { Elapsed = 5, Value = 34 },
+        new() { Elapsed = 8, Value = 28 },
+        new() { Elapsed = 20, Value = 61 },
+        new() { Elapsed = 24, Value = 55 },
+        new() { Elapsed = 45, Value = 78 },
+        new() { Elapsed = 60, Value = 72 }
+    ];
 
     private string _selectedRange = "90d";
 

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Charts/LineChartDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Charts/LineChartDemo.razor
@@ -210,6 +210,33 @@
             </div>
             <CodeBlock Source="Charts/LineChart/custom-dots.txt" />
         </div>
+
+        <!-- Numeric X Axis -->
+        <div>
+            <div class="rounded-xl border bg-card text-card-foreground shadow-sm">
+                <div class="flex flex-col space-y-1.5 p-6">
+                    <h3 class="font-semibold leading-none tracking-tight">Line Chart - Numeric X Axis</h3>
+                    <p class="text-sm text-muted-foreground">Readings at irregular intervals</p>
+                </div>
+                <div class="p-6 pt-0">
+                    <BbLineChart Data="@_readingData" Height="200px">
+                        <BbXAxis Type="AxisType.Value" />
+                        <BbYAxis />
+                        <BbChartTooltip />
+                        <BbLine XDataKey="elapsed" DataKey="value" Name="Reading" Color="var(--chart-1)" ShowDots="true" />
+                    </BbLineChart>
+                </div>
+                <div class="flex flex-col gap-2 p-6 pt-0">
+                    <div class="flex gap-2 items-center font-medium leading-none">
+                        Spacing reflects the gaps between readings
+                    </div>
+                    <div class="text-sm text-muted-foreground leading-none">
+                        XDataKey plots each point at its own X coordinate
+                    </div>
+                </div>
+            </div>
+            <CodeBlock Source="Charts/LineChart/numeric-x.txt" />
+        </div>
     </div>
 
     <!-- API Reference -->
@@ -218,6 +245,20 @@
             <h2 class="text-2xl font-semibold">API Reference</h2>
         </div>
         <div class="border rounded-lg p-6 space-y-4">
+            <div>
+                <h3 class="font-mono text-sm font-semibold mb-2">Line.XDataKey</h3>
+                <p class="text-sm text-muted-foreground mb-2">
+                    Type: <code class="text-xs bg-muted px-1 py-0.5 rounded">string?</code> (default: null)
+                </p>
+                <p class="text-sm text-muted-foreground">
+                    Property name holding each point's X value, plotting it at its own coordinate on a
+                    <code class="text-xs bg-muted px-1 py-0.5 rounded">Value</code>,
+                    <code class="text-xs bg-muted px-1 py-0.5 rounded">Time</code> or
+                    <code class="text-xs bg-muted px-1 py-0.5 rounded">Log</code> axis. Leave it unset for the
+                    usual categorical line, where points are spaced evenly and the X axis supplies its own labels.
+                </p>
+            </div>
+            <BbSeparator />
             <div>
                 <h3 class="font-mono text-sm font-semibold mb-2">Line.Curve</h3>
                 <p class="text-sm text-muted-foreground mb-2">
@@ -295,6 +336,23 @@
         public int Desktop { get; set; }
         public int Mobile { get; set; }
     }
+
+    public class ReadingData
+    {
+        public int Elapsed { get; set; }
+        public int Value { get; set; }
+    }
+
+    private readonly List<ReadingData> _readingData =
+    [
+        new() { Elapsed = 0, Value = 12 },
+        new() { Elapsed = 5, Value = 34 },
+        new() { Elapsed = 8, Value = 28 },
+        new() { Elapsed = 20, Value = 61 },
+        new() { Elapsed = 24, Value = 55 },
+        new() { Elapsed = 45, Value = 78 },
+        new() { Elapsed = 60, Value = 72 }
+    ];
 
     private readonly List<MonthlyData> _monthlyData =
     [

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Charts/ScatterChartDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Charts/ScatterChartDemo.razor
@@ -22,15 +22,15 @@
                 </div>
                 <div class="p-6 pt-0">
                     <BbScatterChart Data="@_scatterData" Height="250px">
-                        <BbXAxis DataKey="height" Type="AxisType.Category" />
-                        <BbYAxis />
+                        <BbXAxis Type="AxisType.Value" Scale="true" />
+                        <BbYAxis Scale="true" />
                         <BbChartTooltip />
-                        <BbScatter DataKey="weight" Name="Weight" Color="var(--chart-1)" />
+                        <BbScatter XDataKey="height" DataKey="weight" Name="Weight" Color="var(--chart-1)" />
                     </BbScatterChart>
                 </div>
                 <div class="flex flex-col gap-2 p-6 pt-0">
                     <div class="flex gap-2 items-center font-medium leading-none">
-                        Default scatter with category axis
+                        True X:Y scatter on a value axis
                     </div>
                     <div class="text-sm text-muted-foreground leading-none">
                         Showing height vs weight correlation
@@ -48,12 +48,12 @@
                 </div>
                 <div class="p-6 pt-0">
                     <BbScatterChart Data="@_scatterData" Height="250px">
-                        <BbXAxis DataKey="height" Type="AxisType.Category" />
-                        <BbYAxis />
+                        <BbXAxis Type="AxisType.Value" Scale="true" />
+                        <BbYAxis Scale="true" />
                         <BbChartTooltip />
                         <BbChartLegend />
-                        <BbScatter DataKey="weight" Name="Group A" Color="var(--chart-1)" />
-                        <BbScatter DataKey="score" Name="Group B" Color="var(--chart-2)" />
+                        <BbScatter XDataKey="height" DataKey="weight" Name="Group A" Color="var(--chart-1)" />
+                        <BbScatter XDataKey="height" DataKey="score" Name="Group B" Color="var(--chart-2)" />
                     </BbScatterChart>
                 </div>
                 <div class="flex flex-col gap-2 p-6 pt-0">
@@ -76,10 +76,10 @@
                 </div>
                 <div class="p-6 pt-0">
                     <BbScatterChart Data="@_scatterData" Height="250px">
-                        <BbXAxis DataKey="height" Type="AxisType.Category" />
-                        <BbYAxis />
+                        <BbXAxis Type="AxisType.Value" Scale="true" />
+                        <BbYAxis Scale="true" />
                         <BbChartTooltip />
-                        <BbScatter DataKey="weight" Name="Weight" Color="var(--chart-3)" SymbolSize="16" />
+                        <BbScatter XDataKey="height" DataKey="weight" Name="Weight" Color="var(--chart-3)" SymbolSize="16" />
                     </BbScatterChart>
                 </div>
                 <div class="flex flex-col gap-2 p-6 pt-0">
@@ -102,10 +102,10 @@
                 </div>
                 <div class="p-6 pt-0">
                     <BbScatterChart Data="@_scatterData" Height="250px">
-                        <BbXAxis DataKey="height" Type="AxisType.Category" />
-                        <BbYAxis />
+                        <BbXAxis Type="AxisType.Value" Scale="true" />
+                        <BbYAxis Scale="true" />
                         <BbChartTooltip />
-                        <BbScatter DataKey="weight" Name="Weight" Color="var(--chart-4)" ShowLabel="true" LabelPosition="LabelPosition.Top" />
+                        <BbScatter XDataKey="height" DataKey="weight" Name="Weight" Color="var(--chart-4)" ShowLabel="true" LabelPosition="LabelPosition.Top" />
                     </BbScatterChart>
                 </div>
                 <div class="flex flex-col gap-2 p-6 pt-0">
@@ -128,10 +128,10 @@
                 </div>
                 <div class="p-6 pt-0">
                     <BbScatterChart Data="@_scatterData" Height="250px">
-                        <BbXAxis DataKey="height" Type="AxisType.Category" />
-                        <BbYAxis />
+                        <BbXAxis Type="AxisType.Value" Scale="true" />
+                        <BbYAxis Scale="true" />
                         <BbChartTooltip />
-                        <BbScatter DataKey="weight" Name="Weight" Color="var(--chart-5)" SymbolSizeKey="score" />
+                        <BbScatter XDataKey="height" DataKey="weight" Name="Weight" Color="var(--chart-5)" SymbolSizeKey="score" />
                     </BbScatterChart>
                 </div>
                 <div class="flex flex-col gap-2 p-6 pt-0">
@@ -154,10 +154,10 @@
                 </div>
                 <div class="p-6 pt-0">
                     <BbScatterChart Data="@_scatterData" Height="250px">
-                        <BbXAxis DataKey="height" Type="AxisType.Category" />
-                        <BbYAxis />
+                        <BbXAxis Type="AxisType.Value" Scale="true" />
+                        <BbYAxis Scale="true" />
                         <BbChartTooltip />
-                        <BbScatter DataKey="weight" Name="Weight" Color="var(--chart-1)" SymbolSize="5" />
+                        <BbScatter XDataKey="height" DataKey="weight" Name="Weight" Color="var(--chart-1)" SymbolSize="5" />
                     </BbScatterChart>
                 </div>
                 <div class="flex flex-col gap-2 p-6 pt-0">
@@ -171,6 +171,32 @@
             </div>
             <CodeBlock Source="Charts/ScatterChart/small.txt" />
         </div>
+
+        <div>
+            <div class="rounded-xl border bg-card text-card-foreground shadow-sm">
+                <div class="flex flex-col space-y-1.5 p-6">
+                    <h3 class="font-semibold leading-none tracking-tight">Categorical X Axis</h3>
+                    <p class="text-sm text-muted-foreground">Sales by region</p>
+                </div>
+                <div class="p-6 pt-0">
+                    <BbScatterChart Data="@_regionData" Height="250px">
+                        <BbXAxis DataKey="region" Type="AxisType.Category" />
+                        <BbYAxis />
+                        <BbChartTooltip />
+                        <BbScatter DataKey="sales" Name="Sales" Color="var(--chart-2)" />
+                    </BbScatterChart>
+                </div>
+                <div class="flex flex-col gap-2 p-6 pt-0">
+                    <div class="flex gap-2 items-center font-medium leading-none">
+                        Omit XDataKey for discrete categories
+                    </div>
+                    <div class="text-sm text-muted-foreground leading-none">
+                        Points sit at evenly spaced positions labelled by the axis
+                    </div>
+                </div>
+            </div>
+            <CodeBlock Source="Charts/ScatterChart/categorical.txt" />
+        </div>
     </div>
 
     <div class="space-y-4">
@@ -178,6 +204,32 @@
             <h2 class="text-2xl font-semibold">API Reference</h2>
         </div>
         <div class="border rounded-lg p-6 space-y-4">
+            <div>
+                <h3 class="font-mono text-sm font-semibold mb-2">Scatter.XDataKey</h3>
+                <p class="text-sm text-muted-foreground mb-2">
+                    Type: <code class="text-xs bg-muted px-1 py-0.5 rounded">string?</code> (default: <code class="text-xs bg-muted px-1 py-0.5 rounded">null</code>)
+                </p>
+                <p class="text-sm text-muted-foreground">
+                    Property name holding each point's X value, plotting it at its own coordinate on a
+                    <code class="text-xs bg-muted px-1 py-0.5 rounded">Value</code>,
+                    <code class="text-xs bg-muted px-1 py-0.5 rounded">Time</code> or
+                    <code class="text-xs bg-muted px-1 py-0.5 rounded">Log</code> axis. Leave it unset for a
+                    categorical scatter, where points are spaced evenly and the X axis supplies its own labels.
+                </p>
+            </div>
+            <BbSeparator />
+            <div>
+                <h3 class="font-mono text-sm font-semibold mb-2">XAxis.Scale / YAxis.Scale</h3>
+                <p class="text-sm text-muted-foreground mb-2">
+                    Type: <code class="text-xs bg-muted px-1 py-0.5 rounded">bool</code> (default: <code class="text-xs bg-muted px-1 py-0.5 rounded">false</code>)
+                </p>
+                <p class="text-sm text-muted-foreground">
+                    Scales a value axis to the data range instead of including zero. Without it, heights of
+                    160-190 sit in the last sixth of the plot. Leave it off wherever the distance from zero
+                    is part of what the reader should see.
+                </p>
+            </div>
+            <BbSeparator />
             <div>
                 <h3 class="font-mono text-sm font-semibold mb-2">Scatter.SymbolSize</h3>
                 <p class="text-sm text-muted-foreground mb-2">
@@ -214,22 +266,37 @@
 @code {
     public class ScatterData
     {
-        public string Height { get; set; } = "";
+        public int Height { get; set; }
         public int Weight { get; set; }
         public int Score { get; set; }
     }
 
     private readonly List<ScatterData> _scatterData =
     [
-        new() { Height = "160", Weight = 55, Score = 8 },
-        new() { Height = "165", Weight = 62, Score = 12 },
-        new() { Height = "170", Weight = 68, Score = 15 },
-        new() { Height = "172", Weight = 71, Score = 10 },
-        new() { Height = "175", Weight = 75, Score = 18 },
-        new() { Height = "178", Weight = 80, Score = 22 },
-        new() { Height = "180", Weight = 82, Score = 14 },
-        new() { Height = "183", Weight = 88, Score = 20 },
-        new() { Height = "185", Weight = 90, Score = 16 },
-        new() { Height = "190", Weight = 95, Score = 25 }
+        new() { Height = 160, Weight = 55, Score = 8 },
+        new() { Height = 165, Weight = 62, Score = 12 },
+        new() { Height = 170, Weight = 68, Score = 15 },
+        new() { Height = 172, Weight = 71, Score = 10 },
+        new() { Height = 175, Weight = 75, Score = 18 },
+        new() { Height = 178, Weight = 80, Score = 22 },
+        new() { Height = 180, Weight = 82, Score = 14 },
+        new() { Height = 183, Weight = 88, Score = 20 },
+        new() { Height = 185, Weight = 90, Score = 16 },
+        new() { Height = 190, Weight = 95, Score = 25 }
+    ];
+
+    public class RegionData
+    {
+        public string Region { get; set; } = "";
+        public int Sales { get; set; }
+    }
+
+    private readonly List<RegionData> _regionData =
+    [
+        new() { Region = "North", Sales = 42 },
+        new() { Region = "South", Sales = 68 },
+        new() { Region = "East", Sales = 55 },
+        new() { Region = "West", Sales = 73 },
+        new() { Region = "Central", Sales = 61 }
     ];
 }

--- a/src/BlazorBlueprint.Components/Components/Chart/Composables/BbXAxis.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Chart/Composables/BbXAxis.razor.cs
@@ -160,6 +160,19 @@ public partial class BbXAxis : ComponentBase, IChartComponent, IDisposable
     [Parameter]
     public object? Max { get; set; }
 
+    /// <summary>
+    /// Gets or sets whether the axis scale should auto-fit to the data range.
+    /// </summary>
+    /// <remarks>
+    /// Applies to value axes only; category axes ignore it. A value axis includes zero by default,
+    /// which is the honest choice for magnitudes but wastes the plot area when the data sits far from
+    /// it — heights of 160-190 against an axis starting at 0 occupy the last sixth of the chart. Set
+    /// this for those, and leave it off wherever the distance from zero is part of what the reader
+    /// should see. Ignored when both <see cref="Min"/> and <see cref="Max"/> are set.
+    /// </remarks>
+    [Parameter]
+    public bool? Scale { get; set; }
+
     protected override void OnInitialized() =>
         ParentChart?.RegisterComponent(this);
 
@@ -180,6 +193,7 @@ public partial class BbXAxis : ComponentBase, IChartComponent, IDisposable
             Name = Name,
             Min = Min,
             Max = Max,
+            Scale = Scale,
             Z = LabelInside ? 10 : null,
             AxisLine = new EChartsAxisLineOption
             {

--- a/src/BlazorBlueprint.Components/Components/Chart/Series/BbArea.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Chart/Series/BbArea.razor.cs
@@ -35,6 +35,18 @@ namespace BlazorBlueprint.Components;
 public partial class BbArea : SeriesBase
 {
     /// <summary>
+    /// Gets or sets the property holding each point's X value.
+    /// </summary>
+    /// <remarks>
+    /// Set this to plot against a numeric or time X axis, where points sit at their own X coordinate
+    /// rather than at evenly spaced positions — irregular sampling intervals, for instance. Leave it
+    /// unset for the usual categorical area, where the X axis supplies labels through
+    /// <see cref="BbXAxis.DataKey"/>.
+    /// </remarks>
+    [Parameter]
+    public string? XDataKey { get; set; }
+
+    /// <summary>
     /// Gets or sets the curve interpolation type.
     /// </summary>
     /// <remarks>
@@ -74,7 +86,7 @@ public partial class BbArea : SeriesBase
         {
             Type = "line",
             Name = GetResolvedName(),
-            Data = GetSeriesData(),
+            Data = GetPointData(XDataKey),
             ShowSymbol = ShowDots,
             AreaStyle = new EChartsAreaStyleOption
             {

--- a/src/BlazorBlueprint.Components/Components/Chart/Series/BbLine.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Chart/Series/BbLine.razor.cs
@@ -28,6 +28,18 @@ namespace BlazorBlueprint.Components;
 public partial class BbLine : SeriesBase
 {
     /// <summary>
+    /// Gets or sets the property holding each point's X value.
+    /// </summary>
+    /// <remarks>
+    /// Set this to plot against a numeric or time X axis, where points sit at their own X coordinate
+    /// rather than at evenly spaced positions — irregular sampling intervals, for instance. Leave it
+    /// unset for the usual categorical line, where the X axis supplies labels through
+    /// <see cref="BbXAxis.DataKey"/>.
+    /// </remarks>
+    [Parameter]
+    public string? XDataKey { get; set; }
+
+    /// <summary>
     /// Gets or sets the curve interpolation type.
     /// </summary>
     /// <remarks>
@@ -69,7 +81,7 @@ public partial class BbLine : SeriesBase
         {
             Type = "line",
             Name = GetResolvedName(),
-            Data = GetSeriesData(),
+            Data = GetPointData(XDataKey),
             ShowSymbol = ShowDots,
             SymbolSize = ShowDots ? DotSize : 0,
             LineStyle = new EChartsLineStyleOption

--- a/src/BlazorBlueprint.Components/Components/Chart/Series/BbScatter.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Chart/Series/BbScatter.razor.cs
@@ -17,14 +17,32 @@ namespace BlazorBlueprint.Components;
 /// <example>
 /// <code>
 /// &lt;BbScatterChart Data="@data"&gt;
-///     &lt;BbXAxis DataKey="x" Type="AxisType.Value" /&gt;
+///     &lt;BbXAxis Type="AxisType.Value" /&gt;
 ///     &lt;BbYAxis /&gt;
-///     &lt;BbScatter DataKey="y" Name="Series A" SymbolSize="12" /&gt;
+///     &lt;BbScatter XDataKey="x" DataKey="y" Name="Series A" SymbolSize="12" /&gt;
 /// &lt;/BbScatterChart&gt;
 /// </code>
 /// </example>
 public partial class BbScatter : SeriesBase
 {
+    /// <summary>
+    /// Gets or sets the property holding each point's X value.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Set this for a true X:Y scatter — each point is plotted at its own X coordinate on a
+    /// <see cref="AxisType.Value"/>, <see cref="AxisType.Time"/> or <see cref="AxisType.Log"/> axis.
+    /// </para>
+    /// <para>
+    /// Leave it unset for a categorical scatter, where points are plotted against the position of
+    /// their row and the X axis supplies its own labels through <see cref="BbXAxis.DataKey"/>.
+    /// Note that a value axis ignores those labels, so numeric X values are only honoured when they
+    /// are supplied here — on the series, not on the axis.
+    /// </para>
+    /// </remarks>
+    [Parameter]
+    public string? XDataKey { get; set; }
+
     /// <summary>
     /// Gets or sets the size of scatter symbols in pixels.
     /// </summary>
@@ -67,7 +85,7 @@ public partial class BbScatter : SeriesBase
     {
         var resolvedColor = GetResolvedColor();
         var effectiveColor = GetResolvedFillColor() ?? resolvedColor;
-        var rawData = GetSeriesData();
+        var rawData = GetPointData(XDataKey);
 
         var series = new EChartsSeriesOption
         {

--- a/src/BlazorBlueprint.Components/Components/Chart/Series/SeriesBase.cs
+++ b/src/BlazorBlueprint.Components/Components/Chart/Series/SeriesBase.cs
@@ -136,6 +136,56 @@ public abstract class SeriesBase : ComponentBase, IChartSeries, IDisposable
     }
 
     /// <summary>
+    /// Extracts data for this series as explicit <c>[x, y]</c> pairs when <paramref name="xDataKey"/>
+    /// is supplied, falling back to the flat <see cref="GetSeriesData"/> list when it is not.
+    /// </summary>
+    /// <param name="xDataKey">
+    /// The property holding each point's X value, or <see langword="null"/> for positional X.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// A flat list of Y values leaves ECharts to derive X from the point's *index*, which is correct
+    /// on a category axis but silently discards real X values on a <see cref="AxisType.Value"/>,
+    /// <see cref="AxisType.Time"/> or <see cref="AxisType.Log"/> axis — the axis ignores its own
+    /// <c>data</c>, so the points end up plotted against ordinal position. Emitting pairs is what
+    /// makes a genuine X:Y plot expressible.
+    /// </para>
+    /// <para>
+    /// A row missing either side yields a null entry rather than a partial pair, which ECharts would
+    /// render against a coerced zero. Null entries are skipped when drawn, and — because callers such
+    /// as per-point symbol sizing zip this list against the source data by index — the returned list
+    /// stays parallel to the chart's data rather than being compacted.
+    /// </para>
+    /// </remarks>
+    /// <returns>A list of two-element <c>[x, y]</c> arrays, or the flat Y list.</returns>
+    protected List<object?> GetPointData(string? xDataKey)
+    {
+        if (string.IsNullOrEmpty(xDataKey))
+        {
+            return GetSeriesData();
+        }
+
+        if (string.IsNullOrEmpty(DataKey))
+        {
+            return [];
+        }
+
+        var xValues = DataExtractor.ExtractValues(ParentChart?.Data, xDataKey);
+        var yValues = DataExtractor.ExtractValues(ParentChart?.Data, DataKey);
+        var count = Math.Min(xValues.Count, yValues.Count);
+        var points = new List<object?>(count);
+
+        for (var i = 0; i < count; i++)
+        {
+            points.Add(xValues[i] == null || yValues[i] == null
+                ? null
+                : new[] { xValues[i], yValues[i] });
+        }
+
+        return points;
+    }
+
+    /// <summary>
     /// Resolves the color for this series by checking the explicit Color parameter first,
     /// then the ChartConfig, returning null if neither is set.
     /// </summary>

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -104,6 +104,7 @@
   - StackGroup : String
   - Stacked : Boolean
   - StrokeWidth : Int32
+  - XDataKey : String
 
 ### BbAreaChart (BlazorBlueprint.Components)
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
@@ -2299,6 +2300,7 @@
   - StackGroup : String
   - Stacked : Boolean
   - StrokeWidth : Int32
+  - XDataKey : String
 
 ### BbLineChart (BlazorBlueprint.Components)
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
@@ -2915,6 +2917,7 @@
   - Stacked : Boolean
   - SymbolSize : Int32
   - SymbolSizeKey : String
+  - XDataKey : String
 
 ### BbScatterChart (BlazorBlueprint.Components)
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
@@ -3688,6 +3691,7 @@
   - Max : Object
   - Min : Object
   - Name : String
+  - Scale : Boolean?
   - Show : Boolean
   - ShowAxisLine : Boolean
   - ShowGrid : Boolean


### PR DESCRIPTION
Fixes #439.

## The bug

Every scatter example on the docs site appeared to compare a Y value against another Y value rather than X against Y. It did — and the cause was not the demo data.

`BbScatter`, `BbLine` and `BbArea` emitted a flat list of Y values, which leaves ECharts to derive each point's X from its *index*. That is correct for a category axis, and it is why the ordinary categorical chart has always looked right. It is wrong for a value axis: an axis of `Type="AxisType.Value"` ignores the `data` it is given, so X values passed to `BbXAxis` through `DataKey` were dropped and points were plotted against ordinal position regardless.

The two halves failed in a way that concealed each other. The axis looked configured, the labels came from the right property, and the plot was a Y-over-position chart wearing X's labels. There was no arrangement of the existing parameters that produced a genuine X:Y plot — which made the answer to the reporter's follow-up question ("how would I implement X:Y instead?") *"you can't"*, and made the example in `BbScatter`'s own XML documentation, which advertised exactly that arrangement, wrong.

## The fix

`XDataKey` on `BbScatter`, `BbLine` and `BbArea`, naming the property holding each point's X value, emitting explicit `[x, y]` pairs via a shared `SeriesBase.GetPointData` helper.

Leave it unset and nothing changes — the flat list is still emitted, so categorical charts and the composite bar-plus-scatter overlay behave exactly as before.

Two details that only surfaced by running it:

- **Null handling.** A row missing either coordinate yields a null entry rather than a partial pair, which ECharts would render against a coerced zero. The returned list stays *parallel* to the source data rather than compacted, because `SymbolSizeKey` zips against it by index — compacting would have silently misassigned every bubble size after the first gap.
- **`BbXAxis.Scale`.** `BbYAxis` has carried `Scale` for some time; the X axis had no equivalent, which went unnoticed while no chart used a numeric X axis. The first genuine one surfaced it immediately: a value axis includes zero by default, so heights of 160-190 occupied the last sixth of the plot — technically fixed, visually still broken. Opt-in on both axes, since suppressing zero exaggerates small differences and is the wrong choice wherever distance from zero is part of the point.

## Scope of the audit

The gap was not scatter-specific — `BbLine` and `BbArea` shared it, so a numeric-X line chart was equally inexpressible.

- **`BbBar` deliberately excluded.** Its `HasNegativeValues` / `BuildPerItemData` path inspects each datum as a scalar and would misread a pair.
- **`BbCandlestick` and `BbHeatmap` unaffected** — both already build their own multi-dimensional data.

## Verification

70/70 tests pass. The API surface diff is exactly four additions — `XDataKey` on the three series, `Scale` on `BbXAxis` — and nothing incidental.

Checked in a browser, not just built:

- Scatter X ticks now read 160-190 (real heights) with points spanning the full plot in a visible correlation, where they were previously evenly spaced ordinals.
- Line and area demos show proportional gaps for irregular sampling intervals.
- Bubble sizes still track `SymbolSizeKey` correctly under the paired data path.
- The composite bar+scatter overlay and a new categorical scatter card confirm the unset path is unchanged.

## Docs

All six scatter examples converted to true X:Y (the demo data's `Height` was typed `string`, so it could only ever have been categorical), plus a new categorical card documenting the fallback, matching code snippets, API-reference entries on all three pages, a corrected XML doc example, and a CHANGELOG entry.
