### PR TITLE
feat: add native dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-08-13
+
+### Added
+
+- **Native `<dialog>` rendering strategy for `BbDialog`** — A new opt-in rendering path that drives the browser's built-in `<dialog>` element instead of the portal + Floating UI handshake. It is the first step of the phased plan in [#376](https://github.com/blazorblueprintui/ui/discussions/376), and it directly fixes [#479](https://github.com/blazorblueprintui/ui/issues/479): portaled overlays stop working when `BbPortalHost` and the interactive content that opens them live in different render-mode scopes (e.g. a static layout hosting an `InteractiveWebAssembly` island), because each scope gets its own scoped `PortalService`. A native `<dialog>` lives in the browser's top layer regardless of DOM position and supplies its own focus trap, Escape handling and `::backdrop`, so `BbDialogPortal` renders inline and no shared scoped service or portal host is needed at all — the dialog simply works across render-mode boundaries. It is additive and non-breaking: the default remains the existing JS path.
+    - Choose per-component with `BbDialog RenderingStrategy="OverlayRenderingStrategy.Native"`, or opt the whole app in by passing a configure action to `AddBlazorBlueprintPrimitives(o => o.DefaultStrategy = OverlayRenderingStrategy.Native)`.
+    - A new scoped `INativeOverlayService` resolves the effective strategy and drives the `<dialog>`; `native-dialog.js` detects `showModal()` support (cached) so an unsupported browser degrades safely rather than breaking.
+    - When native is active, `BbDialogContent` skips the JS focus-trap / scroll-lock / escape-key modules and `BbDialogOverlay` renders nothing (the `::backdrop` is the scrim). `CloseOnEscape`, `CloseOnOverlayClick` and `OnEscapeKeyDown` are honoured through native `cancel`/`close`/backdrop events.
+    - The styled components-layer `BbDialogContent` keeps the same fixed, centred presentation as the JS path (so the design is identical) while the native `<dialog>` additionally enters the top layer via `showModal()`; `dialog`/`::backdrop` CSS provides the scrim and sizing resets. A `dialog[data-state]` reset lives in the low-priority `components` layer so the component's own Tailwind utilities (padding, max-width, border, background, shadow) win over it. The reset pins `border-color` to `var(--border)` — without it the UA/`currentColor` fallback renders a far-too-bright border on dark backgrounds.
+    - AlertDialog, Sheet and the positioned overlays (Popover, Tooltip, Select, etc.) still use the portal path and are the follow-on phases of #376.
+    - `native-dialog.js` avoids top-level `let`/`const`/`class` bindings: Blazor WebAssembly's dynamic `import()` can re-evaluate an ES module in a shared scope, and top-level lexical bindings then collide with "Identifier has already been declared" (which surfaced in WASM as the dialog rendering but never entering the top layer). It uses `function` declarations and `globalThis`-cached state instead, which survive that re-evaluation.
+    - The Dialog demo page gains two examples: the inline `RenderingStrategy="Native"` dialog, and a programmatic `DialogService.OpenAsync<T>()` example whose content component closes via the cascaded `IDialogReference.CloseAsync(...)` (noting that `BbDialogClose` does not close a programmatic dialog — there is no `DialogContext` in the `OpenAsync` path).
+
+---
+
 ## 2026-08-07
 
 ### Added

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dialog/native-service.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dialog/native-service.txt
@@ -1,0 +1,38 @@
+@* Open a dialog programmatically with DialogService.OpenAsync<T>() *@
+@inject DialogService DialogService
+
+<BbButton OnClick="OpenNativeService">Open via DialogService</BbButton>
+
+<span>@nativeServiceResult</span>
+
+@code {
+    private string nativeServiceResult = "-";
+
+    private async Task OpenNativeService()
+    {
+        var result = await DialogService.OpenAsync<NativeDialogBodyComponent>(
+            new Dictionary<string, object?>
+            {
+                ["Message"] = "Opened with OpenAsync<T>()"
+            },
+            new DialogOpenOptions
+            {
+                Title = "Native-Style Dialog",
+                Size = DialogSize.Default
+            });
+
+        nativeServiceResult = result.Cancelled ? "Cancelled" : "Closed";
+    }
+
+    // Content component. Note: BbDialogClose does NOT close a programmatic
+    // dialog (there is no DialogContext here) — close via IDialogReference.
+    public sealed class NativeDialogBodyComponent : ComponentBase
+    {
+        [Parameter] public string Message { get; set; } = "";
+
+        [CascadingParameter]
+        public IDialogReference DialogRef { get; set; } = default!;
+
+        private Task Close() => DialogRef.CloseAsync(DialogResult.Ok());
+    }
+}

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dialog/native.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dialog/native.txt
@@ -1,0 +1,17 @@
+<BbDialog RenderingStrategy="OverlayRenderingStrategy.Native">
+    <BbDialogTrigger AsChild="false" class="...">
+        Open Native Dialog
+    </BbDialogTrigger>
+
+    <BbDialogContent>
+        <BbDialogHeader>
+            <BbDialogTitle>Native dialog</BbDialogTitle>
+            <BbDialogDescription>
+                This dialog is a native &lt;dialog&gt; element shown with showModal().
+            </BbDialogDescription>
+        </BbDialogHeader>
+        <BbDialogFooter>
+            <BbDialogClose AsChild="false" class="...">Close</BbDialogClose>
+        </BbDialogFooter>
+    </BbDialogContent>
+</BbDialog>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DialogDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DialogDemo.razor
@@ -1,4 +1,5 @@
 @page "/components/dialog"
+@using BlazorBlueprint.Primitives.Services
 @inject DialogService DialogService
 <PageTitle>Dialog Component - Blazor Blueprint</PageTitle>
 
@@ -38,6 +39,67 @@
         </BbDialog>
 
         <CodeBlock Source="Components/Dialog/simple.txt" />
+    </div>
+
+    <div class="space-y-4">
+        <h2 class="text-2xl font-semibold">Native Dialog</h2>
+        <p class="text-sm text-muted-foreground">
+            The same dialog rendered through the browser's built-in <code class="text-xs bg-muted px-1 py-0.5 rounded">&lt;dialog&gt;</code>
+            element via <code class="text-xs bg-muted px-1 py-0.5 rounded">RenderingStrategy="Native"</code>. It lives in the
+            top layer and uses the browser's native focus trap, Escape handling and backdrop, so it needs no
+            <code class="text-xs bg-muted px-1 py-0.5 rounded">BbPortalHost</code> and works across Blazor render-mode
+            boundaries (e.g. <code class="text-xs bg-muted px-1 py-0.5 rounded">InteractiveWebAssembly</code>).
+        </p>
+
+        <BbDialog RenderingStrategy="OverlayRenderingStrategy.Native">
+            <BbDialogTrigger AsChild="false" class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
+                Open Native Dialog
+            </BbDialogTrigger>
+
+            <BbDialogContent>
+                <BbDialogHeader>
+                    <BbDialogTitle>Native dialog</BbDialogTitle>
+                    <BbDialogDescription>
+                        This dialog is a native <code class="text-xs bg-muted px-1 py-0.5 rounded">&lt;dialog&gt;</code> element
+                        shown with <code class="text-xs bg-muted px-1 py-0.5 rounded">showModal()</code>. Press Escape or click the
+                        backdrop to dismiss.
+                    </BbDialogDescription>
+                </BbDialogHeader>
+                <BbDialogFooter>
+                    <BbDialogClose AsChild="false" class="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">
+                        Close
+                    </BbDialogClose>
+                </BbDialogFooter>
+            </BbDialogContent>
+        </BbDialog>
+
+        <CodeBlock Source="Components/Dialog/native.txt" />
+    </div>
+
+    <div class="space-y-4">
+        <h2 class="text-2xl font-semibold">Native Dialog via DialogService</h2>
+        <p class="text-sm text-muted-foreground">
+            Open the same dialog programmatically with
+            <code class="text-xs bg-muted px-1 py-0.5 rounded">DialogService.OpenAsync&lt;T&gt;()</code>. The content is a
+            self-contained component rendered by the dialog provider.
+        </p>
+        <div class="p-4 border-l-4 border-amber-500 bg-amber-500/5 rounded-r-lg">
+            <p class="text-sm text-muted-foreground">
+                <strong>Note:</strong> <code class="text-xs bg-muted px-1 py-0.5 rounded">BbDialogClose</code> does not close a
+                programmatic dialog — it drives a <code class="text-xs bg-muted px-1 py-0.5 rounded">DialogContext</code>, which the
+                <code class="text-xs bg-muted px-1 py-0.5 rounded">OpenAsync</code> path does not provide. Close a programmatic dialog
+                from its content by calling the cascaded
+                <code class="text-xs bg-muted px-1 py-0.5 rounded">IDialogReference.CloseAsync(...)</code> instead, exactly as the
+                custom component below does.
+            </p>
+        </div>
+
+        <div class="flex items-center gap-4">
+            <BbButton OnClick="HandleOpenNativeService">Open via DialogService</BbButton>
+            <span class="text-sm text-muted-foreground">@nativeServiceResult</span>
+        </div>
+
+        <CodeBlock Source="Components/Dialog/native-service.txt" />
     </div>
 
     <div class="space-y-4">
