### PR TITLE
fix: scroll area scrollbars, theme persistence opt-out, truncated calendar year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-08-26
+
+### Fixed
+
+- **BbScrollArea: the vertical scrollbar never appeared, even with `ScrollAreaType.Always`** — Reported in [#483](https://github.com/blazorblueprintui/ui/issues/483) by [@DCarlson12](https://github.com/DCarlson12). Neither scrollbar was taken out of flow. The root is `position: relative; overflow: hidden` and the viewport is sized `width: 100%; height: 100%`, so a scrollbar rendered as the viewport's sibling was laid out *after* it — past the bottom edge for the vertical bar, past the right edge for the horizontal one — and then clipped away by the root's `overflow: hidden`. Nothing was wrong with the JS: it sized and positioned the thumb correctly the whole time, against an element the browser was never going to paint. `Type` made no difference because the failure is in layout rather than visibility, which is why `Always` looked as broken as `Hover`. Both scrollbars are now pinned to their edge with `absolute` and given a `z-10` so content cannot paint over them. The horizontal case was reported as working, and was: its demo lets the root grow rather than constraining it, so there was nothing below the viewport to clip against — the same defect, hidden by the example. A demo for `ScrollAreaType.Always` has been added, since its absence is why this went unnoticed, and the API reference's `Type` default is corrected from `Auto` to `Hover`, which is what the component has always used.
+
+- **Theme: `PersistToLocalStorage = false` still read the theme from `localStorage`** — Reported in [#481](https://github.com/blazorblueprintui/ui/issues/481) by [@garrenf](https://github.com/garrenf). `ThemeService.InitializeAsync` consulted the option before *writing* but not before *reading*, so it called `loadTheme` unconditionally and a stored theme overrode every `Default*` value configured in `Program.cs`. The trap is that persistence has to have been enabled at some point for the entry to exist — so the sequence that produces it is running once with the default `true`, then turning it off, at which point the configuration appears to be ignored entirely and the only escape is clearing site data by hand. The option now gates the read as well as the write, and initializing with persistence off removes any entry an earlier run left behind, so a consumer who already has one is fixed by upgrading rather than by asking their users to clear storage. With persistence enabled nothing changes. Regression tests cover both directions.
+
+- **Calendar: the selected year was truncated in the year dropdown** — Reported in [#484](https://github.com/blazorblueprintui/ui/issues/484) by [@garrenf](https://github.com/garrenf), affecting `BbDatePicker` and `BbDateTimePicker`, which both compose `BbCalendar`. The dropdown takes its width from its trigger, and the trigger was `w-[80px]`. Inside that, each item spends 16px on horizontal padding and the list itself takes a scrollbar; the *selected* item additionally renders a 16px check icon, which pushed four digits past the remaining space and clipped `2026` to `20…`. Only the selected row was affected, which is what made it read as a rendering glitch rather than a sizing one — every other year in the list has no check icon and fit. The year select is now `w-[100px]`.
+
+---
+
 ## 2026-08-07
 
 ### Added

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/ScrollArea/always-visible.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/ScrollArea/always-visible.txt
@@ -1,0 +1,3 @@
+<BbScrollArea Type="ScrollAreaType.Always" Height="200px">
+    <!-- Content... -->
+</BbScrollArea>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ScrollAreaDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ScrollAreaDemo.razor
@@ -79,6 +79,28 @@
         <CodeBlock Source="Components/ScrollArea/long-content.txt" />
     </div>
 
+    <!-- Always Visible -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Always Visible</h2>
+            <p class="text-sm text-muted-foreground">
+                <code class="text-xs">ScrollAreaType.Always</code> keeps the scrollbar on screen
+                instead of revealing it on hover.
+            </p>
+        </div>
+        <BbScrollArea Type="ScrollAreaType.Always" Height="200px" Class="w-[350px] rounded-md border p-4">
+            <div class="space-y-4">
+                <h4 class="text-sm font-medium leading-none">Tags</h4>
+                @foreach (var tag in _tags)
+                {
+                    <div class="text-sm">@tag</div>
+                    <BbSeparator />
+                }
+            </div>
+        </BbScrollArea>
+        <CodeBlock Source="Components/ScrollArea/always-visible.txt" />
+    </div>
+
     <!-- Fill Container -->
     <div class="space-y-4">
         <div class="space-y-2">
@@ -121,8 +143,10 @@
                 <ApiParameter Name="Orientation" Type="ScrollAreaOrientation" Default="Vertical">
                     The orientation of the scroll area. Options: Vertical (default), Horizontal, or Both.
                 </ApiParameter>
-                <ApiParameter Name="Type" Type="ScrollAreaType" Default="Auto">
-                    Controls scrollbar visibility behavior. Options: Auto, Always, Hover, or Hidden.
+                <ApiParameter Name="Type" Type="ScrollAreaType" Default="Hover">
+                    Controls scrollbar visibility behavior. Hover (default) fades the scrollbar in
+                    while the pointer is over the area, Always keeps it on screen, Auto shows it only
+                    when the content overflows, and Hidden renders no scrollbar at all.
                 </ApiParameter>
                 <ApiParameter Name="Height" Type="string?">
                     Fixed height applied as an inline style (e.g., "200px").

--- a/src/BlazorBlueprint.Components/Components/Calendar/BbCalendar.razor
+++ b/src/BlazorBlueprint.Components/Components/Calendar/BbCalendar.razor
@@ -38,7 +38,10 @@
                             </BbSelectContent>
                         </BbSelect>
                         @* Year Select *@
-                        <BbSelect TValue="int" Value="@DisplayDate.Year" ValueChanged="@OnYearChanged" Class="w-[80px]">
+                        @* w-[80px] left the selected year truncated: the dropdown inherits the
+                           trigger width, and the selected item spends 16px on px-2 plus a 16px
+                           check icon, leaving too little for four digits (#484). *@
+                        <BbSelect TValue="int" Value="@DisplayDate.Year" ValueChanged="@OnYearChanged" Class="w-[100px]">
                             <BbSelectTrigger Class="h-8 border-0 bg-transparent px-2 text-sm font-medium hover:bg-accent focus:ring-0 focus:ring-offset-0">
                                 <span>@DisplayDate.Year</span>
                             </BbSelectTrigger>

--- a/src/BlazorBlueprint.Components/Components/ScrollArea/BbScrollArea.razor
+++ b/src/BlazorBlueprint.Components/Components/ScrollArea/BbScrollArea.razor
@@ -130,13 +130,16 @@
         _ => ""
     };
 
+    // The scrollbars must be positioned out of flow. The viewport is height/width 100% of the
+    // root, so an in-flow scrollbar is laid out after it and clipped by the root's
+    // overflow: hidden — which is why the vertical bar never appeared, even with Type.Always (#483).
     private string VerticalScrollbarClass => ClassNames.cn(
-        "flex touch-none select-none h-full w-2.5 border-l border-l-transparent p-[1px]",
+        "absolute right-0 top-0 bottom-0 z-10 flex touch-none select-none w-2.5 border-l border-l-transparent p-[1px]",
         ScrollbarVisibilityClass
     );
 
     private string HorizontalScrollbarClass => ClassNames.cn(
-        "flex touch-none select-none flex-col h-2.5 border-t border-t-transparent p-[1px]",
+        "absolute bottom-0 left-0 right-0 z-10 flex touch-none select-none flex-col h-2.5 border-t border-t-transparent p-[1px]",
         ScrollbarVisibilityClass
     );
 

--- a/src/BlazorBlueprint.Components/Components/Theme/ThemeOptions.cs
+++ b/src/BlazorBlueprint.Components/Components/Theme/ThemeOptions.cs
@@ -34,7 +34,13 @@ public class ThemeOptions
     public double DefaultRadius { get; set; } = 0.5;
 
     /// <summary>
-    /// When <c>true</c>, persists theme preferences to <c>localStorage</c>. Defaults to <c>true</c>.
+    /// When <c>true</c>, persists theme preferences to <c>localStorage</c> and restores them on load.
+    /// Defaults to <c>true</c>.
     /// </summary>
+    /// <remarks>
+    /// When <c>false</c>, the saved preferences are neither read nor written, and any entry left
+    /// behind by an earlier run is removed on initialization — so the <c>Default*</c> values here
+    /// (or the system preference, see <see cref="DetectSystemPreference"/>) always win.
+    /// </remarks>
     public bool PersistToLocalStorage { get; set; } = true;
 }

--- a/src/BlazorBlueprint.Components/Components/Theme/ThemeService.cs
+++ b/src/BlazorBlueprint.Components/Components/Theme/ThemeService.cs
@@ -103,7 +103,20 @@ public class ThemeService : IAsyncDisposable
 
         try
         {
-            var saved = await module.InvokeAsync<ThemeState?>("loadTheme");
+            // Only read localStorage when persistence is enabled. Reading it regardless meant a
+            // theme saved by an earlier run kept overriding the configured defaults after
+            // PersistToLocalStorage was turned off, with no way to opt out short of the user
+            // clearing site data by hand (#481). Clearing the stale entry closes the same hole
+            // for anyone who already has one.
+            var saved = options.PersistToLocalStorage
+                ? await module.InvokeAsync<ThemeState?>("loadTheme")
+                : null;
+
+            if (!options.PersistToLocalStorage)
+            {
+                await module.InvokeVoidAsync("clearTheme");
+            }
+
             if (saved is not null)
             {
                 isDarkMode = saved.IsDarkMode;

--- a/src/BlazorBlueprint.Components/wwwroot/js/theme.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/theme.js
@@ -217,3 +217,16 @@ export function saveTheme(isDarkMode, baseColor, primaryColor, radius) {
     // localStorage unavailable — silently ignore
   }
 }
+
+/**
+ * Remove any saved theme preferences from localStorage.
+ * Used when persistence is disabled, so a stale entry written by an earlier
+ * run cannot keep overriding the configured defaults.
+ */
+export function clearTheme() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // localStorage unavailable — silently ignore
+  }
+}

--- a/tests/BlazorBlueprint.Tests/Theme/ThemePersistenceTests.cs
+++ b/tests/BlazorBlueprint.Tests/Theme/ThemePersistenceTests.cs
@@ -1,0 +1,151 @@
+using System.Text.Json;
+using BlazorBlueprint.Components;
+using Microsoft.JSInterop;
+
+namespace BlazorBlueprint.Tests.Theme;
+
+/// <summary>
+/// Guards <see cref="ThemeOptions.PersistToLocalStorage"/> against reading a theme it promised not
+/// to write.
+/// <para>
+/// <c>InitializeAsync</c> used to call <c>loadTheme</c> unconditionally. Anyone who ran once with
+/// persistence on and then turned it off kept getting the stored theme instead of their configured
+/// defaults, with no way out short of clearing site data by hand (#481).
+/// </para>
+/// </summary>
+public class ThemePersistenceTests
+{
+    /// <summary>
+    /// Deliberately the opposite of the defaults asserted below on every axis, so a value leaking
+    /// out of localStorage fails the test rather than coinciding with the expected answer.
+    /// </summary>
+    private const string StoredTheme =
+        """{"isDarkMode":true,"baseColor":"Slate","primaryColor":"Blue","radius":1.0}""";
+
+    [Fact]
+    public async Task PersistenceDisabledDoesNotReadTheStoredTheme()
+    {
+        var module = new RecordingModule { StoredThemeJson = StoredTheme };
+        var service = new ThemeService(
+            new StubJsRuntime(module),
+            new ThemeOptions { PersistToLocalStorage = false });
+
+        await service.InitializeAsync();
+
+        Assert.DoesNotContain("loadTheme", module.Calls);
+    }
+
+    [Fact]
+    public async Task PersistenceDisabledClearsAnyThemeLeftByAnEarlierRun()
+    {
+        var module = new RecordingModule { StoredThemeJson = StoredTheme };
+        var service = new ThemeService(
+            new StubJsRuntime(module),
+            new ThemeOptions { PersistToLocalStorage = false });
+
+        await service.InitializeAsync();
+
+        Assert.Contains("clearTheme", module.Calls);
+    }
+
+    [Fact]
+    public async Task PersistenceDisabledKeepsTheConfiguredDefaults()
+    {
+        var module = new RecordingModule { StoredThemeJson = StoredTheme };
+        var service = new ThemeService(
+            new StubJsRuntime(module),
+            new ThemeOptions
+            {
+                PersistToLocalStorage = false,
+                DetectSystemPreference = false,
+                DefaultDarkMode = false,
+                DefaultBaseColor = BaseColor.Zinc,
+                DefaultPrimaryColor = PrimaryColor.Default,
+                DefaultRadius = 0.5,
+            });
+
+        await service.InitializeAsync();
+
+        Assert.False(service.IsDarkMode);
+        Assert.Equal(BaseColor.Zinc, service.BaseColor);
+        Assert.Equal(PrimaryColor.Default, service.PrimaryColor);
+        Assert.Equal(0.5, service.Radius);
+    }
+
+    [Fact]
+    public async Task PersistenceEnabledStillRestoresTheStoredTheme()
+    {
+        var module = new RecordingModule { StoredThemeJson = StoredTheme };
+        var service = new ThemeService(
+            new StubJsRuntime(module),
+            new ThemeOptions { PersistToLocalStorage = true });
+
+        await service.InitializeAsync();
+
+        Assert.Contains("loadTheme", module.Calls);
+        Assert.DoesNotContain("clearTheme", module.Calls);
+        Assert.True(service.IsDarkMode);
+        Assert.Equal(BaseColor.Slate, service.BaseColor);
+        Assert.Equal(PrimaryColor.Blue, service.PrimaryColor);
+        Assert.Equal(1.0, service.Radius);
+    }
+
+    /// <summary>Hands out the one module. Anything else is a call the service should not be making.</summary>
+    private sealed class StubJsRuntime(RecordingModule module) : IJSRuntime
+    {
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) =>
+            InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+
+        public ValueTask<TValue> InvokeAsync<TValue>(
+            string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            if (identifier != "import")
+            {
+                throw new InvalidOperationException(
+                    $"ThemeService should only call 'import' on IJSRuntime, not '{identifier}'.");
+            }
+
+            return ValueTask.FromResult((TValue)(object)module);
+        }
+    }
+
+    /// <summary>
+    /// Records every call so a test can assert on what the service did and did not ask for.
+    /// <c>loadTheme</c> answers by deserializing JSON, matching how the real interop materializes
+    /// the payload — so the test exercises the same contract rather than a hand-built instance
+    /// (which the service's private state type would not allow anyway).
+    /// </summary>
+    private sealed class RecordingModule : IJSObjectReference
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+        public List<string> Calls { get; } = [];
+
+        /// <summary>What <c>loadTheme</c> returns; <c>null</c> means localStorage holds nothing.</summary>
+        public string? StoredThemeJson { get; set; }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) =>
+            InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+
+        public ValueTask<TValue> InvokeAsync<TValue>(
+            string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            Calls.Add(identifier);
+
+            if (identifier == "loadTheme" && StoredThemeJson is not null)
+            {
+                return ValueTask.FromResult(
+                    JsonSerializer.Deserialize<TValue>(StoredThemeJson, JsonOptions)!);
+            }
+
+            if (identifier == "getPrefersDark")
+            {
+                return ValueTask.FromResult((TValue)(object)false);
+            }
+
+            return ValueTask.FromResult(default(TValue)!);
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Three small, independent bug fixes from the current issue backlog. One commit each, plus a changelog commit — they can be reviewed separately or split if you would rather they landed apart.

Closes #481
Closes #483
Closes #484

---

### `#483` — BbScrollArea: the vertical scrollbar never appeared

Neither scrollbar was taken out of flow. The root is `position: relative; overflow: hidden` and the viewport is sized `width: 100%; height: 100%`, so a scrollbar rendered as the viewport's sibling was laid out *after* it and clipped away by the root.

The JS was never at fault — it sized and positioned the thumb correctly the whole time, against an element the browser was never going to paint. `Type` made no difference because the failure is in layout rather than visibility, which is why `Always` looked as broken as `Hover`.

Both scrollbars are now pinned to their edge with `absolute`, plus `z-10`.

The horizontal case was reported as working, and was: its demo lets the root grow rather than constraining it, so there was nothing below the viewport to clip against. Same defect, hidden by the example.

Also in this commit, because the gap is why nobody caught it:
- added the missing `ScrollAreaType.Always` demo
- corrected the API reference `Type` default from `Auto` to `Hover`, which is what the component has always used

### `#481` — `PersistToLocalStorage = false` still read from localStorage

`ThemeService.InitializeAsync` consulted the option before *writing* but not before *reading*, so a stored theme overrode every `Default*` value in `Program.cs`.

The trap is that persistence has to have been enabled at some point for the entry to exist — so the sequence that produces it is running once with the default `true`, then turning it off, at which point the configuration appears to be ignored entirely.

The option now gates the read as well as the write. Initializing with persistence off also removes any entry an earlier run left behind (new `clearTheme` export), so anyone who already has one is fixed by upgrading rather than by asking their users to clear site data.

**This is a deliberate behaviour change** and the one thing here worth a second opinion: with `PersistToLocalStorage = false`, the library now deletes a key it did not write this session. The alternative — read nothing but leave the entry alone — means the stale value silently comes back the moment persistence is switched on again. I think deleting is right for a flag that says "do not persist", but say if you would rather it were a separate opt-in.

With persistence enabled, nothing changes.

### `#484` — selected year truncated in the calendar year dropdown

Affects `BbDatePicker` and `BbDateTimePicker`, which both compose `BbCalendar`.

The dropdown takes its width from its trigger, and the trigger was `w-[80px]`. Each item spends 16px on padding and the list takes a scrollbar; the *selected* item additionally renders a 16px check icon, which clipped `2026` to `20…`. Only the selected row was affected, which is what made it read as a rendering glitch rather than a sizing one.

Now `w-[100px]`.

---

### Verification

All three were checked in a running browser against the demo host, not only by reading the code:

- **#483** — the vertical bar now measures inside the root bounds with a correctly sized thumb, and hit-testing at the thumb's centre returns the thumb. On the new `Always` example it is opaque with no pointer over it, which is the exact case reported as broken.
- **#484** — on the Date Time Picker page from the report, the selected `2026` has its check icon and `scrollWidth == clientWidth`; no year in the list truncates.
- **#481** — `clearTheme` round-trips against real `localStorage` in the browser (save → load → clear → load returns null).

Tests: 74 pass, 4 new. I reverted the theme fix and confirmed 3 of the 4 fail without it, so they are real regression guards rather than tests that pass either way.

### Not in this PR

`#477` reports the Render Modes guide link in the README is dead. It is not a code bug — `RenderModesGuide.razor` exists and is routed at `/guides/render-modes`. Every `/guides/*` URL 404s on the live site because the docs deployment is stale: `publish/` was last built 2026-05-14 and the guide landed 2026-06-06, so the site is missing 71 demo commits. That needs a redeploy, not a change here.