### PR TITLE
fix(demo): correct ButtonSize.Sm to ButtonSize.Small in CopyText demo

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/CopyText/value-func.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/CopyText/value-func.txt
@@ -1,5 +1,5 @@
 Environment: @_environment
-<BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Sm" OnClick="CycleEnvironment">
+<BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="CycleEnvironment">
     Change
 </BbButton>
 

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CopyTextDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CopyTextDemo.razor
@@ -93,7 +93,7 @@
             <div class="flex items-center gap-2">
                 <span class="text-muted-foreground">Environment:</span>
                 <span class="font-mono">@_environment</span>
-                <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Sm" OnClick="CycleEnvironment">
+                <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small" OnClick="CycleEnvironment">
                     Change
                 </BbButton>
             </div>


### PR DESCRIPTION
Fixes the build break on `develop`.

```
CopyTextDemo.razor(96,76): error CS0117: 'ButtonSize' does not contain a
definition for 'Sm'
```

The `ValueFunc` demo added in #469 used `ButtonSize.Sm`. The enum member is `ButtonSize.Small`. One-line fix in the demo page and its matching code snippet.

**No library code is affected** — `BbCopyText.ValueFunc` itself is fine, and the Components project, the test suite and the API surface snapshot all built clean throughout. This is purely the demo markup.

## How it got through

Worth recording, because the verification failure is more interesting than the typo.

After swapping a `BbNativeSelect` for a `BbButton` in that demo, I piped the demo build through `tail -2`. MSBuild prints its elapsed-time line on failure as well as success, so the tail showed what looked like a clean result. The demo server was then started with `--no-build`, which happily served the **previous** build — the select-based version, which did compile. So the browser check I ran was real, but against markup I had already replaced.

There was a signal I dismissed: when probing the page I looked for a button labelled "Change" and it wasn't in the list. I put that down to the probe only sampling the first ten buttons. It was actually the stale build telling me.

## Verified this time

- **Exit codes, not tail** — all three demo hosts built: Server, Wasm and Auto, each `exit 0`, 0 warnings, 0 errors.
- Full test suite: 70/70, `run-tests exit=0`.
- Browser, against a freshly built output with the server restarted: the Change button renders at 36px (matching `Small`), clicking it cycles `dev` → `staging` and the copy value follows, and copying reaches the `Copied!` state.