@@ -724,6 +786,12 @@
                 <ApiParameter Name="Modal" Type="bool" Default="true">
                     Whether the dialog is modal. Modal dialogs trap focus and lock scroll.
                 </ApiParameter>
+                <ApiParameter Name="RenderingStrategy" Type="OverlayRenderingStrategy?" Default="null">
+                    Overrides how the dialog renders. <code>Native</code> uses the browser's built-in
+                    <code>&lt;dialog&gt;</code> element (top layer, native focus trap/Escape/backdrop), which needs no
+                    portal host and works across render-mode boundaries (e.g. InteractiveWebAssembly). When null, the
+                    global default from <code>AddBlazorBlueprintPrimitives(configureOverlays)</code> applies.
+                </ApiParameter>
                 <ApiParameter Name="OnOpenChange" Type="EventCallback&lt;bool&gt;">
                     Event callback invoked when the dialog open state changes.
                 </ApiParameter>
@@ -946,6 +1014,7 @@
     private string alertStatus = "Idle";
     private string promptResult = "-";
     private string customResult = "-";
+    private string nativeServiceResult = "-";
 
     // Form in Dialog
     private string? formFirstName;
@@ -1070,6 +1139,42 @@
         {
             customResult = "Cancelled";
         }
+    }
+
+    private async Task HandleOpenNativeService()
+    {
+        var result = await DialogService.OpenAsync<NativeDialogBodyComponent>(
+            new Dictionary<string, object?>
+            {
+                ["Message"] = "This dialog was opened with DialogService.OpenAsync<T>(). Its Close button calls IDialogReference.CloseAsync() — BbDialogClose is not usable in the programmatic path."
+            },
+            new DialogOpenOptions
+            {
+                Title = "Native-Style Dialog",
+                Size = DialogSize.Default
+            });
+
+        nativeServiceResult = result.Cancelled ? "Cancelled" : "Closed";
+    }
+
+    public sealed class NativeDialogBodyComponent : ComponentBase
+    {
+        [Parameter] public string Message { get; set; } = "";
+
+        [CascadingParameter]
+        public IDialogReference DialogRef { get; set; } = default!;
+
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
+        {
+            <div class="space-y-4">
+                <p class="text-sm text-muted-foreground">@Message</p>
+                <div class="flex justify-end gap-2">
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="Close">Close</BbButton>
+                </div>
+            </div>
+        }
+
+        private Task Close() => DialogRef.CloseAsync(DialogResult.Ok());
     }
 
     public sealed class EditUserDemoComponent : ComponentBase

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Guides/RenderModesGuide.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Guides/RenderModesGuide.razor
@@ -162,6 +162,33 @@
             </p>
         </section>
 
+        <!-- Native overlays across render modes -->
+        <section class="space-y-4">
+            <h2 class="text-2xl font-semibold">Overlays across render-mode boundaries (Dialog &rarr; native)</h2>
+            <p class="text-muted-foreground leading-relaxed">
+                The default portal-based overlays need <code class="text-xs bg-muted px-1 py-0.5 rounded">BbPortalHost</code>
+                to live in the <strong>same</strong> render-mode scope as the interactive content that opens them.
+                If a <code class="text-xs bg-muted px-1 py-0.5 rounded">BbDialog</code> is opened from an
+                <code class="text-xs bg-muted px-1 py-0.5 rounded">InteractiveWebAssembly</code> island but the host is
+                in a static layout, they use different scoped <code class="text-xs bg-muted px-1 py-0.5 rounded">PortalService</code>
+                instances &mdash; you get &ldquo;No &lt;PortalHost /&gt; detected&rdquo; and a
+                &ldquo;timed out waiting for PortalHost to render&rdquo; warning, and the dialog never appears.
+            </p>
+            <p class="text-muted-foreground leading-relaxed">
+                For <strong>Dialog</strong> there is a second option that sidesteps the scoped-service handshake entirely:
+                render it as a native <code class="text-xs bg-muted px-1 py-0.5 rounded">&lt;dialog&gt;</code> element. Set
+                <code class="text-xs bg-muted px-1 py-0.5 rounded">RenderingStrategy="OverlayRenderingStrategy.Native"</code>
+                on <code class="text-xs bg-muted px-1 py-0.5 rounded">BbDialog</code> (or set the global default via
+                <code class="text-xs bg-muted px-1 py-0.5 rounded">AddBlazorBlueprintPrimitives(o =&gt; o.DefaultStrategy = OverlayRenderingStrategy.Native)</code>).
+                The browser shows the dialog in the top layer with native focus trapping, Escape handling and a
+                <code class="text-xs bg-muted px-1 py-0.5 rounded">::backdrop</code> &mdash; no portal host, no shared
+                scoped service, so it works across <code class="text-xs bg-muted px-1 py-0.5 rounded">InteractiveWebAssembly</code>
+                islands and static layouts. It falls back to the JS path automatically if the browser lacks
+                <code class="text-xs bg-muted px-1 py-0.5 rounded">showModal()</code>. Other overlay components (Popover,
+                Tooltip, Select, Sheet, AlertDialog) still use the portal path for now.
+            </p>
+        </section>
+
         <!-- Troubleshooting -->
         <section class="space-y-4">
             <h2 class="text-2xl font-semibold">Troubleshooting checklist</h2>

--- a/src/BlazorBlueprint.Components/Components/Dialog/BbDialog.razor
+++ b/src/BlazorBlueprint.Components/Components/Dialog/BbDialog.razor
@@ -1,4 +1,5 @@
 @namespace BlazorBlueprint.Components
+@using BlazorBlueprint.Primitives.Services
 
 @*
     Styled Dialog component wrapper.
@@ -10,7 +11,8 @@
                                          DefaultOpen="@DefaultOpen"
                                          OnOpenChange="@OnOpenChange"
                                          Modal="@Modal"
-                                         @attributes="AdditionalAttributes">
+                                         @attributes="AdditionalAttributes"
+                                         RenderingStrategy="@RenderingStrategy">
     @ChildContent
 </BlazorBlueprint.Primitives.Dialog.BbDialog>
 
@@ -59,4 +61,15 @@
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    /// <summary>
+    /// Overrides how this dialog renders. When null, the global default configured via
+    /// <c>AddBlazorBlueprintPrimitives(configureOverlays)</c> applies.
+    /// <see cref="OverlayRenderingStrategy.Native"/> renders through the browser's built-in
+    /// <c>&lt;dialog&gt;</c> element, which works across Blazor render-mode boundaries
+    /// (e.g. InteractiveWebAssembly) without a portal host.
+    /// Defaults to null (use global default, which is <see cref="OverlayRenderingStrategy.JavaScript"/>).
+    /// </summary>
+    [Parameter]
+    public OverlayRenderingStrategy? RenderingStrategy { get; set; }
 }

--- a/src/BlazorBlueprint.Components/Components/Dialog/BbDialog.razor
+++ b/src/BlazorBlueprint.Components/Components/Dialog/BbDialog.razor
@@ -69,6 +69,7 @@
     /// <c>&lt;dialog&gt;</c> element, which works across Blazor render-mode boundaries
     /// (e.g. InteractiveWebAssembly) without a portal host.
     /// Defaults to null (use global default, which is <see cref="OverlayRenderingStrategy.JavaScript"/>).
+    /// The strategy is resolved once on the first render; changing it afterwards has no effect.
     /// </summary>
     [Parameter]
     public OverlayRenderingStrategy? RenderingStrategy { get; set; }

--- a/src/BlazorBlueprint.Components/Components/Dialog/BbDialogContent.razor
+++ b/src/BlazorBlueprint.Components/Components/Dialog/BbDialogContent.razor
@@ -1,19 +1,27 @@
 @namespace BlazorBlueprint.Components
 @using BlazorBlueprint.Icons.Lucide.Components
+@using BlazorBlueprint.Primitives.Services
 @inject IBbLocalizer Localizer
+@inject INativeOverlayService NativeOverlayService
 
 @*
     Styled DialogContent component with shadcn/ui classes.
     Includes overlay, dialog box, and close button.
+    When the effective rendering strategy is Native, the overlay is omitted (the browser's
+    <dialog>::backdrop provides the scrim) and the dialog box is styled for the top layer.
 *@
 
 <BlazorBlueprint.Primitives.Dialog.BbDialogPortal Container="@Container">
-    <BlazorBlueprint.Primitives.Dialog.BbDialogOverlay class="fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
-                                                       CloseOnClick="@CloseOnOverlayClick" />
+    @if (!_useNative)
+    {
+        <BlazorBlueprint.Primitives.Dialog.BbDialogOverlay class="fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+                                                           CloseOnClick="@CloseOnOverlayClick" />
+    }
 
     <BlazorBlueprint.Primitives.Dialog.BbDialogContent
         class="@GetClassNames()"
         CloseOnEscape="@CloseOnEscape"
+        CloseOnOverlayClick="@CloseOnOverlayClick"
         TrapFocus="@TrapFocus"
         InitialFocus="@InitialFocus"
         InitialFocusElement="@InitialFocusElement"
@@ -33,6 +41,9 @@
 </BlazorBlueprint.Primitives.Dialog.BbDialogPortal>
 
 @code {
+    [CascadingParameter(Name = "DialogRenderingStrategy")]
+    private OverlayRenderingStrategy? RenderingStrategy { get; set; }
+
     /// <summary>
     /// The content to render inside the dialog.
     /// </summary>
@@ -121,17 +132,28 @@
     [Parameter]
     public EventCallback<KeyboardEventArgs> OnEscapeKeyDown { get; set; }
 
+    private bool _useNative;
+
+    protected override void OnInitialized()
+    {
+        _useNative = NativeOverlayService.ResolveStrategy(RenderingStrategy) == OverlayRenderingStrategy.Native;
+    }
+
     /// <summary>
     /// Gets the computed CSS classes for the dialog content.
     /// Uses the cn() utility for intelligent class merging and Tailwind conflict resolution.
+    /// Both rendering strategies use the same fixed, centred presentation — the native path
+    /// additionally enters the top layer via showModal() for its backdrop/focus-trap/inertness,
+    /// so no separate positioning branch is needed.
     /// </summary>
-    private string GetClassNames() => ClassNames.cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%]",
-        "gap-4 border bg-background p-6 shadow-lg duration-200",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out",
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-        "sm:rounded-lg",
-        Class
-    );
+    private string GetClassNames() =>
+        ClassNames.cn(
+            "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%]",
+            "gap-4 border bg-background p-6 shadow-lg duration-200",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+            "sm:rounded-lg",
+            Class
+        );
 }

--- a/src/BlazorBlueprint.Components/wwwroot/css/blazorblueprint-input.css
+++ b/src/BlazorBlueprint.Components/wwwroot/css/blazorblueprint-input.css
@@ -871,6 +871,36 @@
 
 } /* end @layer bb */
 
+/* Native <dialog> rendering (OverlayRenderingStrategy.Native).
+   Deliberately OUTSIDE @layer bb (and in @layer components, below utilities) so the
+   component's own Tailwind classes (p-6, max-w-lg, border, bg-background, shadow-lg)
+   override these reset defaults. showModal() puts the dialog in the top layer (native
+   focus trap, inert background and ::backdrop scrim); positioning is the same fixed,
+   centred set the JS path uses, so no margin/inset rules are needed here. */
+@layer components {
+  dialog[data-state] {
+    max-height: calc(100dvh - 2rem);
+    overflow: auto;
+    padding: 0;
+    color: var(--foreground);
+    background: var(--background);
+    /* Reset the UA's opaque default border but keep the theme border colour so the
+       Tailwind `border` utility yields the same subtle border as the JS path (which
+       reads var(--border)); without this the border falls back to currentColor and is
+       far too bright on dark backgrounds. */
+    border: 0 solid var(--border);
+  }
+
+  dialog[data-state="open"]::backdrop {
+    background: rgb(0 0 0 / 0.8);
+    backdrop-filter: blur(2px);
+  }
+
+  dialog[data-state="open"] {
+    outline: none;
+  }
+}
+
 /* Alert countdown bar animation. Keyframes are not subject to cascade
    layers, so left at top level. */
 @keyframes bb-alert-countdown {

--- a/src/BlazorBlueprint.Primitives/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BlazorBlueprint.Primitives/Extensions/ServiceCollectionExtensions.cs
@@ -12,9 +12,22 @@ public static class ServiceCollectionExtensions
     /// Adds all BlazorBlueprint.Primitives primitive services to the service collection.
     /// </summary>
     /// <param name="services">The service collection.</param>
+    /// <param name="configureOverlays">Optional action to configure overlay rendering options
+    /// (e.g. opt the whole app into native <c>&lt;dialog&gt;</c> rendering).</param>
     /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection AddBlazorBlueprintPrimitives(this IServiceCollection services)
+    public static IServiceCollection AddBlazorBlueprintPrimitives(
+        this IServiceCollection services,
+        Action<OverlayRenderingOptions>? configureOverlays = null)
     {
+        // Overlay rendering options (global default strategy). Registered as singleton so the
+        // resolved default is consistent across all render-mode scopes.
+        var overlayOptions = new OverlayRenderingOptions();
+        configureOverlays?.Invoke(overlayOptions);
+        services.AddSingleton(overlayOptions);
+
+        // Native overlay service (capability detection + native <dialog> driving).
+        services.AddScoped<INativeOverlayService, NativeOverlayService>();
+
         // Register PortalService as scoped for user isolation in Blazor Server
         // Each user session gets its own portal registry
         services.AddScoped<IPortalService, PortalService>();

--- a/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialog.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialog.razor
@@ -1,8 +1,11 @@
 @namespace BlazorBlueprint.Primitives.Dialog
+@using BlazorBlueprint.Primitives.Services
 
 @* Dialog primitive root component - headless, unstyled behavior only *@
 <CascadingValue Value="@_context" IsFixed="false">
-    @ChildContent
+    <CascadingValue TValue="OverlayRenderingStrategy?" Name="DialogRenderingStrategy" Value="@RenderingStrategy" IsFixed="false">
+        @ChildContent
+    </CascadingValue>
 </CascadingValue>
 
 @code {
@@ -28,6 +31,17 @@
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Overrides how this dialog renders. When null, the global default configured via
+    /// <c>AddBlazorBlueprintPrimitives(configureOverlays)</c> applies.
+    /// <see cref="OverlayRenderingStrategy.Native"/> renders through the browser's built-in
+    /// <c>&lt;dialog&gt;</c> element (top layer, native focus trap, Escape and backdrop),
+    /// which works across Blazor render-mode boundaries and needs no portal host.
+    /// Defaults to null (use global default, which is <see cref="OverlayRenderingStrategy.JavaScript"/>).
+    /// </summary>
+    [Parameter]
+    public OverlayRenderingStrategy? RenderingStrategy { get; set; }
 
     /// <summary>
     /// Controls whether the dialog is open (controlled mode).

--- a/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialog.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialog.razor
@@ -39,6 +39,7 @@
     /// <c>&lt;dialog&gt;</c> element (top layer, native focus trap, Escape and backdrop),
     /// which works across Blazor render-mode boundaries and needs no portal host.
     /// Defaults to null (use global default, which is <see cref="OverlayRenderingStrategy.JavaScript"/>).
+    /// The strategy is resolved once on the first render; changing it afterwards has no effect.
     /// </summary>
     [Parameter]
     public OverlayRenderingStrategy? RenderingStrategy { get; set; }

--- a/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialogContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialogContent.razor
@@ -84,6 +84,10 @@ else if (Context.IsOpen)
     /// <summary>
     /// Whether to trap focus within the dialog.
     /// Default is true for modal dialogs.
+    /// <para>
+    /// Under <see cref="OverlayRenderingStrategy.Native"/> the browser's <c>&lt;dialog&gt;</c>
+    /// always traps focus for a modal, so setting this to <c>false</c> has no effect in that mode.
+    /// </para>
     /// </summary>
     [Parameter]
     public bool TrapFocus { get; set; } = true;
@@ -111,6 +115,11 @@ else if (Context.IsOpen)
     /// <summary>
     /// Whether to lock body scroll when dialog is open.
     /// Default is true for modal dialogs.
+    /// <para>
+    /// Under <see cref="OverlayRenderingStrategy.Native"/> this is not applied: <c>showModal()</c>
+    /// makes the background inert to interaction but does not stop it scrolling, and there is no
+    /// scroll-lock on the native path.
+    /// </para>
     /// </summary>
     [Parameter]
     public bool LockScroll { get; set; } = true;
@@ -181,7 +190,6 @@ else if (Context.IsOpen)
                 _nativeDialogSetup = await NativeOverlayService.SetupDialogAsync(_contentRef, _dotNetRef);
 
                 await NativeOverlayService.ShowDialogAsync(_contentRef);
-                await NativeOverlayService.FocusDialogAsync(_contentRef);
             }
             catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException or InvalidOperationException)
             {
@@ -297,6 +305,7 @@ else if (Context.IsOpen)
 
         if (CloseOnEscape)
         {
+            await CloseNativeDialogAsync();
             Context.Close();
         }
     }
@@ -318,16 +327,33 @@ else if (Context.IsOpen)
 
     [JSInvokable]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public Task JsOnNativeBackdropClick()
+    public async Task JsOnNativeBackdropClick()
     {
-        if (_disposed) { return Task.CompletedTask; }
+        if (_disposed) { return; }
 
         if (CloseOnOverlayClick)
         {
+            await CloseNativeDialogAsync();
             Context.Close();
         }
+    }
 
-        return Task.CompletedTask;
+    /// <summary>
+    /// Closes the native <c>&lt;dialog&gt;</c> element itself, restoring focus to the trigger,
+    /// before the open state flips to <c>false</c> and the element is unmounted. Closing via the
+    /// element (rather than relying on Blazor removing it from the DOM) is what lets the browser
+    /// return focus to the element that had it before <c>showModal()</c>.
+    /// </summary>
+    private async Task CloseNativeDialogAsync()
+    {
+        try
+        {
+            await NativeOverlayService.CloseDialogAsync(_contentRef);
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
+        {
+            // Expected during circuit disconnect.
+        }
     }
 
     // ---- JS strategy (legacy) ----

--- a/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialogContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialogContent.razor
@@ -1,15 +1,37 @@
 @namespace BlazorBlueprint.Primitives.Dialog
 @using System.ComponentModel
+@using Microsoft.Extensions.Logging
+@using BlazorBlueprint.Primitives.Services
 @inject IFocusManager FocusManager
 @inject IJSRuntime JSRuntime
+@inject INativeOverlayService NativeOverlayService
+@inject ILogger<BbDialogContent> Logger
 @implements IAsyncDisposable
 
 @*
     DialogContent is the main content container for the dialog.
-    Handles focus trap, escape key, scroll lock, and ARIA attributes.
+    - JS strategy (default): renders a div, uses JS focus trap, escape key and scroll lock.
+    - Native strategy: renders a <dialog> element driven with showModal()/close(). The
+      browser provides the top layer, focus trap, Escape handling and ::backdrop, so the JS
+      focus-trap / scroll-lock / escape modules are skipped. Native rendering needs no portal
+      host and works across Blazor render-mode boundaries (e.g. InteractiveWebAssembly).
 *@
 
-@if (Context.IsOpen)
+@if (_useNative)
+{
+    @if (Context.IsOpen)
+    {
+        <dialog @ref="_contentRef"
+                id="@Context.ContentId"
+                aria-labelledby="@Context.TitleId"
+                aria-describedby="@Context.DescriptionId"
+                @attributes="AdditionalAttributes"
+                data-state="open">
+            @ChildContent
+        </dialog>
+    }
+}
+else if (Context.IsOpen)
 {
     <div @ref="_contentRef"
          id="@Context.ContentId"
@@ -27,6 +49,9 @@
 @code {
     [CascadingParameter]
     private DialogContext Context { get; set; } = null!;
+
+    [CascadingParameter(Name = "DialogRenderingStrategy")]
+    private OverlayRenderingStrategy? RenderingStrategy { get; set; }
 
     /// <summary>
     /// The content to render inside the dialog.
@@ -46,6 +71,15 @@
     /// </summary>
     [Parameter]
     public bool CloseOnEscape { get; set; } = true;
+
+    /// <summary>
+    /// Whether clicking the overlay (backdrop) should close the dialog.
+    /// Native strategy only: the browser's ::backdrop is not dismissible by default,
+    /// so this is honoured through a backdrop click listener.
+    /// Default is true.
+    /// </summary>
+    [Parameter]
+    public bool CloseOnOverlayClick { get; set; } = true;
 
     /// <summary>
     /// Whether to trap focus within the dialog.
@@ -96,6 +130,9 @@
     private string _instanceId = Guid.NewGuid().ToString("N");
     private bool _isInitialized = false;
     private bool _disposed;
+    private bool _useNative;
+    private bool _nativeInitialized = false;
+    private IAsyncDisposable? _nativeDialogSetup;
 
     protected override void OnInitialized()
     {
@@ -106,11 +143,58 @@
                 "Ensure DialogContent is a child of a Dialog component.");
         }
 
+        _useNative = NativeOverlayService.ResolveStrategy(RenderingStrategy) == OverlayRenderingStrategy.Native;
+
         // Subscribe to context changes
         Context.OnStateChanged += HandleContextStateChanged;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_useNative)
+        {
+            await HandleNativeLifecycleAsync();
+            return;
+        }
+
+        await HandleJsLifecycleAsync();
+    }
+
+    private async Task HandleNativeLifecycleAsync()
+    {
+        if (Context.IsOpen && !_nativeInitialized)
+        {
+            _nativeInitialized = true;
+
+            try
+            {
+                // Diagnostic only — if native was requested but the browser lacks showModal(),
+                // the element still renders but cannot enter the top layer.
+                if (!await NativeOverlayService.IsDialogSupportedAsync())
+                {
+                    Logger.LogWarning(
+                        "Dialog '{DialogId}' uses OverlayRenderingStrategy.Native but the browser does not support " +
+                        "<dialog>.showModal(); the dialog will not render as a modal.", Context.ContentId);
+                }
+
+                _dotNetRef ??= DotNetObjectReference.Create(this);
+                _nativeDialogSetup = await NativeOverlayService.SetupDialogAsync(_contentRef, _dotNetRef);
+
+                await NativeOverlayService.ShowDialogAsync(_contentRef);
+                await NativeOverlayService.FocusDialogAsync(_contentRef);
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException or InvalidOperationException)
+            {
+                // Expected during circuit disconnect or prerendering.
+            }
+        }
+        else if (!Context.IsOpen && _nativeInitialized)
+        {
+            await CleanupNativeAsync();
+        }
+    }
+
+    private async Task HandleJsLifecycleAsync()
     {
         if (Context.IsOpen && !_isInitialized)
         {
@@ -171,18 +255,25 @@
         }
         else if (!Context.IsOpen && _isInitialized)
         {
-            await CleanupAsync();
+            await CleanupJsAsync();
         }
     }
 
     private void HandleContextStateChanged()
     {
-        if (!Context.IsOpen && _isInitialized)
+        if (!Context.IsOpen && (_isInitialized || _nativeInitialized))
         {
             // Dialog closed, clean up on the Blazor sync context
             _ = InvokeAsync(async () =>
             {
-                await CleanupAsync();
+                if (_useNative)
+                {
+                    await CleanupNativeAsync();
+                }
+                else
+                {
+                    await CleanupJsAsync();
+                }
                 StateHasChanged();
             });
             return;
@@ -190,6 +281,56 @@
 
         StateHasChanged();
     }
+
+    // ---- Native dialog events (invoked from native-dialog.js) ----
+
+    [JSInvokable]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public async Task JsOnNativeCancel()
+    {
+        if (_disposed) { return; }
+
+        if (OnEscapeKeyDown.HasDelegate)
+        {
+            await OnEscapeKeyDown.InvokeAsync(new KeyboardEventArgs { Key = "Escape" });
+        }
+
+        if (CloseOnEscape)
+        {
+            Context.Close();
+        }
+    }
+
+    [JSInvokable]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public Task JsOnNativeClose()
+    {
+        if (_disposed) { return Task.CompletedTask; }
+
+        // Safety net: sync state if the dialog was closed natively.
+        if (Context.IsOpen)
+        {
+            Context.Close();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    [JSInvokable]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public Task JsOnNativeBackdropClick()
+    {
+        if (_disposed) { return Task.CompletedTask; }
+
+        if (CloseOnOverlayClick)
+        {
+            Context.Close();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    // ---- JS strategy (legacy) ----
 
     [JSInvokable]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -210,7 +351,38 @@
         }
     }
 
-    private async Task CleanupAsync()
+    private async Task CleanupNativeAsync()
+    {
+        if (_nativeDialogSetup != null)
+        {
+            try
+            {
+                await _nativeDialogSetup.DisposeAsync();
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
+            {
+                // Cleanup may already be disposed or circuit disconnected.
+            }
+            _nativeDialogSetup = null;
+        }
+
+        // Ensure the dialog is closed if it was left open (e.g. ForceMount kept it mounted).
+        if (Context.IsOpen == false)
+        {
+            try
+            {
+                await NativeOverlayService.CloseDialogAsync(_contentRef);
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
+            {
+                // Expected during circuit disconnect.
+            }
+        }
+
+        _nativeInitialized = false;
+    }
+
+    private async Task CleanupJsAsync()
     {
         // Dispose focus trap
         if (_focusTrap != null)
@@ -256,7 +428,14 @@
     {
         _disposed = true;
 
-        await CleanupAsync();
+        if (_useNative)
+        {
+            await CleanupNativeAsync();
+        }
+        else
+        {
+            await CleanupJsAsync();
+        }
 
         if (_portalModule != null)
         {

--- a/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialogOverlay.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialogOverlay.razor
@@ -1,11 +1,15 @@
 @namespace BlazorBlueprint.Primitives.Dialog
+@using BlazorBlueprint.Primitives.Services
+@inject INativeOverlayService NativeOverlayService
 
 @*
     DialogOverlay provides a background overlay for modal dialogs.
     Can handle click-outside-to-close if configured.
+    In native strategy mode this renders nothing — the browser's <dialog>::backdrop
+    provides the scrim, and backdrop dismissal is handled by BbDialogContent.
 *@
 
-@if (Context.IsOpen)
+@if (!_useNative && Context.IsOpen)
 {
     <div id="@(Context.Id)-overlay"
          @onclick="HandleClick"
@@ -18,6 +22,9 @@
 @code {
     [CascadingParameter]
     private DialogContext Context { get; set; } = null!;
+
+    [CascadingParameter(Name = "DialogRenderingStrategy")]
+    private OverlayRenderingStrategy? RenderingStrategy { get; set; }
 
     /// <summary>
     /// The content to render within the overlay (typically empty for a simple backdrop).
@@ -44,6 +51,8 @@
     [Parameter]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
 
+    private bool _useNative;
+
     protected override void OnInitialized()
     {
         if (Context == null)
@@ -52,6 +61,8 @@
                 "DialogOverlay must be used within a Dialog component. " +
                 "Ensure DialogOverlay is a child of a Dialog component.");
         }
+
+        _useNative = NativeOverlayService.ResolveStrategy(RenderingStrategy) == OverlayRenderingStrategy.Native;
     }
 
     private async Task HandleClick(MouseEventArgs args)

--- a/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialogPortal.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialogPortal.razor
@@ -1,26 +1,36 @@
 @namespace BlazorBlueprint.Primitives.Dialog
+@using BlazorBlueprint.Primitives.Services
 @inject IPortalService PortalService
+@inject INativeOverlayService NativeOverlayService
 @implements IDisposable
 
 @*
     DialogPortal renders its content at the document body level using PortalService.
     This ensures proper z-index stacking for overlays.
     When Container is set, renders inline instead (for contained scenarios).
+    When the effective rendering strategy is Native, renders inline too: the native
+    <dialog> element lives in the browser's top layer regardless of DOM position, so no
+    portal relocation or shared scoped service is needed. This is what makes dialogs work
+    across Blazor render-mode boundaries (e.g. InteractiveWebAssembly).
 *@
 
-@if (!string.IsNullOrEmpty(Container))
+@if (!_useNative && string.IsNullOrEmpty(Container))
 {
-    @if (Context.IsOpen || ForceMount)
-    {
-        <CascadingValue Value="Context" IsFixed="false">
-            @ChildContent
-        </CascadingValue>
-    }
+    @* Default: render through the PortalService (JS strategy). *@
+}
+else if (Context.IsOpen || ForceMount)
+{
+    <CascadingValue Value="Context" IsFixed="false">
+        @ChildContent
+    </CascadingValue>
 }
 
 @code {
     [CascadingParameter]
     private DialogContext Context { get; set; } = null!;
+
+    [CascadingParameter(Name = "DialogRenderingStrategy")]
+    private OverlayRenderingStrategy? RenderingStrategy { get; set; }
 
     /// <summary>
     /// The content to render in the portal (typically DialogOverlay and DialogContent).
@@ -48,6 +58,7 @@
 
     private string _portalId = string.Empty;
     private bool _isRegistered = false;
+    private bool _useNative;
 
     protected override void OnInitialized()
     {
@@ -60,11 +71,15 @@
 
         _portalId = $"{Context.Id}-portal";
 
+        // Resolve the effective rendering strategy synchronously for this render.
+        _useNative = NativeOverlayService.ResolveStrategy(RenderingStrategy) == OverlayRenderingStrategy.Native;
+
         // Subscribe to context changes to update portal content
         Context.OnStateChanged += HandleStateChanged;
 
-        // When Container is set, content renders inline — skip portal registration
-        if (string.IsNullOrEmpty(Container))
+        // When Container is set or the native strategy is active, content renders inline —
+        // skip portal registration.
+        if (string.IsNullOrEmpty(Container) && !_useNative)
         {
             // Register initial portal if dialog is open or force mount
             if (Context.IsOpen || ForceMount)
@@ -76,8 +91,8 @@
 
     protected override void OnParametersSet()
     {
-        // When Container is set, content renders inline — skip portal registration
-        if (!string.IsNullOrEmpty(Container))
+        // When Container is set or native strategy is active, content renders inline — skip portal registration
+        if (!string.IsNullOrEmpty(Container) || _useNative)
         {
             UnregisterPortal();
             return;

--- a/src/BlazorBlueprint.Primitives/Services/INativeOverlayService.cs
+++ b/src/BlazorBlueprint.Primitives/Services/INativeOverlayService.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorBlueprint.Primitives.Services;
+
+/// <summary>
+/// Resolves the effective <see cref="OverlayRenderingStrategy"/> for a component and drives
+/// the browser's native overlay primitives (currently the <c>&lt;dialog&gt;</c> element).
+/// </summary>
+public interface INativeOverlayService
+{
+    /// <summary>
+    /// Gets whether the browser supports the native <c>&lt;dialog&gt;</c> element's
+    /// <c>showModal()</c>. Resolved once per scope and cached. Returns false when JS interop
+    /// is unavailable (e.g. during prerendering). Used for diagnostics when native is requested.
+    /// </summary>
+    Task<bool> IsDialogSupportedAsync();
+
+    /// <summary>
+    /// Resolves the strategy a component should render with, synchronously (safe to call during
+    /// render). A non-null <paramref name="requested"/> (the component's own parameter) wins;
+    /// otherwise the global default applies.
+    /// </summary>
+    OverlayRenderingStrategy ResolveStrategy(OverlayRenderingStrategy? requested);
+
+    /// <summary>
+    /// Opens a <c>&lt;dialog&gt;</c> element as a modal (top layer).
+    /// </summary>
+    Task ShowDialogAsync(ElementReference element);
+
+    /// <summary>
+    /// Closes a <c>&lt;dialog&gt;</c> element.
+    /// </summary>
+    Task CloseDialogAsync(ElementReference element, string? returnValue = null);
+
+    /// <summary>
+    /// Focuses a dialog's content after opening (falls back to first focusable element).
+    /// </summary>
+    Task FocusDialogAsync(ElementReference element);
+
+    /// <summary>
+    /// Restores focus to the element that opened the dialog.
+    /// </summary>
+    Task FocusTriggerAsync(ElementReference element);
+
+    /// <summary>
+    /// Wires native <c>&lt;dialog&gt;</c> lifecycle events (Escape/cancel, close, backdrop click)
+    /// to a .NET instance. The returned handle must be disposed to remove the listeners.
+    /// </summary>
+    Task<IAsyncDisposable> SetupDialogAsync(ElementReference element, object dotNetRef);
+}

--- a/src/BlazorBlueprint.Primitives/Services/NativeOverlayService.cs
+++ b/src/BlazorBlueprint.Primitives/Services/NativeOverlayService.cs
@@ -1,0 +1,182 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace BlazorBlueprint.Primitives.Services;
+
+/// <summary>
+/// Default implementation of <see cref="INativeOverlayService"/> backed by the
+/// <c>native-dialog.js</c> module.
+/// </summary>
+public class NativeOverlayService : INativeOverlayService, IAsyncDisposable
+{
+    private readonly IJSRuntime jsRuntime;
+    private readonly OverlayRenderingOptions options;
+    private readonly SemaphoreSlim moduleLock = new(1, 1);
+    private IJSObjectReference? module;
+    private bool? dialogSupported;
+    private bool disposed;
+
+    public NativeOverlayService(IJSRuntime jsRuntime, OverlayRenderingOptions options)
+    {
+        this.jsRuntime = jsRuntime;
+        this.options = options;
+    }
+
+    private async Task<IJSObjectReference> GetModuleAsync()
+    {
+        ObjectDisposedException.ThrowIf(disposed, nameof(NativeOverlayService));
+
+        await moduleLock.WaitAsync();
+        try
+        {
+            if (module == null)
+            {
+                module = await jsRuntime.InvokeAsync<IJSObjectReference>(
+                    "import", "./_content/BlazorBlueprint.Primitives/js/primitives/native-dialog.js");
+            }
+            return module;
+        }
+        finally
+        {
+            moduleLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsDialogSupportedAsync()
+    {
+        if (dialogSupported.HasValue)
+        {
+            return dialogSupported.Value;
+        }
+
+        try
+        {
+            var objectReference = await GetModuleAsync();
+            dialogSupported = await objectReference.InvokeAsync<bool>("supportsNativeDialog");
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException or InvalidOperationException)
+        {
+            // JS interop unavailable (prerendering / disconnect). Assume unsupported for now.
+            dialogSupported = false;
+        }
+
+        return dialogSupported.Value;
+    }
+
+    /// <inheritdoc />
+    public OverlayRenderingStrategy ResolveStrategy(OverlayRenderingStrategy? requested)
+        => requested ?? options.DefaultStrategy;
+
+    /// <inheritdoc />
+    public async Task ShowDialogAsync(ElementReference element)
+    {
+        try
+        {
+            var objectReference = await GetModuleAsync();
+            await objectReference.InvokeVoidAsync("showModal", element);
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException or InvalidOperationException)
+        {
+            // Expected during prerendering / disconnect.
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task CloseDialogAsync(ElementReference element, string? returnValue = null)
+    {
+        try
+        {
+            var objectReference = await GetModuleAsync();
+            await objectReference.InvokeVoidAsync("closeDialog", element, returnValue);
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException or InvalidOperationException)
+        {
+            // Expected during prerendering / disconnect.
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task FocusDialogAsync(ElementReference element)
+    {
+        try
+        {
+            var objectReference = await GetModuleAsync();
+            await objectReference.InvokeVoidAsync("focusDialog", element);
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException or InvalidOperationException)
+        {
+            // Expected during prerendering / disconnect.
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task FocusTriggerAsync(ElementReference element)
+    {
+        try
+        {
+            var objectReference = await GetModuleAsync();
+            await objectReference.InvokeVoidAsync("focusElement", element);
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException or InvalidOperationException)
+        {
+            // Expected during prerendering / disconnect.
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IAsyncDisposable> SetupDialogAsync(ElementReference element, object dotNetRef)
+    {
+        var objectReference = await GetModuleAsync();
+        var cleanup = await objectReference.InvokeAsync<IJSObjectReference>("setupDialog", element, dotNetRef);
+        return new NativeDialogHandle(cleanup);
+    }
+
+    private sealed class NativeDialogHandle : IAsyncDisposable
+    {
+        private readonly IJSObjectReference cleanup;
+
+        public NativeDialogHandle(IJSObjectReference cleanup)
+        {
+            this.cleanup = cleanup;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await cleanup.InvokeVoidAsync("dispose");
+                await cleanup.DisposeAsync();
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
+            {
+                // Cleanup may already be disposed or circuit disconnected.
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        GC.SuppressFinalize(this);
+        disposed = true;
+
+        if (module != null)
+        {
+            try
+            {
+                await module.DisposeAsync();
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+            {
+                // Expected during circuit disconnect.
+            }
+        }
+
+        moduleLock.Dispose();
+    }
+}

--- a/src/BlazorBlueprint.Primitives/Services/NativeOverlayService.cs
+++ b/src/BlazorBlueprint.Primitives/Services/NativeOverlayService.cs
@@ -45,23 +45,29 @@ public class NativeOverlayService : INativeOverlayService, IAsyncDisposable
     /// <inheritdoc />
     public async Task<bool> IsDialogSupportedAsync()
     {
-        if (dialogSupported.HasValue)
+        // Cache only a positive result. A false result may be a transient failure while JS
+        // interop is unavailable (prerendering / disconnect); caching it would make the
+        // "browser does not support" warning fire forever in a browser that supports it.
+        if (dialogSupported == true)
         {
-            return dialogSupported.Value;
+            return true;
         }
 
         try
         {
             var objectReference = await GetModuleAsync();
-            dialogSupported = await objectReference.InvokeAsync<bool>("supportsNativeDialog");
+            var supported = await objectReference.InvokeAsync<bool>("supportsNativeDialog");
+            if (supported)
+            {
+                dialogSupported = true;
+            }
+            return supported;
         }
         catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException or InvalidOperationException)
         {
             // JS interop unavailable (prerendering / disconnect). Assume unsupported for now.
-            dialogSupported = false;
+            return false;
         }
-
-        return dialogSupported.Value;
     }
 
     /// <inheritdoc />

--- a/src/BlazorBlueprint.Primitives/Services/OverlayRenderingOptions.cs
+++ b/src/BlazorBlueprint.Primitives/Services/OverlayRenderingOptions.cs
@@ -1,0 +1,16 @@
+namespace BlazorBlueprint.Primitives.Services;
+
+/// <summary>
+/// Global options controlling how BlazorBlueprint overlays render by default.
+/// Supplied via <c>AddBlazorBlueprintPrimitives(configure)</c> and read at run time.
+/// </summary>
+public class OverlayRenderingOptions
+{
+    /// <summary>
+    /// The default <see cref="OverlayRenderingStrategy"/> used by overlay components when
+    /// they do not specify one themselves. Defaults to <see cref="OverlayRenderingStrategy.JavaScript"/>,
+    /// preserving existing behaviour. Set to <see cref="OverlayRenderingStrategy.Native"/> to opt
+    /// the whole app into native rendering (with automatic fallback when a browser lacks support).
+    /// </summary>
+    public OverlayRenderingStrategy DefaultStrategy { get; set; } = OverlayRenderingStrategy.JavaScript;
+}

--- a/src/BlazorBlueprint.Primitives/Services/OverlayRenderingStrategy.cs
+++ b/src/BlazorBlueprint.Primitives/Services/OverlayRenderingStrategy.cs
@@ -1,0 +1,25 @@
+namespace BlazorBlueprint.Primitives.Services;
+
+/// <summary>
+/// Selects how portal-based overlay components (Dialog, and in future AlertDialog/Sheet,
+/// Popover, Tooltip, etc.) render and are positioned.
+/// </summary>
+public enum OverlayRenderingStrategy
+{
+    /// <summary>
+    /// Render through the Blazor portal system (scoped <see cref="PortalService"/> +
+    /// Floating UI positioning over JS interop). This is the original behaviour and the
+    /// default. It requires <c>&lt;BbPortalHost /&gt;</c> to live in the same render-mode
+    /// scope as the interactive content that opens overlays.
+    /// </summary>
+    JavaScript = 0,
+
+    /// <summary>
+    /// Use the browser's native primitives (e.g. <c>&lt;dialog&gt;</c> / <c>popover</c>)
+    /// which render in the top layer without a portal handshake or a shared scoped service.
+    /// This makes overlays work across Blazor render-mode boundaries (e.g.
+    /// <c>InteractiveWebAssembly</c>) and removes the JS focus-trap / scroll-lock /
+    /// escape-key machinery for the components that opt in.
+    /// </summary>
+    Native = 1
+}

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/native-dialog.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/native-dialog.js
@@ -1,0 +1,130 @@
+// Native <dialog> rendering helper for Blazor components.
+// Drives the browser's built-in <dialog> element (top layer, focus trap, Escape,
+// ::backdrop) instead of the JS focus-trap/scroll-lock/portal handshake. This
+// removes the scoped-service + render-handshake dependency that breaks portaled
+// overlays across Blazor render-mode boundaries (e.g. InteractiveWebAssembly).
+//
+// NOTE: this module deliberately uses only function declarations and globalThis
+// state — no top-level `let`/`const`/`class`. Blazor WebAssembly's dynamic
+// `import()` can re-evaluate a module in a shared scope, and top-level lexical
+// bindings then collide with "Identifier has already been declared". Function
+// declarations and globalThis assignments survive that re-evaluation safely.
+
+/**
+ * Detects whether the browser supports the native <dialog> element with showModal().
+ * Baseline: Chrome 37+, Firefox 98+, Safari 15.4+. Cached after the first call.
+ * @returns {boolean}
+ */
+export function supportsNativeDialog() {
+    if (globalThis.__bbSupportsNativeDialog !== undefined) {
+        return globalThis.__bbSupportsNativeDialog;
+    }
+    globalThis.__bbSupportsNativeDialog = typeof HTMLDialogElement !== 'undefined'
+        && typeof HTMLDialogElement.prototype.showModal === 'function';
+    return globalThis.__bbSupportsNativeDialog;
+}
+
+/**
+ * Opens a <dialog> element as a modal (top layer). No-op if already open.
+ * @param {HTMLDialogElement} element
+ */
+export function showModal(element) {
+    if (!element) {
+        return;
+    }
+    if (supportsNativeDialog() && !element.open) {
+        element.showModal();
+    }
+}
+
+/**
+ * Closes a <dialog> element. No-op if not open.
+ * @param {HTMLDialogElement} element
+ * @param {string|null} [returnValue]
+ */
+export function closeDialog(element, returnValue) {
+    if (!element) {
+        return;
+    }
+    if (supportsNativeDialog() && element.open) {
+        element.close(returnValue ?? null);
+    }
+}
+
+/**
+ * Focuses the dialog itself (the browser's native focus trap already confines
+ * Tab within a modal dialog). Falls back to the first focusable element.
+ * @param {HTMLDialogElement} element
+ */
+export function focusDialog(element) {
+    if (!element) {
+        return;
+    }
+    if (document.activeElement === element) {
+        return;
+    }
+    element.focus();
+    if (document.activeElement !== element) {
+        const focusable = element.querySelector(
+            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), '
+            + 'textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable) {
+            focusable.focus();
+        }
+    }
+}
+
+/**
+ * Focuses the element that opened the dialog, restoring the trigger's focus.
+ * @param {HTMLElement} element
+ */
+export function focusElement(element) {
+    if (element && typeof element.focus === 'function') {
+        element.focus();
+    }
+}
+
+// ============================================================================
+// Native <dialog> event wiring
+// Blazor cannot reliably distinguish a backdrop click from a content click, and
+// Escape (cancel) must be preventable so the component can honour CloseOnEscape.
+// These listeners forward the native events to .NET, which owns the close logic.
+// ============================================================================
+
+/**
+ * Wires native dialog lifecycle events to a .NET instance.
+ * Expects the .NET object to expose JSInvokable methods:
+ *   JsOnNativeCancel()          - Escape pressed (cancel is prevented here)
+ *   JsOnNativeClose()           - dialog closed (safety net)
+ *   JsOnNativeBackdropClick()   - click landed on the dialog itself (backdrop)
+ * @param {HTMLDialogElement} dialog
+ * @param {object} dotNetRef - a DotNetObjectReference
+ * @returns {{ dispose: () => void }}
+ */
+export function setupDialog(dialog, dotNetRef) {
+    const onCancel = (e) => {
+        e.preventDefault();
+        dotNetRef.invokeMethodAsync('JsOnNativeCancel');
+    };
+    const onClose = () => {
+        dotNetRef.invokeMethodAsync('JsOnNativeClose');
+    };
+    const onClick = (e) => {
+        if (e.target === dialog) {
+            dotNetRef.invokeMethodAsync('JsOnNativeBackdropClick');
+        }
+    };
+
+    dialog.addEventListener('cancel', onCancel);
+    dialog.addEventListener('close', onClose);
+    dialog.addEventListener('click', onClick);
+
+    return {
+        dispose: () => {
+            dialog.removeEventListener('cancel', onCancel);
+            dialog.removeEventListener('close', onClose);
+            dialog.removeEventListener('click', onClick);
+        }
+    };
+}

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/native-dialog.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/native-dialog.js
@@ -111,7 +111,20 @@ export function setupDialog(dialog, dotNetRef) {
         dotNetRef.invokeMethodAsync('JsOnNativeClose');
     };
     const onClick = (e) => {
-        if (e.target === dialog) {
+        // A native modal dialog fills the top layer, so both a click on the ::backdrop
+        // (outside the dialog) and a click on the dialog's own box (including its padding)
+        // resolve to e.target === dialog. Only the former is a backdrop dismissal; a click
+        // inside the dialog — padding included — must not close it. Compare the click point
+        // against the dialog's border box to tell them apart (the JS path renders content and
+        // overlay as separate elements, so it never conflates these).
+        if (e.target !== dialog) {
+            return;
+        }
+        const rect = dialog.getBoundingClientRect();
+        const x = e.clientX;
+        const y = e.clientY;
+        const insideBox = x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+        if (!insideBox) {
             dotNetRef.invokeMethodAsync('JsOnNativeBackdropClick');
         }
     };

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -1255,6 +1255,7 @@
   - OnOpenChange : EventCallback<Boolean>
   - Open : Boolean?
   - OpenChanged : EventCallback<Boolean>
+  - RenderingStrategy : OverlayRenderingStrategy?
 
 ### BbDialogClose (BlazorBlueprint.Components)
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
@@ -1276,6 +1277,7 @@
   - OnEscapeKeyDown : EventCallback<KeyboardEventArgs>
   - ShowClose : Boolean
   - TrapFocus : Boolean
+  - RenderingStrategy : OverlayRenderingStrategy? [CascadingParameter]
 
 ### BbDialogDescription (BlazorBlueprint.Components)
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]

--- a/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
@@ -233,6 +233,7 @@
   - OnOpenChange : EventCallback<Boolean>
   - Open : Boolean?
   - OpenChanged : EventCallback<Boolean>
+  - RenderingStrategy : OverlayRenderingStrategy?
 
 ### BbDialogClose (BlazorBlueprint.Primitives.Dialog)
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
@@ -246,12 +247,14 @@
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
   - ChildContent : RenderFragment
   - CloseOnEscape : Boolean
+  - CloseOnOverlayClick : Boolean
   - InitialFocus : FocusTrapInitialFocus
   - InitialFocusElement : ElementReference?
   - LockScroll : Boolean
   - OnEscapeKeyDown : EventCallback<KeyboardEventArgs>
   - TrapFocus : Boolean
   - Context : DialogContext [CascadingParameter]
+  - RenderingStrategy : OverlayRenderingStrategy? [CascadingParameter]
 
 ### BbDialogDescription (BlazorBlueprint.Primitives.Dialog)
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
@@ -264,12 +267,14 @@
   - CloseOnClick : Boolean
   - OnClick : EventCallback<MouseEventArgs>
   - Context : DialogContext [CascadingParameter]
+  - RenderingStrategy : OverlayRenderingStrategy? [CascadingParameter]
 
 ### BbDialogPortal (BlazorBlueprint.Primitives.Dialog)
   - ChildContent : RenderFragment
   - Container : String
   - ForceMount : Boolean
   - Context : DialogContext [CascadingParameter]
+  - RenderingStrategy : OverlayRenderingStrategy? [CascadingParameter]
 
 ### BbDialogTitle (BlazorBlueprint.Primitives.Dialog)
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
@@ -1049,6 +1054,10 @@
   - Horizontal = 0
   - Vertical = 1
 
+### OverlayRenderingStrategy (BlazorBlueprint.Primitives.Services)
+  - JavaScript = 0
+  - Native = 1
+
 ### SheetSide (BlazorBlueprint.Primitives)
   - Top = 0
   - Right = 1
@@ -1186,6 +1195,15 @@
   - Resume() : Void
   - Suspend() : Void
   - Unregister(String id) : Void
+
+### INativeOverlayService (BlazorBlueprint.Primitives.Services)
+  - CloseDialogAsync(ElementReference element, String returnValue) : Task
+  - FocusDialogAsync(ElementReference element) : Task
+  - FocusTriggerAsync(ElementReference element) : Task
+  - IsDialogSupportedAsync() : Task<Boolean>
+  - ResolveStrategy(OverlayRenderingStrategy? requested) : OverlayRenderingStrategy
+  - SetupDialogAsync(ElementReference element, Object dotNetRef) : Task<IAsyncDisposable>
+  - ShowDialogAsync(ElementReference element) : Task
 
 ### IPortalService (BlazorBlueprint.Primitives.Services)
   - HasHost : Boolean { get; }

--- a/tests/BlazorBlueprint.Tests/Services/NativeOverlayServiceTests.cs
+++ b/tests/BlazorBlueprint.Tests/Services/NativeOverlayServiceTests.cs
@@ -1,0 +1,53 @@
+using BlazorBlueprint.Primitives.Services;
+using Microsoft.JSInterop;
+using Xunit;
+
+namespace BlazorBlueprint.Tests.Services;
+
+public class NativeOverlayServiceTests
+{
+    private static NativeOverlayService CreateService(OverlayRenderingStrategy globalDefault)
+    {
+        var options = new OverlayRenderingOptions { DefaultStrategy = globalDefault };
+        return new NativeOverlayService(new StubJsRuntime(), options);
+    }
+
+    [Fact]
+    public void RequestedStrategyOverridesGlobalDefault()
+    {
+        var service = CreateService(globalDefault: OverlayRenderingStrategy.JavaScript);
+
+        var resolved = service.ResolveStrategy(OverlayRenderingStrategy.Native);
+
+        Assert.Equal(OverlayRenderingStrategy.Native, resolved);
+    }
+
+    [Fact]
+    public void NullUsesGlobalDefaultNative()
+    {
+        var service = CreateService(globalDefault: OverlayRenderingStrategy.Native);
+
+        var resolved = service.ResolveStrategy(null);
+
+        Assert.Equal(OverlayRenderingStrategy.Native, resolved);
+    }
+
+    [Fact]
+    public void NullUsesGlobalDefaultJavaScript()
+    {
+        var service = CreateService(globalDefault: OverlayRenderingStrategy.JavaScript);
+
+        var resolved = service.ResolveStrategy(null);
+
+        Assert.Equal(OverlayRenderingStrategy.JavaScript, resolved);
+    }
+
+    private sealed class StubJsRuntime : IJSRuntime
+    {
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) =>
+            throw new JSDisconnectedException("stub");
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args) =>
+            throw new JSDisconnectedException("stub");
+    }
+}

--- a/tests/BlazorBlueprint.Tests/Services/ServiceCollectionExtensionsTests.cs
+++ b/tests/BlazorBlueprint.Tests/Services/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,42 @@
+using BlazorBlueprint.Primitives.Extensions;
+using BlazorBlueprint.Primitives.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BlazorBlueprint.Tests.Services;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void RegistersNativeOverlayService()
+    {
+        var services = new ServiceCollection();
+
+        services.AddBlazorBlueprintPrimitives();
+
+        Assert.Contains(services, d => d.ServiceType == typeof(INativeOverlayService));
+        Assert.Contains(services, d => d.Lifetime == ServiceLifetime.Scoped && d.ServiceType == typeof(INativeOverlayService));
+    }
+
+    [Fact]
+    public void RegistersOverlayRenderingOptionsAsSingleton()
+    {
+        var services = new ServiceCollection();
+
+        services.AddBlazorBlueprintPrimitives();
+
+        Assert.Contains(services, d => d.ServiceType == typeof(OverlayRenderingOptions) && d.Lifetime == ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void ConfigureOverlaysSetsGlobalDefault()
+    {
+        var services = new ServiceCollection();
+
+        services.AddBlazorBlueprintPrimitives(o => o.DefaultStrategy = OverlayRenderingStrategy.Native);
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<OverlayRenderingOptions>();
+        Assert.Equal(OverlayRenderingStrategy.Native, options.DefaultStrategy);
+    }
+}


### PR DESCRIPTION
As outlined in https://github.com/blazorblueprintui/ui/discussions/376 , there are some design limitations of the current dialog component. It requires to have a ``BbPortalHost`` within the same circuit. This makes it not possible to render the portal host in SSR but show a dialog within a WebAssembly component. Additionally, due to the network latency and the roundtrip required by a ``InteractiveServer`` call for a dialog, they can feel sluggish.

This PR implements the support for the [native dialog](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog) with a fallback to the interactive dialog if the browser does not support it. The native dialog is nowadays well implemented across many browsers. This change also adds an example for opening the dialog using ``OpenAsync`` and points out the limitation of the DialogRef, since I ran into this limitation in my own app.

The change should be backward compatible but I only verified using the Sample project and my own project.

> [!NOTE]
> For the sake of transparency, this PR was partially generated by AI. I used it to refactor, organize and write tests. Smoke tests were conducted manually.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Checklist

- [x] Blazor Server
- [x] Blazor WebAssembly
- [ ] Blazor Hybrid (MAUI)
- [ ] Keyboard navigation / accessibility
- [x] Dark mode

## Related Issues
https://github.com/blazorblueprintui/ui/issues/479
https://github.com/blazorblueprintui/ui/discussions/376