### PR TITLE
feat(datagrid): sort/filter selector, selection behaviour, CSV export, nested grouping, row editing

### DIFF
--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/csv-export.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/csv-export.txt
@@ -1,0 +1,43 @@
+<BbDataGrid @ref="exportGrid" TData="Person" Items="@people" InitialPageSize="5"
+            ShowSearch="true" ShowExport="true" ExportFileName="employees.csv">
+    <Columns>
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable Filterable />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Email)" Filterable />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable Filterable />
+
+        @* Exports "Berlin", not the Id it was resolved from. *@
+        <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Id)" Id="export-office"
+                                  Title="Office" Sortable Filterable
+                                  SortAndFilterBy="@(p => OfficeFor(p))">
+            <CellTemplate>@OfficeFor(context)</CellTemplate>
+        </BbDataGridPropertyColumn>
+
+        <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" Sortable Filterable />
+    </Columns>
+</BbDataGrid>
+
+@code {
+    private BbDataGrid<Person>? exportGrid;
+
+    // Export from a button of your own.
+    private async Task Export() => await exportGrid!.ExportToCsvAsync();
+
+    // Or get the text without downloading it — to store it, mail it, or assert on it in a test.
+    private string? BuildOnly() => exportGrid?.BuildCsv();
+}
+
+@* What gets exported
+
+     Rows      every row that survives the current search, filters and sort, across all pages
+     Columns   the visible data columns, in their current order; select and expand columns are skipped
+     Values    each column's display value, so a Format is applied and a SortAndFilterBy label wins
+
+   ExportScope="DataGridExportScope.CurrentPage" narrows it to the page on screen. A grid backed by
+   an ItemsProvider only holds the page it fetched, so it exports that page and logs a warning.
+
+   ExportDelimiter=";" for locales whose spreadsheet expects a semicolon — the usual reason a CSV
+   opens with every row crammed into one column.
+
+   A cell starting with =, +, -, @ or a tab is prefixed with an apostrophe on the way out. Those
+   characters make a spreadsheet execute the cell as a formula, so this is a security measure, not
+   formatting. A value that parses as a number is left alone, so -1500 still exports as a number. *@

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/inline-row-editing.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/inline-row-editing.txt
@@ -1,0 +1,69 @@
+<BbDataGrid TData="Person" Items="@people" InitialPageSize="6"
+            EditMode="DataGridEditMode.Row"
+            OnRowCommit="HandleRowCommit"
+            OnRowCancel="HandleRowCancel">
+    <Columns>
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable Width="220px">
+            <EditTemplate>
+                <BbInput @bind-Value="context.Name" Class="h-8" />
+            </EditTemplate>
+        </BbDataGridPropertyColumn>
+
+        @* No EditTemplate, so this column stays read-only while the rest of the row is in edit. *@
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable Width="150px" />
+
+        <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" Sortable Width="150px">
+            <EditTemplate>
+                <BbNumericInput TValue="int" @bind-Value="context.Salary" Class="h-8" />
+            </EditTemplate>
+        </BbDataGridPropertyColumn>
+
+        @* Renders Edit on a row at rest, and Save and Cancel on the row being edited. *@
+        <BbDataGridEditColumn TData="Person" />
+    </Columns>
+</BbDataGrid>
+
+@code {
+    private void HandleRowCommit(DataGridRowCommitContext<Person> context)
+    {
+        if (string.IsNullOrWhiteSpace(context.Item.Name))
+        {
+            // Refuse the save and keep the row open, so the user keeps their typing.
+            context.Cancel = true;
+            return;
+        }
+
+        // context.Item already carries the changes — persist it here.
+    }
+
+    private void HandleRowCancel(Person person)
+    {
+        // The original values are already back on the item by the time this runs.
+    }
+}
+
+@* The edit template binds straight to the row, so @bind-Value is all it takes. The grid records
+   the row's values when editing starts and puts them back on Cancel, so nothing needs copying by
+   hand — and because it restores onto the same instance, anything else holding that row sees the
+   values revert too.
+
+   Enter saves and Escape cancels from anywhere in the row. Shift+Enter is left alone, so a
+   multi-line editor still works. Before committing on Enter the grid blurs the field the user is
+   in, so an input that only writes its value back on change — which is BbInput's default — still
+   hands over what was just typed rather than dropping it.
+
+   Validation runs through the row's own EditContext, so DataAnnotations on your model apply
+   unchanged and a row that fails validation stays open.
+
+   Other ways to start and end an edit:
+
+     EditOnRowClick="true"    a row click starts the edit (leave off if row click also selects)
+     StartEditAsync(item)     from a button of your own
+     CommitEditAsync()        returns false when validation or OnRowCommit refused the save
+     CancelEditAsync()
+     EditingItem              the row currently in edit, or null
+
+   Starting an edit on another row commits the one being left. Committing re-runs the sort,
+   filter and grouping pass, so a row edited out of its current position moves where it belongs.
+
+   Row editing applies to flat and grouped rows. Hierarchy mode does not support it yet. *@

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/nested-grouping.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/nested-grouping.txt
@@ -1,0 +1,46 @@
+<BbDataGrid @ref="grid" TData="Person" Items="@people" InitialPageSize="8">
+    <Columns>
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable Groupable />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Status)" Sortable Groupable />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Role)" Groupable />
+        <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" Sortable
+                                  Aggregate="AggregateFunction.Sum" />
+    </Columns>
+</BbDataGrid>
+
+@code {
+    private BbDataGrid<Person>? grid;
+
+    // Set every level at once, outermost first.
+    private Task GroupByDepartmentThenStatus() =>
+        grid!.SetGroupingAsync(new[] { "department", "status" });
+
+    // Or build it up one level at a time.
+    private async Task AddALevel()
+    {
+        await grid!.GroupByColumnAsync("department");   // replaces all grouping with one level
+        await grid.AddGroupByColumnAsync("status");     // nests inside it
+        await grid.MoveGroupByColumnAsync("status", 0); // status now groups outermost
+        await grid.RemoveGroupByColumnAsync("status");  // back to department alone
+    }
+}
+
+@* Mark a column Groupable and its ellipsis menu offers "Group by". Once something is grouped it
+   also offers "Then group by", which nests a level inside the current ones.
+
+   The breadcrumb above the grid lists the active levels in order, with a control on each to drop
+   it or move it outward. Set ShowGroupingBreadcrumb="false" to hide it when the page fixes the
+   grouping and the user should not change it.
+
+   Each header collapses on its own. Collapsed state is keyed by the full path, so collapsing
+   Active under Engineering leaves Active under Sales open. A group carries every row beneath it,
+   so aggregates roll up: a department header sums all its rows, not just its own level.
+
+   Pagination counts data rows, not headers. When a page boundary lands inside a subtree, every
+   open ancestor header is repeated at the top of the next page, so a row is never shown without
+   the headers that say what it belongs to.
+
+   Server-side: a GroupedItemsProvider receives every level in DataGridRequest.GroupDefinitions.
+   Translate them to one GROUP BY a, b and return a flat row per innermost group, each setting
+   KeyPath to its full path. The grid rebuilds the header tree from those paths. *@

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/selection-behavior.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/selection-behavior.txt
@@ -1,0 +1,37 @@
+<BbDataGrid TData="Person" Items="@people" InitialPageSize="8"
+            SelectionMode="DataTableSelectionMode.Multiple"
+            SelectionBehavior="DataGridSelectionBehavior.Replace"
+            SelectedItemsChanged="HandleSelectionChanged">
+    <Columns>
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Email)" />
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable />
+        <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" Sortable />
+    </Columns>
+</BbDataGrid>
+
+@code {
+    private IReadOnlyCollection<Person> selected = Array.Empty<Person>();
+
+    private void HandleSelectionChanged(IReadOnlyCollection<Person> people) => selected = people;
+}
+
+@* Replace gives the conventions a user brings from a file explorer:
+
+     Click             select only this row; clear the selection if it was already the only one
+     Shift+Click       select the range from the anchor row to this row
+     Ctrl / Cmd+Click  add or remove this row, leave the rest alone
+
+   The range extends from the anchor — the row of the last plain click or Ctrl+Click — not from
+   the last selected row. Repeated Shift+Clicks re-extend from the same anchor, so the range can
+   be grown and shrunk rather than walking along.
+
+   Range and additive selection need SelectionMode.Multiple; under Single every click is a plain
+   click. A range covers the rows on the current page, because those are the rows the user sees.
+
+   Two things keep toggle semantics under either behaviour: the checkboxes in a
+   BbDataGridSelectColumn, which would be unusable if ticking one cleared the rest, and the Space
+   and Enter keys on a focused row, which act as that row's checkbox.
+
+   The default, DataGridSelectionBehavior.Toggle, is unchanged: each click flips one row and
+   modifier keys are ignored. *@

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/sort-filter-by.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/DataGrid/sort-filter-by.txt
@@ -1,0 +1,41 @@
+<BbDataGrid TData="Person" Items="@people" InitialPageSize="5">
+    <Columns>
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable Width="200px" />
+
+        @* Without SortAndFilterBy the header click orders by Id, not by the office name shown. *@
+        <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Id)"
+                                  Title="Office (sorts by id)" Sortable Width="180px">
+            <CellTemplate>
+                <BbBadge Variant="BadgeVariant.Secondary">@OfficeFor(context)</BbBadge>
+            </CellTemplate>
+        </BbDataGridPropertyColumn>
+
+        @* SortAndFilterBy points sorting, filtering, grouping and search at the displayed value. *@
+        <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Id)" Id="office-by-name"
+                                  Title="Office (sorts by name)" Sortable Filterable Groupable Width="200px"
+                                  SortAndFilterBy="@(p => OfficeFor(p))"
+                                  FilterType="FilterFieldType.Enum"
+                                  FilterOptions="@(OfficeNames.Select(o => new SelectOption<string>(o, o)))">
+            <CellTemplate>
+                <BbBadge Variant="BadgeVariant.Secondary">@OfficeFor(context)</BbBadge>
+            </CellTemplate>
+        </BbDataGridPropertyColumn>
+
+        <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable Width="150px" />
+    </Columns>
+</BbDataGrid>
+
+@code {
+    private static readonly string[] OfficeNames = { "Singapore", "Berlin", "Austin", "London" };
+
+    private static string OfficeFor(Person person) => OfficeNames[person.Id % OfficeNames.Length];
+}
+
+@* Two columns declared from the same Property need distinct Ids, so give the second one an
+   explicit Id. Sorting, per-column filtering, global search, grouping and CSV export all read
+   SortAndFilterBy, so every one of them agrees with what the cell shows.
+
+   SortAndFilterBy is an expression, not a delegate, so a grid backed by a server-side
+   ItemsProvider over IQueryable can translate it to SQL. Keep the body translatable: a lookup
+   your provider cannot translate throws at query time. For a lookup the server cannot perform,
+   join the label into the query and point Property at it instead. *@

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
@@ -119,6 +119,147 @@
         <CodeBlock Source="Components/DataGrid/column-filtering.txt" />
     </div>
 
+    <!-- ── Inline Row Editing ─────────────────────────────────────── -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Inline Row Editing</h2>
+            <p class="text-sm text-muted-foreground">
+                Set <code class="bg-muted px-1 py-0.5 rounded">EditMode="DataGridEditMode.Row"</code>, give each
+                column the user may change an <code class="bg-muted px-1 py-0.5 rounded">EditTemplate</code>, and
+                add a <code class="bg-muted px-1 py-0.5 rounded">BbDataGridEditColumn</code> for the Edit, Save and
+                Cancel buttons. The template binds straight to the row, so an ordinary
+                <code class="bg-muted px-1 py-0.5 rounded">@@bind-Value</code> is all it takes.
+            </p>
+            <p class="text-sm text-muted-foreground">
+                Press <strong>Enter</strong> to save or <strong>Escape</strong> to cancel without reaching for the
+                buttons. Cancel puts the original values back, so nothing needs copying by hand. A column with no
+                edit template keeps showing its normal cell — Department below is read-only.
+                <code class="bg-muted px-1 py-0.5 rounded">OnRowCommit</code> can refuse the save and keep the row
+                open with the user's typing intact; try clearing a name and saving.
+                Validation runs through the row's own <code class="bg-muted px-1 py-0.5 rounded">EditContext</code>,
+                so <code class="bg-muted px-1 py-0.5 rounded">DataAnnotations</code> on your model apply unchanged.
+            </p>
+        </div>
+        <BbDataGrid TData="Person" Items="@editablePeople" InitialPageSize="6"
+                   EditMode="DataGridEditMode.Row"
+                   OnRowCommit="HandleRowCommit"
+                   OnRowCancel="HandleRowCancel">
+            <Columns>
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable Width="220px">
+                    <EditTemplate>
+                        <BbInput @bind-Value="context.Name" Class="h-8" />
+                    </EditTemplate>
+                </BbDataGridPropertyColumn>
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable Width="150px" />
+                <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Age)" Sortable Width="120px">
+                    <EditTemplate>
+                        <BbNumericInput TValue="int" @bind-Value="context.Age" Class="h-8" />
+                    </EditTemplate>
+                </BbDataGridPropertyColumn>
+                <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" Sortable Width="150px">
+                    <EditTemplate>
+                        <BbNumericInput TValue="int" @bind-Value="context.Salary" Class="h-8" />
+                    </EditTemplate>
+                </BbDataGridPropertyColumn>
+                <BbDataGridEditColumn TData="Person" />
+            </Columns>
+        </BbDataGrid>
+        @if (_editMessage != null)
+        {
+            <p class="text-sm text-muted-foreground">@_editMessage</p>
+        }
+        <CodeBlock Source="Components/DataGrid/inline-row-editing.txt" />
+    </div>
+
+    <!-- ── CSV Export ─────────────────────────────────────────────── -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">CSV Export</h2>
+            <p class="text-sm text-muted-foreground">
+                Set <code class="bg-muted px-1 py-0.5 rounded">ShowExport="true"</code> to put an Export button
+                in the toolbar. It downloads what the user sees: the rows that survive the current search,
+                filters and sort, in the visible columns, in their current order — across every page, not just
+                the one on screen.
+            </p>
+            <p class="text-sm text-muted-foreground">
+                Search or reorder the columns first, then export, and the file follows. The Status column
+                exports its label rather than the number behind it, because it sets
+                <code class="bg-muted px-1 py-0.5 rounded">SortAndFilterBy</code>. Call
+                <code class="bg-muted px-1 py-0.5 rounded">ExportToCsvAsync()</code> on a grid reference to
+                export from a button of your own, or
+                <code class="bg-muted px-1 py-0.5 rounded">BuildCsv()</code> to get the text without
+                downloading it.
+            </p>
+        </div>
+        <BbDataGrid @ref="exportGrid" TData="Person" Items="@people" InitialPageSize="5"
+                   ShowSearch="true" ShowExport="true" ExportFileName="employees.csv"
+                   Resizable="true" Reorderable="true">
+            <Columns>
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable Filterable />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Email)" Filterable />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable Filterable />
+                <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Id)" Id="export-office"
+                    Title="Office" Sortable Filterable
+                    SortAndFilterBy="@(p => OfficeFor(p))">
+                    <CellTemplate>@OfficeFor(context)</CellTemplate>
+                </BbDataGridPropertyColumn>
+                <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" Sortable Filterable />
+            </Columns>
+        </BbDataGrid>
+        <div class="space-y-2">
+            <BbButton Variant="ButtonVariant.Secondary" Size="ButtonSize.Small" OnClick="ShowCsvPreview">
+                Preview the CSV instead of downloading
+            </BbButton>
+            @if (_csvPreview != null)
+            {
+                <pre class="max-h-48 overflow-auto rounded-md border bg-muted p-3 text-xs">@_csvPreview</pre>
+            }
+        </div>
+        <CodeBlock Source="Components/DataGrid/csv-export.txt" />
+    </div>
+
+    <!-- ── Sort and Filter by a Different Value ────────────────────── -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Sort and Filter by a Different Value</h2>
+            <p class="text-sm text-muted-foreground">
+                A column that displays something other than its raw property — the common case being a
+                <code class="bg-muted px-1 py-0.5 rounded">CellTemplate</code> that resolves a key to a label —
+                still sorts and filters on the key by default. The user sees office names, clicks the header,
+                and the rows reorder by a number they cannot see.
+                <code class="bg-muted px-1 py-0.5 rounded">SortAndFilterBy</code> points sorting, filtering,
+                grouping and search at the value the column displays instead. One parameter covers all four,
+                so they cannot disagree.
+            </p>
+            <p class="text-sm text-muted-foreground">
+                Sort the two columns below and compare them. Both resolve the same office, but only the second
+                orders alphabetically by office name.
+            </p>
+        </div>
+        <BbDataGrid TData="Person" Items="@people" InitialPageSize="5">
+            <Columns>
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable Width="200px" />
+                <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Id)" Title="Office (sorts by id)"
+                    Sortable Width="180px">
+                    <CellTemplate>
+                        <BbBadge Variant="BadgeVariant.Secondary">@OfficeFor(context)</BbBadge>
+                    </CellTemplate>
+                </BbDataGridPropertyColumn>
+                <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Id)" Id="office-by-name"
+                    Title="Office (sorts by name)" Sortable Filterable Groupable Width="200px"
+                    SortAndFilterBy="@(p => OfficeFor(p))"
+                    FilterType="FilterFieldType.Enum"
+                    FilterOptions="@(OfficeNames.Select(o => new SelectOption<string>(o, o)))">
+                    <CellTemplate>
+                        <BbBadge Variant="BadgeVariant.Secondary">@OfficeFor(context)</BbBadge>
+                    </CellTemplate>
+                </BbDataGridPropertyColumn>
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable Width="150px" />
+            </Columns>
+        </BbDataGrid>
+        <CodeBlock Source="Components/DataGrid/sort-filter-by.txt" />
+    </div>
+
     <!-- ── Row Selection ───────────────────────────────────────────── -->
     <div class="space-y-4">
         <div class="space-y-2">
@@ -147,6 +288,50 @@
             </p>
         }
         <CodeBlock Source="Components/DataGrid/row-selection.txt" />
+    </div>
+
+    <!-- ── Selection Behaviour (Replace) ──────────────────────────── -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Selection Behaviour</h2>
+            <p class="text-sm text-muted-foreground">
+                By default a row click toggles that one row and leaves the rest alone. Set
+                <code class="bg-muted px-1 py-0.5 rounded">SelectionBehavior="DataGridSelectionBehavior.Replace"</code>
+                for the conventions a user brings from a file explorer: a plain click selects only the clicked
+                row, <strong>Shift+Click</strong> selects the range from the anchor row, and
+                <strong>Ctrl+Click</strong> (Cmd+Click on macOS) adds or removes one row. Clicking the only
+                selected row clears the selection.
+            </p>
+            <p class="text-sm text-muted-foreground">
+                The range extends from the <em>anchor</em> — the row of the last plain click or Ctrl+Click —
+                not from the last selected row. Click a row, Ctrl+Click a second, then Shift+Click a third:
+                the range starts at the Ctrl+Clicked row. There is no select column here, because a row click
+                is the whole point; where a select column is present its checkboxes keep toggle semantics, and
+                so do the Space and Enter keys on a focused row.
+            </p>
+        </div>
+        <BbDataGrid TData="Person" Items="@people" InitialPageSize="8"
+                   SelectionMode="DataTableSelectionMode.Multiple"
+                   SelectionBehavior="DataGridSelectionBehavior.Replace"
+                   SelectedItemsChanged="HandleReplaceSelectionChanged">
+            <Columns>
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Email)" />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable />
+                <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" Sortable />
+            </Columns>
+        </BbDataGrid>
+        <p class="text-sm text-muted-foreground">
+            @if (_replaceSelectedPeople.Count > 0)
+            {
+                <text>Selected @_replaceSelectedPeople.Count: @string.Join(", ", _replaceSelectedPeople.Select(p => p.Name))</text>
+            }
+            else
+            {
+                <text>Nothing selected.</text>
+            }
+        </p>
+        <CodeBlock Source="Components/DataGrid/selection-behavior.txt" />
     </div>
 
     <!-- ── Per-Page Select-All (SelectAllScope) ──────────────────── -->
@@ -893,8 +1078,9 @@
             <p class="text-sm text-muted-foreground">
                 Mark a column <code class="bg-muted px-1 py-0.5 rounded">Groupable</code> to let users group by it
                 at runtime. An ellipsis menu appears in the column header with a "Group by" action, and the grid
-                regroups without a page refresh. Only one column is grouped at a time — choosing another replaces
-                the current grouping. Columns left without the flag (like Name) offer no menu.
+                regroups without a page refresh. Once something is grouped the menu also offers "Then group by",
+                which nests a second level inside the first — see Nested Grouping below.
+                Columns left without the flag (like Name) offer no menu.
                 Grouping can also be driven from code with
                 <code class="bg-muted px-1 py-0.5 rounded">GroupByColumnAsync</code>, which takes a
                 <code class="bg-muted px-1 py-0.5 rounded">SortDirection</code> controlling the order of the group
@@ -929,6 +1115,53 @@
             </Columns>
         </BbDataGrid>
         <CodeBlock Source="Components/DataGrid/interactive-grouping.txt" />
+    </div>
+
+    <!-- ── Nested Grouping ──────────────────────────────────────── -->
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <h2 class="text-2xl font-semibold">Nested Grouping</h2>
+            <p class="text-sm text-muted-foreground">
+                Grouping nests to any depth. Use "Then group by" in a column's ellipsis menu, or call
+                <code class="bg-muted px-1 py-0.5 rounded">AddGroupByColumnAsync</code> and
+                <code class="bg-muted px-1 py-0.5 rounded">SetGroupingAsync</code> from code. The breadcrumb above
+                the grid shows the levels in order; use it to drop a level or move one outward.
+            </p>
+            <p class="text-sm text-muted-foreground">
+                Each header collapses on its own, and the same key under different parents stays separate —
+                collapsing Active under Engineering leaves Active under Sales open. Aggregates roll up, so a
+                department header sums every row beneath it, not just its own level. The page size here is
+                deliberately small: page through and every header above the first row is repeated at the top of
+                the page, so a row is never shown without the headers that say what it belongs to.
+            </p>
+        </div>
+        <BbDataGrid @ref="nestedGroupingGrid" TData="Person" Items="@people" InitialPageSize="8">
+            <Toolbar>
+                <div class="flex items-center gap-2">
+                    <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small"
+                              OnClick="@(() => nestedGroupingGrid!.SetGroupingAsync(new[] { "department", "status" }))">
+                        Department › Status
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small"
+                              OnClick="@(() => nestedGroupingGrid!.SetGroupingAsync(new[] { "status", "department", "role" }))">
+                        Status › Department › Role
+                    </BbButton>
+                    <BbButton Variant="ButtonVariant.Outline" Size="ButtonSize.Small"
+                              OnClick="@(() => nestedGroupingGrid!.ClearGroupingAsync())">
+                        Clear grouping
+                    </BbButton>
+                </div>
+            </Toolbar>
+            <Columns>
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Name)" Sortable />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Department)" Sortable Groupable />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Status)" Sortable Groupable />
+                <BbDataGridPropertyColumn TData="Person" TProp="string" Property="@(p => p.Role)" Groupable />
+                <BbDataGridPropertyColumn TData="Person" TProp="int" Property="@(p => p.Salary)" Format="C0" Sortable
+                    Aggregate="BlazorBlueprint.Primitives.DataGrid.AggregateFunction.Sum" />
+            </Columns>
+        </BbDataGrid>
+        <CodeBlock Source="Components/DataGrid/nested-grouping.txt" />
     </div>
 
     <!-- ── Live Collection Updates ──────────────────────────────── -->
@@ -1009,8 +1242,41 @@
                 <ApiParameter Name="ItemsProvider" Type="DataGridItemsProvider&lt;TData&gt;">
                     Async delegate for server-side data fetching. Receives sort definitions, pagination parameters, and a cancellation token. Mutually exclusive with Items.
                 </ApiParameter>
+                <ApiParameter Name="EditMode" Type="DataGridEditMode" Default="None">
+                    How the grid lets a user edit rows in place. Row puts a whole row into edit at once: every column with an EditTemplate becomes an input, and the changes commit or discard together. A row goes into edit through BbDataGridEditColumn, through EditOnRowClick, or through StartEditAsync. Enter commits, Escape cancels. Cancel restores the values the row held when editing started, onto the same instance. Applies to flat and grouped rows; hierarchy mode does not support it yet.
+                </ApiParameter>
+                <ApiParameter Name="EditOnRowClick" Type="bool" Default="false">
+                    Clicking a row puts it into edit. Leave this off when the grid also selects on row click, or a click would do both.
+                </ApiParameter>
+                <ApiParameter Name="OnRowCommit" Type="EventCallback&lt;DataGridRowCommitContext&lt;TData&gt;&gt;">
+                    Called when a row's edits are committed, before the row closes. The item already carries the changes. Set context.Cancel to keep the row in edit — for instance when a save is rejected by the server — so the user keeps their typing. Validation through the row's EditContext runs first, so DataAnnotations on the model apply unchanged.
+                </ApiParameter>
+                <ApiParameter Name="OnRowCancel" Type="EventCallback&lt;TData&gt;">
+                    Called when a row's edits are discarded, after the original values are put back.
+                </ApiParameter>
+                <ApiParameter Name="ShowGroupingBreadcrumb" Type="bool" Default="true">
+                    Shows a breadcrumb of the active grouping levels above the grid, with a control on each to remove it or move it outward. Only appears while something is grouped. It is the practical way to see and change a nested grouping — past two levels, reading the order out of the per-column menus stops working. Set it false when the page fixes the grouping and the user should not change it.
+                </ApiParameter>
+                <ApiParameter Name="ShowExport" Type="bool" Default="false">
+                    Renders an Export button in the toolbar that downloads the rows as CSV. It exports what the user sees: the rows that survive the current search, filters and sort, across every page, in the visible columns, in their current order, using each column's display value. Select and expand columns are skipped.
+                </ApiParameter>
+                <ApiParameter Name="ExportFileName" Type="string" Default="export.csv">
+                    The file name offered for the CSV download. A .csv extension is appended when the name has none.
+                </ApiParameter>
+                <ApiParameter Name="ExportDelimiter" Type="string" Default=",">
+                    The field delimiter written between CSV values. Set it to ";" for locales whose spreadsheet expects a semicolon, which is the usual reason a CSV opens with every row crammed into one column.
+                </ApiParameter>
+                <ApiParameter Name="ExportScope" Type="DataGridExportScope" Default="FilteredRows">
+                    Which rows the export writes. FilteredRows covers every row that survives the current filters, search and sort, across all pages. CurrentPage narrows it to the page on screen. A grid backed by an ItemsProvider only holds the page it fetched, so it exports that page and logs a warning.
+                </ApiParameter>
+                <ApiParameter Name="OnExport" Type="EventCallback&lt;string&gt;">
+                    Called after an export completes, with the CSV text that was downloaded. The download happens either way.
+                </ApiParameter>
                 <ApiParameter Name="SelectionMode" Type="DataTableSelectionMode" Default="None">
                     The selection mode: None, Single, or Multiple.
+                </ApiParameter>
+                <ApiParameter Name="SelectionBehavior" Type="DataGridSelectionBehavior" Default="Toggle">
+                    How clicking a row changes the selection. Toggle, the default and the long-standing behaviour, flips one row per click and ignores modifier keys. Replace gives the conventions a user brings from a file explorer: a plain click selects only the clicked row, Shift+Click selects the range from the anchor row, and Ctrl+Click (Cmd+Click on macOS) adds or removes one row; clicking the only selected row clears the selection. The range extends from the anchor — the row of the last plain click or Ctrl+Click — not from the last selected row, and repeated Shift+Clicks re-extend from that same anchor. Range and additive selection need SelectionMode.Multiple, and a range covers the current page's rows. Select-column checkboxes and the Space and Enter keys keep toggle semantics under either behaviour.
                 </ApiParameter>
                 <ApiParameter Name="SelectedItemsChanged" Type="EventCallback&lt;IReadOnlyCollection&lt;TData&gt;&gt;">
                     Event callback invoked when the selected items change.
@@ -1152,6 +1418,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Format" Type="string?">
                     Format string for displaying the property value (e.g., "C0" for currency, "N2" for numbers, "d" for dates).
+                </ApiParameter>
+                <ApiParameter Name="SortAndFilterBy" Type="Expression&lt;Func&lt;TData, object?&gt;&gt;?" Default="null">
+                    Projects the value this column sorts and filters on, when that differs from Property. Set it when the cell displays something other than the raw property — the common case being a CellTemplate that resolves a key to a label — so the header click orders by what the user reads rather than by the key behind it. One parameter covers sorting, per-column filtering, global search, grouping and CSV export, so all of them agree; two separate selectors could disagree. It is an expression rather than a delegate so a server-side ItemsProvider over IQueryable can still translate it, which means the body must stay translatable by your provider. Format is not applied to the projected value.
                 </ApiParameter>
                 <ApiParameter Name="Sortable" Type="bool" Default="false">
                     Whether this column can be sorted by clicking its header.
@@ -1308,6 +1577,15 @@
                 </ApiParameter>
             </ApiReference>
 
+            <ApiReference ComponentName="DataGridEditColumn">
+                <ApiParameter Name="Width" Type="string?" Default="120px">
+                    Column width. Defaults to a width that fits the Save and Cancel buttons.
+                </ApiParameter>
+                <ApiParameter Name="Pinned" Type="ColumnPinning" Default="None">
+                    Pins the column to an edge of the scrollable viewport. Pin it right on a wide grid so the Save button stays reachable without scrolling back.
+                </ApiParameter>
+            </ApiReference>
+
             <ApiReference ComponentName="DataGridExpandColumn">
                 <ApiParameter Name="Width" Type="string?" Default="48px">
                     Column width for the expand chevron column. Defaults to a compact button width.
@@ -1393,6 +1671,46 @@
     // Column Filtering demo state
     private BlazorBlueprint.Primitives.DataGrid.DataGridState<Person> _gridState = new();
 
+    // Inline row editing demo state
+    private List<Person> editablePeople = new();
+    private string? _editMessage;
+
+    private void HandleRowCommit(DataGridRowCommitContext<Person> context)
+    {
+        if (string.IsNullOrWhiteSpace(context.Item.Name))
+        {
+            // Refuse the save and keep the row open, so the user keeps their typing.
+            context.Cancel = true;
+            _editMessage = "A name is required — the row stays open until you give it one.";
+            return;
+        }
+
+        _editMessage = $"Saved {context.Item.Name}.";
+    }
+
+    private void HandleRowCancel(Person person) =>
+        _editMessage = $"Discarded the changes to {person.Name}.";
+
+    // Nested grouping demo state
+    private BbDataGrid<Person>? nestedGroupingGrid;
+
+    // CSV export demo state
+    private BbDataGrid<Person>? exportGrid;
+    private string? _csvPreview;
+
+    private void ShowCsvPreview() => _csvPreview = exportGrid?.BuildCsv();
+
+    // Selection behaviour demo state
+    private IReadOnlyCollection<Person> _replaceSelectedPeople = Array.Empty<Person>();
+
+    private void HandleReplaceSelectionChanged(IReadOnlyCollection<Person> selected) =>
+        _replaceSelectedPeople = selected;
+
+    // SortAndFilterBy demo: an office name resolved from a key the column does not display.
+    private static readonly string[] OfficeNames = { "Singapore", "Berlin", "Austin", "London" };
+
+    private static string OfficeFor(Person person) => OfficeNames[person.Id % OfficeNames.Length];
+
     // Expandable detail rows demo data
     private record TeamMember(string Name, string Title, string Department, List<TeamMember> DirectReports);
 
@@ -1472,6 +1790,9 @@
     protected override void OnInitialized()
     {
         people = MockDataService.GeneratePersons(50);
+
+        // A set of its own, so editing here does not change the rows every other example shows.
+        editablePeople = MockDataService.GeneratePersons(12);
         manyPeople = MockDataService.GeneratePersons(1000);
         asyncPeople = MockDataService.GeneratePersons(100);
 

--- a/docs/plans/2026-08-27-datagrid-enhancements.md
+++ b/docs/plans/2026-08-27-datagrid-enhancements.md
@@ -1,0 +1,215 @@
+# DataGrid enhancement plan
+
+Drafted 2026-08-27. Covers five issues, to be run as one sweep.
+
+| # | Issue | Size | Depends on |
+|---|---|---|---|
+| 1 | [#463](https://github.com/blazorblueprintui/ui/issues/463) sort/filter on the displayed value | S | — |
+| 2 | [#456](https://github.com/blazorblueprintui/ui/issues/456) enterprise row selection | S | — |
+| 3 | [#412](https://github.com/blazorblueprintui/ui/issues/412) nested multi-level grouping | L | #463 |
+| 4 | [#497](https://github.com/blazorblueprintui/ui/issues/497) inline and cell editing | XL | — |
+| 5 | [#498](https://github.com/blazorblueprintui/ui/issues/498) export visible rows to CSV | S | #463 |
+
+Two of these (#497, #498) were raised from this plan and did not exist before it.
+
+## Where the grid actually stands
+
+Worth stating, because it changes what is worth building. `BbDataGrid` already has:
+virtualization, server-side `ItemsProvider`, hierarchy/tree rows with paged lazy children,
+single-level grouping (client and server), multi-column sort, per-column filtering, global
+search, column resize, reorder, visibility, **pinning**, **aggregates/footer**, detail rows,
+row context menu, keyboard navigation, sticky header.
+
+That is a strong feature set. The gaps below are narrow and specific, not foundational.
+
+Confirmed absent: **inline/cell editing** and **export**. Everything else a mainstream Blazor
+grid offers is already here in some form.
+
+---
+
+## Ordering, and why
+
+```
+#463  sort/filter selector  ──┬──→  #412  nested grouping   (reuses the selector)
+                              └──→  #498  CSV export        (exports display values)
+
+#456  selection behaviour     ─────  independent, small
+#497  inline editing          ─────  independent, extra large
+```
+
+`#463` is the keystone, and goes first. Not because it is the loudest, but because two other
+items consume its selector: `#412`'s own design notes say grouping has the same defect and wants
+the same selector, and `#498` has to export what the column displays. Building grouping first
+means building that selector twice, the second time through a recursive code path.
+
+`#456` is small, has an agreed design, and touches hit-testing that `#412` also touches. Doing
+it before the grouping re-architecture keeps the two apart.
+
+---
+
+## 1. `#463` — sort and filter on a value the column does not display
+
+**The defect.** A column with a `CellTemplate` resolving a key to a label still sorts and filters
+on the raw property. The user sees `Active / Cancelled / Pending`, clicks the header, and the rows
+reorder by `StatusId`. It reads as a broken grid rather than a template limitation.
+
+**Shape.** One selector, not two:
+
+```razor
+<BbDataGridPropertyColumn Property="x => x.StatusId" Title="Status"
+                          SortAndFilterBy="x => statuses[x.StatusId].StatusName">
+```
+
+Settled deliberately as **one** parameter. Separate `SortBy`/`FilterBy` invites them to disagree,
+which is confusing to debug and impossible to explain. The split stays available later; merging
+two into one afterwards is not.
+
+**Open decisions**
+- **Server-side.** A client `Func` cannot be translated by `ItemsProvider`. Either take
+  `Expression<Func<TData, object>>` so it can project into a query, or document it as
+  client-side only and log when one is set alongside `ItemsProvider`. Prefer the expression.
+- **Grouping** must consume the same selector — see step 3.
+
+**Done when:** header click orders by the visible text, the filter compares against the visible
+text, and a grouped column groups by it too.
+
+---
+
+## 2. `#456` — enterprise row selection
+
+**Shape.** A small enum, as already agreed with the reporter on the issue:
+
+```csharp
+public enum DataGridSelectionBehavior { Toggle, Replace }
+```
+
+`Toggle` is today's behaviour and stays the default, so nothing breaks. `Replace` gives:
+
+| Input | Result |
+|---|---|
+| Click | clear selection, select this row; if already the only selection, clear it |
+| Shift+Click | select the range from the anchor to this row |
+| Ctrl/Cmd+Click | add or remove this row, leave the rest |
+
+**Deliberately not** a pluggable strategy. A public extension point in the middle of selection,
+hit-testing and keyboard nav would constrain steps 1 and 3, and it is close to permanent once
+someone implements one.
+
+**Watch:** the anchor row. Shift+click extends from the last *anchor*, not the last *selected* row
+— those differ after a Ctrl+click. Getting this wrong is the usual bug, and it is what makes the
+feature feel wrong rather than broken. Needs an explicit anchor field, reset on plain click.
+
+Also decide interaction with the checkbox `BbDataGridSelectColumn`: checkbox clicks should stay
+`Toggle` semantics even under `Replace`, or checkboxes become unusable.
+
+---
+
+## 3. `#412` — nested multi-level grouping
+
+The largest of the three, and a re-architecture of group state rather than an increment.
+
+**What is in the way** (from the issue, all still true):
+- `DataGridGroupState.ActiveGroup` is a single `GroupDefinition?`
+- `GroupDefinition` has no parent/child/level/order
+- the grouping pass is one flat `GroupBy`
+- `DataGridGroupRow<TData>` has no `Depth`/`Children`
+- collapsed groups are a flat `HashSet<object>` of raw keys, so nested groups sharing a leaf key
+  collide — needs composite path keys
+- `DataGridGroupedResult<TData>` (server contract) is flat with one `object? Key`
+
+**Design**
+- `ActiveGroup` → ordered `ActiveGroups`, keeping the single-level members as shims.
+- Collapsed keys → a `GroupPath` record with value equality; compute ancestor-collapse at render
+  rather than materialising descendants.
+- Recursive grouping; group rows carry all descendant leaf items so aggregates roll up.
+- Server contract stays **flat**, each row carrying its full group path. That matches what
+  `GROUP BY a, b` returns and avoids inventing a recursive wire shape.
+- Surface: past two levels a per-column menu is unusable. A grouping breadcrumb
+  (`Department › Status ›`) with remove and reorder is the likelier control.
+
+**Pagination is the hard part.** A page boundary can land mid-subtree, so every open ancestor
+header must be re-emitted at the top of the next page or rows lose their context. This is where
+the subtle bugs will be. Budget for it explicitly.
+
+**Fold in the known bug:** grouping + `Virtualize` + `ItemsProvider` renders an empty grid.
+`#411` suppressed the menu action there and logs a warning, but the gap stands. Nesting changes
+the render-list shape anyway, so fix it here rather than leaving a second warning behind.
+
+---
+
+## 4. `#497` — inline / cell editing
+
+**Why.** The clearest remaining gap against Radzen, Syncfusion and MudBlazor, which all ship
+inline and cell editing with validation. It is also the underlying need behind `#464`: that
+reporter wants a JS-free `BbNumericInput` because they are hand-building an editable grid out of
+200 numeric inputs. A real editing mode serves them better than the thing they asked for.
+
+**Shape**
+
+```razor
+<BbDataGrid EditMode="DataGridEditMode.Row" OnRowCommit="Save">
+    <BbDataGridPropertyColumn Property="x => x.Name">
+        <EditTemplate>
+            <BbInput @bind-Value="context.Name" />
+        </EditTemplate>
+    </BbDataGridPropertyColumn>
+```
+
+- `EditMode`: `None` (default), `Cell`, `Row`.
+- `EditTemplate` per column; fall back to a type-appropriate editor when absent.
+- `OnRowCommit` / `OnRowCancel`, both cancellable, returning the edited item.
+- Validation through the existing `EditContext` so `DataAnnotations` work unchanged.
+- Keyboard: Enter commits, Escape cancels, Tab moves cell to cell in `Cell` mode.
+
+**Risks.** Editing interacts with virtualization (an editor scrolled out of view must not lose
+its buffer), with sorting (a row edited into a new sort position should not jump under the
+cursor mid-edit), and with the row context menu. Scope the first pass to `Row` mode only if
+that keeps it landable — `Cell` mode is where most of the complexity is.
+
+**Size:** the largest item here, comfortably larger than `#412`. It deserves its own issue and
+its own plan.
+
+## 5. `#498` — export visible rows to CSV
+
+Small, self-contained, and asked for by every grid consumer eventually.
+
+```razor
+<BbDataGrid ShowExport="true" ExportFileName="employees.csv" />
+```
+
+- Export the **visible, sorted, filtered** rows by default, not the raw source. That is what
+  people mean, and getting it wrong is the usual complaint.
+- Use each column's display value — so it must consume `#463`'s selector. Another reason `#463`
+  goes first.
+- `ExportAsync()` on the grid ref for programmatic use.
+- Respect column visibility and order.
+- Excel is deliberately out of scope: it needs a dependency, and CSV covers the reported need.
+
+**Watch:** CSV injection. A cell starting `=`, `+`, `-` or `@` executes as a formula in Excel.
+Prefix with an apostrophe. This is a security issue, not a formatting one.
+
+---
+
+## Not included, and why
+
+- **`#464` NumericInput JS opt-out** — likely obviated by item 4. Revisit after editing lands
+  rather than building both.
+- **Excel export, PDF export** — dependency cost, no reported demand.
+- **Column groups / banded headers** — not requested, and pinning already covers the common case.
+- **`#486` attribute splatting** — repo-wide, already has PR #490 open.
+
+## Sequencing for the sweep
+
+**Wave 1 — #463 + #456.** Both small. Both fix things that currently read as bugs rather than
+missing features: a column that sorts by an invisible key, and a multi-select that ignores every
+convention the user brought from their file explorer. Ship together.
+
+**Wave 2 — #498.** Small, and #463 has just landed the selector it needs.
+
+**Wave 3 — #412 and #497.** Each is a multi-week piece and each deserves its own plan. They touch
+different parts of the grid — group state and render-list shape versus cell hit-testing and edit
+buffers — so they can run in parallel given capacity. If choosing one, #497 closes the larger
+competitive gap and probably retires #464 with it.
+
+**Do not** start #412 before #463. Grouping needs the same selector, and building it inside the
+recursive grouping pass first means building it twice, the second time in the harder place.

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor
@@ -3,11 +3,12 @@
 @attribute [CascadingTypeParameter(nameof(TData))]
 @using BlazorBlueprint.Icons.Lucide.Components
 @using BlazorBlueprint.Primitives.DataGrid
+@using Microsoft.AspNetCore.Components.Forms
 @inject IBbLocalizer Localizer
 
 <CascadingValue Value="this" IsFixed="true">
     <div class="@ClassNames.cn("w-full", Class)">
-        @if (ShowSearch || Toolbar != null)
+        @if (ShowSearch || ShowExport || Toolbar != null)
         {
             <div class="flex items-center justify-between gap-2 py-4">
                 @if (ShowSearch)
@@ -17,7 +18,74 @@
                              Placeholder="@(SearchPlaceholder ?? Localizer["DataGrid.SearchPlaceholder"])"
                              Class="max-w-sm" />
                 }
-                @Toolbar
+                @if (ShowExport)
+                {
+                    @if (!ShowSearch)
+                    {
+                        @* Keeps the export button on the right when there is no search input on
+                           the left for justify-between to push against. *@
+                        <div></div>
+                    }
+                    <div class="flex items-center gap-2">
+                        @Toolbar
+                        <BbButton Variant="ButtonVariant.Outline"
+                                  Size="ButtonSize.Small"
+                                  OnClick="@(async () => await ExportToCsvAsync())"
+                                  AriaLabel="@Localizer["DataGrid.ExportAriaLabel"]">
+                            <LucideIcon Name="download" Class="w-4 h-4 mr-2" />
+                            @Localizer["DataGrid.Export"]
+                        </BbButton>
+                    </div>
+                }
+                else
+                {
+                    @* Left exactly as it was, so a grid that only supplies a Toolbar keeps its
+                       existing layout. *@
+                    @Toolbar
+                }
+            </div>
+        }
+        @if (ShowGroupingBreadcrumb && _gridState.Grouping.HasGroups)
+        {
+            @* Past two levels a per-column menu stops being a usable way to see or change the
+               grouping, so the active levels are shown in order with their own controls. *@
+            <div class="flex flex-wrap items-center gap-1 pb-3 text-sm" role="group"
+                 aria-label="@Localizer["DataGrid.GroupingBreadcrumbLabel"]">
+                <span class="text-muted-foreground mr-1">@Localizer["DataGrid.GroupingBreadcrumbLabel"]</span>
+                @for (var levelIndex = 0; levelIndex < _gridState.Grouping.ActiveGroups.Count; levelIndex++)
+                {
+                    var level = _gridState.Grouping.ActiveGroups[levelIndex];
+                    var levelTitle = GetGroupLevelTitle(level.ColumnId);
+                    var index = levelIndex;
+
+                    <span class="inline-flex items-center gap-1 rounded-md border bg-muted/50 px-2 py-1">
+                        @if (index > 0)
+                        {
+                            <button type="button"
+                                    class="inline-flex items-center justify-center rounded w-5 h-5 hover:bg-muted transition-colors"
+                                    aria-label="@Localizer["DataGrid.MoveGroupLevelOut", levelTitle]"
+                                    @onclick="@(() => MoveGroupByColumnAsync(level.ColumnId, index - 1))">
+                                <LucideIcon Name="chevron-left" Class="w-3.5 h-3.5" />
+                            </button>
+                        }
+                        <span>@levelTitle</span>
+                        <button type="button"
+                                class="inline-flex items-center justify-center rounded w-5 h-5 hover:bg-muted transition-colors"
+                                aria-label="@Localizer["DataGrid.RemoveGroupLevel", levelTitle]"
+                                @onclick="@(() => RemoveGroupByColumnAsync(level.ColumnId))">
+                            <LucideIcon Name="x" Class="w-3.5 h-3.5" />
+                        </button>
+                    </span>
+                    @if (index < _gridState.Grouping.ActiveGroups.Count - 1)
+                    {
+                        <span class="text-muted-foreground" aria-hidden="true">&#8250;</span>
+                    }
+                }
+                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Small"
+                          Class="ml-1 h-7"
+                          OnClick="ClearGroupingAsync">
+                    @Localizer["DataGrid.ClearGrouping"]
+                </BbButton>
             </div>
         }
         <div @ref="containerRef"
@@ -54,6 +122,10 @@
                     Items="@_processedData"
                     @bind-State="@_gridState"
                     SelectionMode="@GetPrimitiveSelectionMode()"
+                    SelectionBehavior="@SelectionBehavior"
+                    IsRowEditing="@(EditMode != DataGridEditMode.None ? _isRowEditing : null)"
+                    OnCommitEdit="@(EditMode != DataGridEditMode.None ? _commitEditFromRow : null)"
+                    OnCancelEdit="@(EditMode != DataGridEditMode.None ? _cancelEditFromRow : null)"
                     ManualPagination="true"
                     EnableKeyboardNavigation="@EnableKeyboardNavigation"
                     OnSortChange="HandleSortChange"
@@ -261,6 +333,16 @@
                                                                     <LucideIcon Name="group" Class="w-4 h-4 mr-2" />
                                                                     @Localizer["DataGrid.GroupByColumn", menuColumn.Title ?? string.Empty]
                                                                 </BbDropdownMenuItem>
+                                                                @if (_gridState.Grouping.HasGroups)
+                                                                {
+                                                                    @* Only offered once something is already grouped, so a first-time
+                                                                       user is not asked to choose between two actions that do the same
+                                                                       thing. *@
+                                                                    <BbDropdownMenuItem OnClick="@(() => HandleAddGroupColumnAsync(menuColumn.ColumnId))">
+                                                                        <LucideIcon Name="list-tree" Class="w-4 h-4 mr-2" />
+                                                                        @Localizer["DataGrid.AddGroupByColumn", menuColumn.Title ?? string.Empty]
+                                                                    </BbDropdownMenuItem>
+                                                                }
                                                             }
                                                         </BbDropdownMenuContent>
                                                     </BbDropdownMenu>
@@ -448,11 +530,23 @@
 
     private RenderFragment<TData> RenderDataRow => item =>
         @<BlazorBlueprint.Primitives.DataGrid.BbDataGridRow TData="TData" Item="@item"
-            Class="@ClassNames.cn("group/row bg-background", Striped ? StripeClass : null, RowClass?.Invoke(item))">
+            Class="@ClassNames.cn("group/row bg-background", Striped ? StripeClass : null, RowClass?.Invoke(item), IsEditing(item) ? "bg-muted/40" : null)">
+            @{
+                var rowIsEditing = IsEditing(item);
+            }
+            @if (rowIsEditing && _editContext != null)
+            {
+                @* Cascaded rather than wrapped in an EditForm: a form element is not valid inside
+                   a table row, but the validator only needs the context. *@
+                <CascadingValue Value="_editContext" IsFixed="false">
+                    <DataAnnotationsValidator />
+                </CascadingValue>
+            }
             @foreach (var column in _cachedVisibleColumns)
             {
                 var isSelectColumn = column.ColumnId == "__select";
                 var isExpandColumn = column.ColumnId == "__expand";
+                var isEditColumn = column.ColumnId == "__edit";
                 var isLastLeft = column.ColumnId == _cachedLastLeftId;
                 var isFirstRight = column.ColumnId == _cachedFirstRightId;
                 var pinnedStyle = GetPinnedStyle(column, _cachedVisibleColumns);
@@ -462,7 +556,48 @@
                     Class="@GetCellClass(column, isSelectColumn, isExpandColumn, isLastLeft, isFirstRight, item)"
                     style="@pinnedStyle"
                     data-pinned="@(column.Pinned != ColumnPinning.None ? "true" : null)">
-                    @if (isExpandColumn)
+                    @if (isEditColumn)
+                    {
+                        <div @onclick:stopPropagation="true" class="flex items-center gap-1">
+                            @if (rowIsEditing)
+                            {
+                                <BbButton Variant="ButtonVariant.Default" Size="ButtonSize.Small"
+                                          OnClick="@(async () => await CommitEditAsync())"
+                                          AriaLabel="@Localizer["DataGrid.SaveRow"]">
+                                    @Localizer["DataGrid.SaveRow"]
+                                </BbButton>
+                                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Small"
+                                          OnClick="CancelEditAsync"
+                                          AriaLabel="@Localizer["DataGrid.CancelRowEdit"]">
+                                    @Localizer["DataGrid.CancelRowEdit"]
+                                </BbButton>
+                            }
+                            else
+                            {
+                                <BbButton Variant="ButtonVariant.Ghost" Size="ButtonSize.Small"
+                                          OnClick="@(async () => await StartEditAsync(item))"
+                                          AriaLabel="@Localizer["DataGrid.EditRow"]">
+                                    <LucideIcon Name="pencil" Class="w-4 h-4" />
+                                </BbButton>
+                            }
+                        </div>
+                    }
+                    else if (ShouldRenderEditor(column, item))
+                    {
+                        @* Enter commits and Escape cancels from anywhere in the row; the row
+                           itself owns those keys, because a handler here would never see them —
+                           the row's keyboard interceptor stops an input's events reaching
+                           Blazor's document-level delegation. *@
+                        <div @onclick:stopPropagation="true">
+                            @column.EditTemplate!(new BlazorBlueprint.Primitives.DataGrid.DataGridCellContext<TData>
+                            {
+                                Item = item,
+                                Column = column,
+                                Value = column.GetValue(item)
+                            })
+                        </div>
+                    }
+                    else if (isExpandColumn)
                     {
                         @if (DetailTemplate != null || HasDetailRows)
                         {
@@ -508,7 +643,8 @@
         {
             var group = renderItem.GroupRow!;
             var groupKey = group.Key ?? "(empty)";
-            var isCollapsed = _gridState.Grouping.IsCollapsed(groupKey);
+            var isCollapsed = _gridState.Grouping.IsCollapsed(group.Path);
+            var groupIndent = group.Depth * GetGroupIndentSize();
             var effectiveTemplate = _groupColumnHeaderTemplate ?? GroupHeaderTemplate;
             var groupContext = new DataGridGroupContext<TData>
             {
@@ -521,7 +657,8 @@
             if (effectiveTemplate != null)
             {
                 return @<tr role="row" class="bg-muted/50 border-b font-medium">
-                    <td role="gridcell" colspan="@_cachedVisibleColumns.Count" class="px-4 py-2">
+                    <td role="gridcell" colspan="@_cachedVisibleColumns.Count" class="px-4 py-2"
+                        style="@(groupIndent > 0 ? $"padding-left: {groupIndent + 16}px;" : null)">
                         @effectiveTemplate(groupContext)
                     </td>
                 </tr>;
@@ -531,7 +668,7 @@
                 var groupLabelColSpan = GetGroupLabelColSpan(group);
                 return @<tr role="row" class="bg-muted/50 border-b font-medium">
                     <td role="gridcell" colspan="@groupLabelColSpan" class="px-4 py-2">
-                        <div class="flex items-center gap-2">
+                        <div class="flex items-center gap-2" style="@(groupIndent > 0 ? $"padding-left: {groupIndent}px;" : null)">
                             <button type="button"
                                     class="inline-flex items-center justify-center rounded-md w-6 h-6 hover:bg-muted transition-colors"
                                     aria-expanded="@(!isCollapsed)"
@@ -715,4 +852,10 @@
         // Default to 24px
         return 24;
     }
+
+    /// <summary>
+    /// How far each nested grouping level is indented, in pixels. Matches the hierarchy indent so
+    /// a grid that uses both reads as one structure.
+    /// </summary>
+    private int GetGroupIndentSize() => GetHierarchyIndentSize();
 }

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGrid.razor.cs
@@ -6,6 +6,7 @@ using BlazorBlueprint.Primitives.Filtering;
 using BlazorBlueprint.Primitives.Table;
 using BlazorBlueprint.Primitives.Utilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 
@@ -28,6 +29,41 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     private readonly List<IDataGridColumn<TData>> _columns = new();
     private IEnumerable<TData> _processedData = Array.Empty<TData>();
     private IEnumerable<TData> _allSortedData = Array.Empty<TData>();
+
+    /// <summary>
+    /// Every row that survives the current filters, search and sort, across all pages. Null when
+    /// the grid never saw the full set — with an <see cref="ItemsProvider"/> it only holds the
+    /// page it fetched.
+    /// </summary>
+    private IReadOnlyList<TData>? _exportRows;
+
+    private IJSObjectReference? downloadModule;
+
+    private TData? _editingItem;
+
+    private DataGridRowSnapshot<TData>? _editSnapshot;
+
+    private EditContext? _editContext;
+
+    // Held rather than built per render: a fresh lambda each time would make the primitive grid
+    // see a changed parameter on every render of a grid that is not even editable.
+    private readonly Func<Task> _commitEditFromRow;
+
+    private readonly Func<Task> _cancelEditFromRow;
+
+    private readonly Func<TData, bool> _isRowEditing;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BbDataGrid{TData}"/> class.
+    /// </summary>
+    public BbDataGrid()
+    {
+        _commitEditFromRow = async () => await CommitEditAsync();
+        _cancelEditFromRow = CancelEditAsync;
+        _isRowEditing = IsEditing;
+    }
+
+    private bool warnedAboutProviderExportScope;
     private IEnumerable<TData>? _lastProcessedData;
     private List<TData>? _processedDataList;
     private CancellationTokenSource? _loadCts;
@@ -48,7 +84,10 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     private bool _groupsCollapsedByDefault;
     private RenderFragment<DataGridGroupContext<TData>>? _groupColumnHeaderTemplate;
     private Expression<Func<TData, object>>? _lastGroupBy;
-    private List<object>? _allGroupKeys;
+    /// <summary>
+    /// Every group path in the tree the last pass built, at every level. Used by collapse-all.
+    /// </summary>
+    private List<GroupPath>? _allGroupPaths;
     private int _lastGroupingVersion;
     private bool _virtualGroupingWarned;
 
@@ -166,6 +205,30 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     /// </summary>
     [Parameter]
     public DataTableSelectionMode SelectionMode { get; set; } = DataTableSelectionMode.None;
+
+    /// <summary>
+    /// How clicking a row changes the selection.
+    /// Default is <see cref="DataGridSelectionBehavior.Toggle"/>, which is the long-standing
+    /// behaviour: each click flips one row and modifier keys are ignored.
+    /// </summary>
+    /// <remarks>
+    /// Set <see cref="DataGridSelectionBehavior.Replace"/> for the conventions a user brings from
+    /// a file explorer or a spreadsheet: a plain click selects only the clicked row, Shift+Click
+    /// selects the range from the anchor row, and Ctrl+Click (Cmd+Click on macOS) adds or removes
+    /// one row. Clicking the only selected row clears the selection.
+    /// <para>
+    /// Range and additive selection need <see cref="DataTableSelectionMode.Multiple"/>; under
+    /// <see cref="DataTableSelectionMode.Single"/> every click is a plain click. A Shift+Click
+    /// range covers the rows on the current page, because those are the rows the user can see.
+    /// </para>
+    /// <para>
+    /// Two things deliberately keep toggle semantics under either behaviour: the checkboxes in a
+    /// <see cref="BbDataGridSelectColumn{TData}"/>, which would be unusable if ticking one cleared
+    /// the rest, and the Space and Enter keys on a focused row, which act as that row's checkbox.
+    /// </para>
+    /// </remarks>
+    [Parameter]
+    public DataGridSelectionBehavior SelectionBehavior { get; set; } = DataGridSelectionBehavior.Toggle;
 
     /// <summary>
     /// Event callback for selection changes.
@@ -319,6 +382,106 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     /// </summary>
     [Parameter]
     public bool ShowSearch { get; set; }
+
+    /// <summary>
+    /// How the grid lets a user edit rows in place.
+    /// Default is <see cref="DataGridEditMode.None"/>.
+    /// </summary>
+    /// <remarks>
+    /// Set <see cref="DataGridEditMode.Row"/> and give the columns the user may change an
+    /// <c>EditTemplate</c>. A row goes into edit through
+    /// <see cref="BbDataGridEditColumn{TData}"/>, through <see cref="EditOnRowClick"/>, or
+    /// through <see cref="StartEditAsync"/>. Enter commits and Escape cancels.
+    /// </remarks>
+    [Parameter]
+    public DataGridEditMode EditMode { get; set; } = DataGridEditMode.None;
+
+    /// <summary>
+    /// When <c>true</c>, clicking a row puts it into edit. Default is false.
+    /// </summary>
+    /// <remarks>
+    /// Leave this off when the grid also selects on row click, or a click would do both.
+    /// </remarks>
+    [Parameter]
+    public bool EditOnRowClick { get; set; }
+
+    /// <summary>
+    /// Called when a row's edits are committed, before the row closes.
+    /// </summary>
+    /// <remarks>
+    /// The item already carries the user's changes. Set
+    /// <see cref="DataGridRowCommitContext{TData}.Cancel"/> to keep the row in edit — for
+    /// instance when a save is rejected by the server — so the user keeps their typing.
+    /// </remarks>
+    [Parameter]
+    public EventCallback<DataGridRowCommitContext<TData>> OnRowCommit { get; set; }
+
+    /// <summary>
+    /// Called when a row's edits are discarded, after the old values are put back.
+    /// </summary>
+    [Parameter]
+    public EventCallback<TData> OnRowCancel { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, renders an Export button above the grid that downloads the rows as CSV.
+    /// Default is false.
+    /// </summary>
+    /// <remarks>
+    /// The button appears in the same toolbar row as <see cref="ShowSearch"/> and
+    /// <see cref="Toolbar"/>. Call <see cref="ExportToCsvAsync"/> on a grid reference instead to
+    /// export from a button of your own.
+    /// </remarks>
+    [Parameter]
+    public bool ShowExport { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, shows a breadcrumb of the active grouping levels above the grid, with a
+    /// control on each to remove it or move it outward. Default is true.
+    /// </summary>
+    /// <remarks>
+    /// The breadcrumb only appears while something is grouped. It is the practical way to see and
+    /// change a nested grouping: past two levels, reading the order out of the per-column menus
+    /// stops working. Set it false when the grouping is fixed by the page and the user should not
+    /// change it.
+    /// </remarks>
+    [Parameter]
+    public bool ShowGroupingBreadcrumb { get; set; } = true;
+
+    /// <summary>
+    /// The file name offered for the CSV download. Default is <c>export.csv</c>.
+    /// </summary>
+    /// <remarks>
+    /// A <c>.csv</c> extension is appended when the name has none.
+    /// </remarks>
+    [Parameter]
+    public string ExportFileName { get; set; } = "export.csv";
+
+    /// <summary>
+    /// The field delimiter written between CSV values. Default is a comma.
+    /// </summary>
+    /// <remarks>
+    /// Set this to <c>";"</c> for locales where a spreadsheet expects a semicolon, which is the
+    /// usual reason a CSV opens with every row crammed into one column.
+    /// </remarks>
+    [Parameter]
+    public string ExportDelimiter { get; set; } = ",";
+
+    /// <summary>
+    /// Which rows the export writes. Default is
+    /// <see cref="DataGridExportScope.FilteredRows"/>.
+    /// </summary>
+    [Parameter]
+    public DataGridExportScope ExportScope { get; set; } = DataGridExportScope.FilteredRows;
+
+    /// <summary>
+    /// Called after an export completes, with the CSV text that was downloaded.
+    /// </summary>
+    /// <remarks>
+    /// Use it to log the export or to send the same text somewhere else. The download happens
+    /// either way.
+    /// </remarks>
+    [Parameter]
+    public EventCallback<string> OnExport { get; set; }
 
     /// <summary>
     /// The current global search text. Use with <c>@bind-SearchText</c> for two-way binding.
@@ -864,6 +1027,14 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     }
 
     /// <summary>
+    /// Registers an edit column.
+    /// </summary>
+    internal void RegisterColumn(BbDataGridEditColumn<TData> column)
+    {
+        AddColumn(column);
+    }
+
+    /// <summary>
     /// Registers a select column. Always laid out first, ahead of every data column.
     /// </summary>
     internal void RegisterColumn(BbDataGridSelectColumn<TData> column)
@@ -1030,14 +1201,41 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     /// than only against a markup-configured expression.
     /// Returns null when no grouping is active or the target column is not registered.
     /// </summary>
-    private GroupResolution? ResolveGrouping()
+    /// <summary>
+    /// Resolves every active group level into an accessor, outermost first.
+    /// Returns an empty list when no grouping is active.
+    /// </summary>
+    /// <remarks>
+    /// A level whose column is not registered is dropped rather than failing the pass, and every
+    /// level after it is dropped too: grouping by A then C when B is missing would silently mean
+    /// something different from what the state says.
+    /// </remarks>
+    private IReadOnlyList<GroupResolution> ResolveGroupings()
     {
-        var activeGroup = _gridState.Grouping.ActiveGroup;
-        if (activeGroup == null)
+        var activeGroups = _gridState.Grouping.ActiveGroups;
+        if (activeGroups.Count == 0)
         {
-            return null;
+            return Array.Empty<GroupResolution>();
         }
 
+        var resolved = new List<GroupResolution>(activeGroups.Count);
+
+        foreach (var activeGroup in activeGroups)
+        {
+            var level = ResolveGroupLevel(activeGroup);
+            if (level == null)
+            {
+                break;
+            }
+
+            resolved.Add(level.Value);
+        }
+
+        return resolved;
+    }
+
+    private GroupResolution? ResolveGroupLevel(GroupDefinition activeGroup)
+    {
         // GroupBy / BbDataGridGroupColumn supply their own accessor, which may group by an
         // arbitrary expression that has no corresponding column.
         if (_groupByAccessor != null && activeGroup.ColumnId == _groupByColumnId)
@@ -1049,7 +1247,7 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
         {
             if (column.ColumnId == activeGroup.ColumnId)
             {
-                return new GroupResolution(column.GetRawValue, column.ColumnId, column.Title);
+                return new GroupResolution(column.GetSortAndFilterValue, column.ColumnId, column.Title);
             }
         }
 
@@ -1072,6 +1270,15 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
             _gridState.Grouping.SetGroup(definition);
         }
 
+        MarkGroupingApplied();
+    }
+
+    /// <summary>
+    /// Records that the grid itself changed the grouping, so the next pass does not re-detect it
+    /// as a change made from outside, and drops the render list built for the old shape.
+    /// </summary>
+    private void MarkGroupingApplied()
+    {
         _lastGroupingVersion = _gridState.Grouping.Version;
         _groupedRenderItems = null;
         _needsDataRefresh = true;
@@ -1086,7 +1293,30 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
 
     private bool CanGroupColumn(IDataGridColumn<TData> column) => column.Groupable && SupportsGrouping;
 
-    private bool IsGroupedBy(string columnId) => _gridState.Grouping.ActiveGroup?.ColumnId == columnId;
+    private bool IsGroupedBy(string columnId) => _gridState.Grouping.IsGroupedBy(columnId);
+
+    /// <summary>
+    /// Gets the label for a grouping level: the column's title, or the column id when the column
+    /// is not registered — which happens when grouping was restored from a snapshot taken against
+    /// a different set of columns.
+    /// </summary>
+    private string GetGroupLevelTitle(string columnId)
+    {
+        if (_groupByColumnId == columnId && !string.IsNullOrEmpty(_groupByColumnTitle))
+        {
+            return _groupByColumnTitle;
+        }
+
+        foreach (var column in _columns)
+        {
+            if (column.ColumnId == columnId)
+            {
+                return column.Title ?? columnId;
+            }
+        }
+
+        return columnId;
+    }
 
     private bool GetHeaderMenuOpen(string columnId) =>
         _headerMenuOpen.TryGetValue(columnId, out var open) && open;
@@ -1108,7 +1338,13 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     private async Task HandleUngroupColumnAsync(string columnId)
     {
         _headerMenuOpen[columnId] = false;
-        await ClearGroupingAsync();
+        await RemoveGroupByColumnAsync(columnId);
+    }
+
+    private async Task HandleAddGroupColumnAsync(string columnId)
+    {
+        _headerMenuOpen[columnId] = false;
+        await AddGroupByColumnAsync(columnId);
     }
 
     /// <summary>
@@ -1268,6 +1504,92 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     }
 
     /// <summary>
+    /// Adds a grouping level inside the levels already active, so rows group by the existing
+    /// columns first and then by this one.
+    /// </summary>
+    /// <remarks>
+    /// Does nothing when the column already groups at some level. Collapsed state is cleared,
+    /// because every path is now one level short of identifying a group.
+    /// </remarks>
+    /// <param name="columnId">The column to group by.</param>
+    /// <param name="direction">The order the new level's groups appear in.</param>
+    public async Task AddGroupByColumnAsync(string columnId, SortDirection direction = SortDirection.Ascending)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(columnId);
+
+        if (!_gridState.Grouping.AddGroup(new GroupDefinition
+        {
+            ColumnId = columnId,
+            GroupSortDirection = direction
+        }))
+        {
+            return;
+        }
+
+        MarkGroupingApplied();
+        await RefreshDataAsync();
+        await NotifyStateChangedAsync();
+    }
+
+    /// <summary>
+    /// Removes one grouping level, leaving the others in order.
+    /// </summary>
+    /// <param name="columnId">The column to stop grouping by.</param>
+    public async Task RemoveGroupByColumnAsync(string columnId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(columnId);
+
+        if (!_gridState.Grouping.RemoveGroup(columnId))
+        {
+            return;
+        }
+
+        MarkGroupingApplied();
+        await RefreshDataAsync();
+        await NotifyStateChangedAsync();
+    }
+
+    /// <summary>
+    /// Moves a grouping level to a different position, changing which column groups outermost.
+    /// </summary>
+    /// <param name="columnId">The column whose level should move.</param>
+    /// <param name="newIndex">The zero-based position among the remaining levels.</param>
+    public async Task MoveGroupByColumnAsync(string columnId, int newIndex)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(columnId);
+
+        if (!_gridState.Grouping.MoveGroup(columnId, newIndex))
+        {
+            return;
+        }
+
+        MarkGroupingApplied();
+        await RefreshDataAsync();
+        await NotifyStateChangedAsync();
+    }
+
+    /// <summary>
+    /// Replaces every grouping level at once, outermost first.
+    /// </summary>
+    /// <param name="columnIds">The columns to group by, outermost first. Empty clears grouping.</param>
+    /// <param name="direction">The order every level's groups appear in.</param>
+    public async Task SetGroupingAsync(
+        IEnumerable<string> columnIds, SortDirection direction = SortDirection.Ascending)
+    {
+        ArgumentNullException.ThrowIfNull(columnIds);
+
+        _gridState.Grouping.SetGroups(columnIds.Select(id => new GroupDefinition
+        {
+            ColumnId = id,
+            GroupSortDirection = direction
+        }));
+
+        MarkGroupingApplied();
+        await RefreshDataAsync();
+        await NotifyStateChangedAsync();
+    }
+
+    /// <summary>
     /// Clears any active grouping, returning the grid to flat rows.
     /// </summary>
     public async Task ClearGroupingAsync()
@@ -1319,6 +1641,8 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
 
         if (ItemsProvider != null)
         {
+            // The provider only returns the requested page, so there is no full set to export.
+            _exportRows = null;
             await LoadFromProviderAsync();
         }
         else if (Items != null)
@@ -1329,6 +1653,7 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
         {
             _processedData = Array.Empty<TData>();
             _processedDataList = null;
+            _exportRows = Array.Empty<TData>();
         }
 
         _stateVersion++;
@@ -1354,9 +1679,9 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
 
             var sortedList = ApplyGlobalSearch(sorted.ToList()).ToList();
 
-            if (ResolveGrouping() is { } queryableGrouping)
+            if (ResolveGroupings() is { Count: > 0 } queryableGroupings)
             {
-                ProcessGroupedData(sortedList, queryableGrouping);
+                ProcessGroupedData(sortedList, queryableGroupings);
                 return;
             }
 
@@ -1376,6 +1701,7 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
             }
 
             _allSortedData = Array.Empty<TData>();
+            _exportRows = sortedList;
         }
         else
         {
@@ -1386,14 +1712,15 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
             var searched = ApplyGlobalSearch(sorted);
             var list = searched as IList<TData> ?? searched.ToList();
 
-            if (ResolveGrouping() is { } grouping)
+            if (ResolveGroupings() is { Count: > 0 } groupings)
             {
-                ProcessGroupedData(list, grouping);
+                ProcessGroupedData(list, groupings);
                 return;
             }
 
             _groupedRenderItems = null;
             _allSortedData = list;
+            _exportRows = list as IReadOnlyList<TData> ?? list.ToList();
             _gridState.Pagination.TotalItems = list.Count;
 
             if (Virtualize)
@@ -1429,147 +1756,259 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
         UpdateVirtualizationList();
     }
 
-    private void ProcessGroupedData(IList<TData> sortedData, GroupResolution grouping)
+    /// <summary>
+    /// Groups the rows into a tree, one level per active group definition, and flattens the part
+    /// of that tree the current page shows.
+    /// </summary>
+    /// <remarks>
+    /// A page boundary can land part-way through a subtree. Every open ancestor of the first row
+    /// on a page is re-emitted at the top of that page, so a row never appears without the headers
+    /// that say what it belongs to.
+    /// </remarks>
+    private void ProcessGroupedData(IList<TData> sortedData, IReadOnlyList<GroupResolution> groupings)
     {
-        var groupDef = _gridState.Grouping.ActiveGroup;
-        var accessor = grouping.Accessor;
+        var levels = _gridState.Grouping.ActiveGroups;
 
-        // Group the sorted data
-        var groups = sortedData
-            .GroupBy(item => accessor(item))
-            .ToList();
-
-        // Sort groups by key
-        if (groupDef?.GroupSortDirection == SortDirection.Descending)
-        {
-            groups = groups.OrderByDescending(g => g.Key).ToList();
-        }
-        else
-        {
-            groups = groups.OrderBy(g => g.Key).ToList();
-        }
-
-        // Handle collapsed-by-default on first process
-        var isFirstProcess = _gridState.Grouping.CollapsedKeys.Count == 0
+        // Collapse-by-default only applies the first time, and only to the outermost level:
+        // collapsing every level would hide the nesting the user just asked for.
+        var isFirstProcess = _gridState.Grouping.CollapsedPaths.Count == 0
             && _groupsCollapsedByDefault
             && _groupedRenderItems == null;
 
-        // Build ordered list of groups with their metadata
-        var groupInfos = new List<(object Key, List<TData> Items, DataGridGroupRow<TData> Row)>();
-        foreach (var group in groups)
-        {
-            var items = group.ToList();
-            var groupKey = group.Key ?? "(empty)";
-
-            if (isFirstProcess && _groupsCollapsedByDefault)
-            {
-                _gridState.Grouping.CollapseAll(new[] { groupKey });
-            }
-
-            var aggregates = ComputeAggregates(items, _columns);
-            var groupRow = new DataGridGroupRow<TData>
-            {
-                Key = groupKey,
-                ColumnId = grouping.ColumnId,
-                ColumnTitle = grouping.Title,
-                ItemCount = items.Count,
-                Items = items,
-                Aggregates = aggregates
-            };
-
-            groupInfos.Add((groupKey, items, groupRow));
-        }
+        var roots = BuildGroupTree(sortedData, groupings, levels, GroupPath.Root, 0, isFirstProcess);
 
         _allSortedData = sortedData;
-        _allGroupKeys = groupInfos.Select(g => g.Key).ToList();
+        _exportRows = sortedData as IReadOnlyList<TData> ?? sortedData.ToList();
+        _allGroupPaths = CollectGroupPaths(roots);
 
-        // Count total visible data rows (collapsed groups contribute 0 data rows)
-        var totalDataRows = 0;
-        foreach (var (key, items, _) in groupInfos)
-        {
-            if (!_gridState.Grouping.IsCollapsed(key))
-            {
-                totalDataRows += items.Count;
-            }
-        }
+        _gridState.Pagination.TotalItems = CountVisibleDataRows(roots);
 
-        _gridState.Pagination.TotalItems = totalDataRows;
+        var window = Virtualize
+            ? new GroupPageWindow(0, int.MaxValue)
+            : new GroupPageWindow(
+                _gridState.Pagination.StartIndex,
+                // Saturating add: a page size large enough to mean "everything" would otherwise
+                // overflow to a negative end and render no rows at all.
+                (int)Math.Min(
+                    int.MaxValue,
+                    (long)_gridState.Pagination.StartIndex + _gridState.Pagination.PageSize));
 
-        if (Virtualize)
-        {
-            // For virtualization, build the full flattened list
-            var allRenderItems = new List<DataGridRenderItem<TData>>();
-            var allDataItems = new List<TData>();
-            foreach (var (key, items, row) in groupInfos)
-            {
-                allRenderItems.Add(DataGridRenderItem<TData>.ForGroup(row));
-                if (!_gridState.Grouping.IsCollapsed(key))
-                {
-                    foreach (var item in items)
-                    {
-                        allRenderItems.Add(DataGridRenderItem<TData>.ForData(item));
-                        allDataItems.Add(item);
-                    }
-                }
-            }
+        EmitGroups(roots, new List<DataGridGroupRow<TData>>(), window);
 
-            _groupedRenderItems = allRenderItems;
-            _processedData = allDataItems;
-        }
-        else
-        {
-            // Paginate by data rows only — group headers are "free" and don't count.
-            // Groups that span a page boundary get their header repeated on each page.
-            // Collapsed groups appear at their natural position between expanded groups.
-            var pageStart = _gridState.Pagination.StartIndex;
-            var pageSize = _gridState.Pagination.PageSize;
-            var pageEnd = pageStart + pageSize;
-            var pageRenderItems = new List<DataGridRenderItem<TData>>();
-            var pageDataItems = new List<TData>();
-            var dataRowIndex = 0;
-
-            foreach (var (key, items, row) in groupInfos)
-            {
-                var isCollapsed = _gridState.Grouping.IsCollapsed(key);
-
-                if (isCollapsed)
-                {
-                    // Collapsed groups appear at the current data row position.
-                    // Show them if that position falls within (or at the boundary of) the current page.
-                    if (dataRowIndex >= pageStart && dataRowIndex < pageEnd)
-                    {
-                        pageRenderItems.Add(DataGridRenderItem<TData>.ForGroup(row));
-                    }
-                }
-                else
-                {
-                    var groupDataEnd = dataRowIndex + items.Count;
-
-                    if (groupDataEnd > pageStart && dataRowIndex < pageEnd)
-                    {
-                        // This group has data rows on the current page — emit header
-                        pageRenderItems.Add(DataGridRenderItem<TData>.ForGroup(row));
-
-                        // Emit only the data rows that fall within the page window
-                        var skipInGroup = Math.Max(0, pageStart - dataRowIndex);
-                        var takeFromGroup = Math.Min(items.Count - skipInGroup, pageEnd - (dataRowIndex + skipInGroup));
-
-                        for (var i = skipInGroup; i < skipInGroup + takeFromGroup; i++)
-                        {
-                            pageRenderItems.Add(DataGridRenderItem<TData>.ForData(items[i]));
-                            pageDataItems.Add(items[i]);
-                        }
-                    }
-
-                    dataRowIndex += items.Count;
-                }
-            }
-
-            _groupedRenderItems = pageRenderItems;
-            _processedData = pageDataItems;
-        }
+        _groupedRenderItems = window.RenderItems;
+        _processedData = window.DataItems;
 
         UpdateVirtualizationList();
+    }
+
+    /// <summary>
+    /// Builds one level of the group tree and recurses into the next, so each group carries every
+    /// item beneath it and its aggregates roll up rather than counting only the leaf level.
+    /// </summary>
+    private List<DataGridGroupRow<TData>> BuildGroupTree(
+        IList<TData> items,
+        IReadOnlyList<GroupResolution> groupings,
+        IReadOnlyList<GroupDefinition> levels,
+        GroupPath parentPath,
+        int depth,
+        bool collapseOutermostByDefault)
+    {
+        var grouping = groupings[depth];
+        var accessor = grouping.Accessor;
+
+        var grouped = items.GroupBy(item => accessor(item)).ToList();
+
+        grouped = depth < levels.Count && levels[depth].GroupSortDirection == SortDirection.Descending
+            ? grouped.OrderByDescending(g => g.Key).ToList()
+            : grouped.OrderBy(g => g.Key).ToList();
+
+        var rows = new List<DataGridGroupRow<TData>>(grouped.Count);
+
+        foreach (var group in grouped)
+        {
+            var groupItems = group.ToList();
+            var groupKey = group.Key ?? "(empty)";
+            var path = parentPath.Append(groupKey);
+
+            if (collapseOutermostByDefault && depth == 0)
+            {
+                _gridState.Grouping.CollapseAll(new[] { path });
+            }
+
+            var children = depth + 1 < groupings.Count
+                ? BuildGroupTree(groupItems, groupings, levels, path, depth + 1, false)
+                : new List<DataGridGroupRow<TData>>();
+
+            rows.Add(new DataGridGroupRow<TData>
+            {
+                Key = groupKey,
+                Path = path,
+                Depth = depth,
+                ColumnId = grouping.ColumnId,
+                ColumnTitle = grouping.Title,
+                ItemCount = groupItems.Count,
+                Items = groupItems,
+                Children = children,
+                Aggregates = ComputeAggregates(groupItems, _columns)
+            });
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// Counts the data rows a fully rendered grid would show. A collapsed group contributes none,
+    /// including every group nested inside it.
+    /// </summary>
+    private int CountVisibleDataRows(IReadOnlyList<DataGridGroupRow<TData>> groups)
+    {
+        var total = 0;
+
+        foreach (var group in groups)
+        {
+            if (_gridState.Grouping.IsCollapsed(group.Path))
+            {
+                continue;
+            }
+
+            total += group.Children.Count > 0
+                ? CountVisibleDataRows(group.Children)
+                : group.ItemCount;
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// Collects every group path in the tree, used by expand-all and collapse-all.
+    /// </summary>
+    private static List<GroupPath> CollectGroupPaths(IReadOnlyList<DataGridGroupRow<TData>> groups)
+    {
+        var paths = new List<GroupPath>();
+        Collect(groups);
+        return paths;
+
+        void Collect(IReadOnlyList<DataGridGroupRow<TData>> level)
+        {
+            foreach (var group in level)
+            {
+                paths.Add(group.Path);
+                Collect(group.Children);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The slice of data rows a page shows, and the render list being built for it.
+    /// </summary>
+    private sealed class GroupPageWindow
+    {
+        public GroupPageWindow(int pageStart, int pageEnd)
+        {
+            PageStart = pageStart;
+            PageEnd = pageEnd;
+        }
+
+        public int PageStart { get; }
+
+        public int PageEnd { get; }
+
+        /// <summary>
+        /// How many data rows the walk has passed, counting rows on earlier pages.
+        /// </summary>
+        public int DataIndex { get; set; }
+
+        public List<DataGridRenderItem<TData>> RenderItems { get; } = new();
+
+        public List<TData> DataItems { get; } = new();
+
+        /// <summary>
+        /// The group headers already written to this page, so an ancestor re-emitted for one row
+        /// is not written again for the next.
+        /// </summary>
+        public HashSet<GroupPath> EmittedHeaders { get; } = new();
+    }
+
+    /// <summary>
+    /// Walks the group tree in render order and writes the part of it that falls on the page.
+    /// </summary>
+    private void EmitGroups(
+        IReadOnlyList<DataGridGroupRow<TData>> groups,
+        List<DataGridGroupRow<TData>> chain,
+        GroupPageWindow window)
+    {
+        foreach (var group in groups)
+        {
+            if (window.DataIndex >= window.PageEnd)
+            {
+                // Everything from here on is on a later page. Headers for it are re-emitted there.
+                return;
+            }
+
+            chain.Add(group);
+
+            if (_gridState.Grouping.IsCollapsed(group.Path))
+            {
+                // A collapsed group shows no rows, so it sits at the position of the row that
+                // would have come next and does not advance the count.
+                if (window.DataIndex >= window.PageStart && window.DataIndex < window.PageEnd)
+                {
+                    EmitChain(chain, window);
+                }
+            }
+            else if (group.Children.Count > 0)
+            {
+                // The header is written by whichever descendant first lands on the page, which is
+                // what re-emits it after a page break.
+                EmitGroups(group.Children, chain, window);
+            }
+            else
+            {
+                EmitLeafGroup(group, chain, window);
+            }
+
+            chain.RemoveAt(chain.Count - 1);
+        }
+    }
+
+    /// <summary>
+    /// Writes the rows of an innermost group that fall on the page, preceded by its headers.
+    /// </summary>
+    private static void EmitLeafGroup(
+        DataGridGroupRow<TData> group,
+        List<DataGridGroupRow<TData>> chain,
+        GroupPageWindow window)
+    {
+        var skip = Math.Max(0, window.PageStart - window.DataIndex);
+        var take = Math.Min(group.ItemCount - skip, window.PageEnd - (window.DataIndex + skip));
+
+        if (take > 0)
+        {
+            EmitChain(chain, window);
+
+            for (var i = skip; i < skip + take; i++)
+            {
+                window.RenderItems.Add(
+                    DataGridRenderItem<TData>.ForGroupedData(group.Items[i], group.Depth + 1));
+                window.DataItems.Add(group.Items[i]);
+            }
+        }
+
+        window.DataIndex += group.ItemCount;
+    }
+
+    /// <summary>
+    /// Writes any header in the ancestor chain that this page has not shown yet.
+    /// </summary>
+    private static void EmitChain(List<DataGridGroupRow<TData>> chain, GroupPageWindow window)
+    {
+        foreach (var ancestor in chain)
+        {
+            if (window.EmittedHeaders.Add(ancestor.Path))
+            {
+                window.RenderItems.Add(DataGridRenderItem<TData>.ForGroup(ancestor));
+            }
+        }
     }
 
     private static Dictionary<string, AggregateResult> ComputeAggregates(
@@ -1887,6 +2326,13 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
             HasChildrenPredicate,
             effectiveFilterMode);
 
+        // Every visible data row across all pages, in the order the tree renders them. Child pager
+        // rows are not data, so they are left out of the export.
+        _exportRows = flatResult
+            .Where(r => !r.IsChildPagerRow)
+            .Select(r => r.Item)
+            .ToList();
+
         // Build render items with hierarchy metadata, applying pagination.
         // When a filter is active, paginate by total visible rows to prevent
         // a single root with thousands of expanded descendants from rendering
@@ -2065,7 +2511,7 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
         {
             foreach (var (column, condition) in columnFilters)
             {
-                var value = column.GetRawValue(item);
+                var value = column.GetSortAndFilterValue(item);
                 if (!EvaluateFilter(value, condition))
                 {
                     return false;
@@ -2417,11 +2863,11 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
                 .Select(c => c.ColumnId)
                 .ToList();
 
-            var grouping = ResolveGrouping();
+            var providerGroupings = ResolveGroupings();
 
             // When grouping client-side from a flat provider, fetch all items so
             // ProcessGroupedData can correctly paginate across groups.
-            var isClientSideGrouping = grouping != null && GroupedItemsProvider == null;
+            var isClientSideGrouping = providerGroupings.Count > 0 && GroupedItemsProvider == null;
 
             var request = new DataGridRequest
             {
@@ -2431,18 +2877,19 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
                 CancellationToken = token,
                 Filters = _gridState.Filtering.Filters,
                 GroupDefinition = _gridState.Grouping.ActiveGroup,
+                GroupDefinitions = _gridState.Grouping.ActiveGroups,
                 AggregateColumns = aggregateColumns.Count > 0 ? aggregateColumns : null,
                 SearchText = SearchText
             };
 
             // Use grouped provider when grouping is active and provider is available
-            if (grouping != null && GroupedItemsProvider != null)
+            if (providerGroupings.Count > 0 && GroupedItemsProvider != null)
             {
                 var groupedResult = await GroupedItemsProvider(request);
 
                 if (!token.IsCancellationRequested)
                 {
-                    BuildRenderItemsFromGroupedResult(groupedResult, grouping.Value);
+                    BuildRenderItemsFromGroupedResult(groupedResult, providerGroupings);
                 }
             }
             else
@@ -2451,11 +2898,11 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
 
                 if (!token.IsCancellationRequested)
                 {
-                    if (grouping is { } providerGrouping)
+                    if (providerGroupings.Count > 0)
                     {
                         // Group client-side from flat provider results
                         var items = result.Items as IList<TData> ?? result.Items.ToList();
-                        ProcessGroupedData(items, providerGrouping);
+                        ProcessGroupedData(items, providerGroupings);
                     }
                     else
                     {
@@ -2473,43 +2920,104 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
         }
     }
 
+    /// <summary>
+    /// Turns a server-grouped result into the render list.
+    /// </summary>
+    /// <remarks>
+    /// The wire shape stays flat: one entry per innermost group, each carrying its full key path.
+    /// That is what <c>GROUP BY a, b</c> already returns, so a provider projects straight from a
+    /// query instead of reshaping the result into a tree. The ancestor headers are rebuilt here
+    /// from the paths, and a header is written once however many innermost groups sit under it.
+    /// <para>
+    /// The server has already paged, so the result is rendered whole rather than sliced again.
+    /// </para>
+    /// </remarks>
     private void BuildRenderItemsFromGroupedResult(
-        DataGridGroupedResult<TData> groupedResult, GroupResolution grouping)
+        DataGridGroupedResult<TData> groupedResult, IReadOnlyList<GroupResolution> groupings)
     {
         var allRenderItems = new List<DataGridRenderItem<TData>>();
         var allDataItems = new List<TData>();
+        var emittedHeaders = new HashSet<GroupPath>();
+        var allPaths = new List<GroupPath>();
 
         foreach (var group in groupedResult.Groups)
         {
-            var groupKey = group.Key ?? "(empty)";
             var items = group.Items.ToList();
+            var keys = ResolveGroupKeyPath(group);
 
-            var groupRow = new DataGridGroupRow<TData>
+            // Write any ancestor header this result has not shown yet, outermost first.
+            var path = GroupPath.Root;
+            var hiddenByCollapse = false;
+
+            for (var depth = 0; depth < keys.Count; depth++)
             {
-                Key = groupKey,
-                ColumnId = grouping.ColumnId,
-                ColumnTitle = grouping.Title,
-                ItemCount = group.ItemCount > 0 ? group.ItemCount : items.Count,
-                Items = items,
-                Aggregates = group.Aggregates ?? new Dictionary<string, AggregateResult>()
-            };
+                path = path.Append(keys[depth]);
 
-            allRenderItems.Add(DataGridRenderItem<TData>.ForGroup(groupRow));
-
-            if (!_gridState.Grouping.IsCollapsed(groupKey))
-            {
-                foreach (var item in items)
+                if (hiddenByCollapse)
                 {
-                    allRenderItems.Add(DataGridRenderItem<TData>.ForData(item));
-                    allDataItems.Add(item);
+                    continue;
                 }
+
+                if (emittedHeaders.Add(path))
+                {
+                    allPaths.Add(path);
+
+                    var level = depth < groupings.Count ? groupings[depth] : groupings[^1];
+                    allRenderItems.Add(DataGridRenderItem<TData>.ForGroup(new DataGridGroupRow<TData>
+                    {
+                        Key = keys[depth],
+                        Path = path,
+                        Depth = depth,
+                        ColumnId = level.ColumnId,
+                        ColumnTitle = level.Title,
+                        ItemCount = depth == keys.Count - 1
+                            ? (group.ItemCount > 0 ? group.ItemCount : items.Count)
+                            : items.Count,
+                        Items = items,
+                        Aggregates = depth == keys.Count - 1
+                            ? group.Aggregates ?? new Dictionary<string, AggregateResult>()
+                            : new Dictionary<string, AggregateResult>()
+                    }));
+                }
+
+                if (_gridState.Grouping.IsCollapsed(path))
+                {
+                    hiddenByCollapse = true;
+                }
+            }
+
+            if (hiddenByCollapse)
+            {
+                continue;
+            }
+
+            foreach (var item in items)
+            {
+                allRenderItems.Add(DataGridRenderItem<TData>.ForGroupedData(item, keys.Count));
+                allDataItems.Add(item);
             }
         }
 
+        _allGroupPaths = allPaths;
         _gridState.Pagination.TotalItems = groupedResult.TotalItemCount;
         _groupedRenderItems = allRenderItems;
         _processedData = allDataItems;
+        _exportRows = null;
         UpdateVirtualizationList();
+    }
+
+    /// <summary>
+    /// Gets the ordered keys for a server-supplied group, falling back to its single
+    /// <see cref="DataGridGroupResult{TData}.Key"/> when no path was given.
+    /// </summary>
+    private static IReadOnlyList<object?> ResolveGroupKeyPath(DataGridGroupResult<TData> group)
+    {
+        if (group.KeyPath is { Count: > 0 } path)
+        {
+            return path.Select(k => k ?? "(empty)").ToList();
+        }
+
+        return new object?[] { group.Key ?? "(empty)" };
     }
 
     private async Task NotifyStateChangedAsync()
@@ -2607,6 +3115,16 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
                 continue;
             }
 
+            // A column with its own sort/filter selector filters on the value it displays, so the
+            // predicate is built from that projection rather than from the column's property.
+            var selector = column.GetSortAndFilterExpression();
+            if (selector != null)
+            {
+                queryable = queryable.Where(
+                    condition.ToExpressionForSelector<TData>(selector, GetFilterFieldTypeForColumn(column)));
+                continue;
+            }
+
             var field = GetFilterFieldForColumn(column);
             if (field == null)
             {
@@ -2690,6 +3208,18 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
                         return true;
                     }
                 }
+
+                // And the sort/filter value, which for a template column is the label the user
+                // actually reads — searching for it should find the row.
+                if (column.GetSortAndFilterExpression() != null)
+                {
+                    var displayValue = column.GetSortAndFilterValue(item);
+                    var displayStr = displayValue?.ToString();
+                    if (displayStr != null && displayStr.Contains(searchText, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
             }
 
             return false;
@@ -2716,6 +3246,18 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
                 continue;
             }
 
+            // A column with its own sort/filter selector filters on the value it displays, so the
+            // condition is tested against that projection rather than against a reflected property.
+            if (column.GetSortAndFilterExpression() != null)
+            {
+                var selectorColumn = column;
+                var selectorCondition = condition;
+                var selectorFieldType = GetFilterFieldTypeForColumn(column);
+                data = data.Where(item =>
+                    selectorCondition.MatchesValue(selectorColumn.GetSortAndFilterValue(item), selectorFieldType));
+                continue;
+            }
+
             var field = GetFilterFieldForColumn(column);
             if (field == null)
             {
@@ -2733,6 +3275,13 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
 
         return data;
     }
+
+    /// <summary>
+    /// Gets the filter field type for a column, or null when the column does not declare one.
+    /// Used to pick whole-day semantics for date comparisons.
+    /// </summary>
+    private static FilterFieldType? GetFilterFieldTypeForColumn(IDataGridColumn<TData> column) =>
+        column is IFilterableColumn filterable ? filterable.GetFilterFieldType() : null;
 
     private static FilterField? GetFilterFieldForColumn(IDataGridColumn<TData> column)
     {
@@ -2995,6 +3544,10 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
             _gridState.Selection.Deselect(item);
         }
 
+        // A checkbox click moves the anchor, so a following Shift+Click extends from the row the
+        // user last acted on rather than from wherever the anchor happened to be.
+        _gridState.Selection.Anchor = item;
+
         if (HierarchySelectionMode == HierarchySelectionMode.Cascade
             && IsHierarchyMode && _hierarchyManager != null && ItemValueSelector != null)
         {
@@ -3102,9 +3655,11 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
 
     internal async Task HandleGroupToggle(DataGridGroupRow<TData> groupRow)
     {
-        var key = groupRow.Key ?? "(empty)";
-        var wasCollapsed = _gridState.Grouping.IsCollapsed(key);
-        _gridState.Grouping.Toggle(key);
+        // Keyed by the full path, so collapsing "Active" under Sales leaves "Active" under
+        // Support alone.
+        var path = groupRow.Path;
+        var wasCollapsed = _gridState.Grouping.IsCollapsed(path);
+        _gridState.Grouping.Toggle(path);
 
         // Reprocess to rebuild the flattened render items
         await ProcessDataAsync();
@@ -3144,12 +3699,12 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
     /// </summary>
     public async Task CollapseAllGroups()
     {
-        if (_allGroupKeys == null || _allGroupKeys.Count == 0)
+        if (_allGroupPaths == null || _allGroupPaths.Count == 0)
         {
             return;
         }
 
-        _gridState.Grouping.CollapseAll(_allGroupKeys);
+        _gridState.Grouping.CollapseAll(_allGroupPaths);
         await ProcessDataAsync();
         StateHasChanged();
     }
@@ -3179,9 +3734,13 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Gets the visible columns that hold data, dropping the select, expand and edit columns.
+    /// Those three are controls, so they have nothing to export and nothing to group by.
+    /// </summary>
     private List<IDataGridColumn<TData>> GetVisibleDataColumns() =>
         GetVisibleColumns()
-            .Where(c => c.ColumnId != "__select" && c.ColumnId != "__expand")
+            .Where(c => c.ColumnId is not ("__select" or "__expand" or BbDataGridEditColumn<TData>.EditColumnId))
             .ToList();
 
     private async Task HandleRowClick(TData item)
@@ -3189,6 +3748,11 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
         if (OnRowClick.HasDelegate)
         {
             await OnRowClick.InvokeAsync(item);
+        }
+
+        if (EditOnRowClick && EditMode != DataGridEditMode.None && !IsEditing(item))
+        {
+            await StartEditAsync(item);
         }
     }
 
@@ -3199,6 +3763,253 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
         if (rowContextMenu != null)
         {
             await rowContextMenu.OpenAt(args.ClientX, args.ClientY);
+        }
+    }
+
+    /// <summary>
+    /// Gets the item currently being edited, or null when no row is in edit.
+    /// </summary>
+    public TData? EditingItem => _editingItem;
+
+    /// <summary>
+    /// Gets whether a given row is the one currently being edited.
+    /// </summary>
+    /// <param name="item">The row to check.</param>
+    /// <returns>True when that row is in edit.</returns>
+    public bool IsEditing(TData item) => _editingItem != null && SameRow(_editingItem, item);
+
+    /// <summary>
+    /// Compares two rows the way the rest of the grid does: by <see cref="ItemKey"/> when one is
+    /// supplied, so a row re-materialized by a data refresh is still recognised, and by reference
+    /// otherwise.
+    /// </summary>
+    private bool SameRow(TData left, TData right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        return ItemKey != null && Equals(ItemKey(left), ItemKey(right));
+    }
+
+    /// <summary>
+    /// Puts a row into edit, committing any row already being edited.
+    /// </summary>
+    /// <remarks>
+    /// Does nothing when <see cref="EditMode"/> is <see cref="DataGridEditMode.None"/>. The item's
+    /// current values are recorded first, so <see cref="CancelEditAsync"/> can put them back.
+    /// </remarks>
+    /// <param name="item">The row to edit.</param>
+    public async Task StartEditAsync(TData item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        if (EditMode == DataGridEditMode.None)
+        {
+            return;
+        }
+
+        if (_editingItem != null)
+        {
+            // Moving to another row commits the one being left, which is what a user who clicks
+            // straight onto the next row means. A failed commit keeps them where they were.
+            if (!await CommitEditAsync())
+            {
+                return;
+            }
+        }
+
+        _editingItem = item;
+        _editSnapshot = DataGridRowSnapshot<TData>.Capture(item);
+        _editContext = new EditContext(item);
+        _stateVersion++;
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Commits the row being edited and closes it.
+    /// </summary>
+    /// <remarks>
+    /// Validates the item first through its own <see cref="EditContext"/>, so
+    /// <c>DataAnnotations</c> on the model apply unchanged. A row that fails validation stays open.
+    /// <see cref="OnRowCommit"/> can also keep it open by setting
+    /// <see cref="DataGridRowCommitContext{TData}.Cancel"/>.
+    /// </remarks>
+    /// <returns>True when the row closed.</returns>
+    public async Task<bool> CommitEditAsync()
+    {
+        if (_editingItem == null)
+        {
+            return true;
+        }
+
+        if (_editContext != null && !_editContext.Validate())
+        {
+            StateHasChanged();
+            return false;
+        }
+
+        var item = _editingItem;
+
+        if (OnRowCommit.HasDelegate)
+        {
+            var context = new DataGridRowCommitContext<TData> { Item = item };
+            await OnRowCommit.InvokeAsync(context);
+
+            if (context.Cancel)
+            {
+                StateHasChanged();
+                return false;
+            }
+        }
+
+        ClearEditState();
+
+        // The edited values may change where the row sorts, which group it belongs to, or whether
+        // it still passes the filters, so the pass is redone rather than only re-rendered.
+        await RefreshDataAsync();
+        StateHasChanged();
+        return true;
+    }
+
+    /// <summary>
+    /// Discards the row's edits, putting the values it held when editing started back on it, and
+    /// closes the row.
+    /// </summary>
+    public async Task CancelEditAsync()
+    {
+        if (_editingItem == null)
+        {
+            return;
+        }
+
+        var item = _editingItem;
+        _editSnapshot?.Restore();
+        ClearEditState();
+
+        if (OnRowCancel.HasDelegate)
+        {
+            await OnRowCancel.InvokeAsync(item);
+        }
+
+        await RefreshDataAsync();
+        StateHasChanged();
+    }
+
+    private void ClearEditState()
+    {
+        _editingItem = null;
+        _editSnapshot = null;
+        _editContext = null;
+        _stateVersion++;
+    }
+
+    /// <summary>
+    /// Gets whether a cell should render its edit template rather than its value.
+    /// </summary>
+    private bool ShouldRenderEditor(IDataGridColumn<TData> column, TData item) =>
+        EditMode != DataGridEditMode.None && column.EditTemplate != null && IsEditing(item);
+
+    /// <summary>
+    /// Builds the CSV for the current rows and downloads it in the browser.
+    /// </summary>
+    /// <remarks>
+    /// Exports what the user sees: the rows that survive the current filters, search and sort,
+    /// in the visible columns, in their current order, using each column's display value. A
+    /// column with a sort-and-filter selector exports that value, so a cell showing <c>Active</c>
+    /// exports <c>Active</c> and not the key behind it.
+    /// <para>
+    /// <see cref="ExportScope"/> chooses between every filtered row and just the page on screen.
+    /// A grid backed by an <see cref="ItemsProvider"/> only holds the page it fetched, so it
+    /// exports that page and logs a warning the first time.
+    /// </para>
+    /// </remarks>
+    /// <returns>The CSV text that was downloaded.</returns>
+    public async Task<string> ExportToCsvAsync()
+    {
+        var csv = BuildCsv();
+        await DownloadCsvAsync(csv);
+
+        if (OnExport.HasDelegate)
+        {
+            await OnExport.InvokeAsync(csv);
+        }
+
+        return csv;
+    }
+
+    /// <summary>
+    /// Builds the CSV for the current rows without downloading it.
+    /// </summary>
+    /// <remarks>
+    /// Use this to write the file somewhere other than the browser — a server-side store, an
+    /// email attachment — or to assert on the output in a test.
+    /// </remarks>
+    /// <returns>The CSV text.</returns>
+    public string BuildCsv() =>
+        DataGridCsvWriter.Write(GetExportRows(), GetExportColumns(), ExportDelimiter);
+
+    /// <summary>
+    /// Gets the columns the export writes: the visible data columns in their current order,
+    /// without the select and expand columns, which hold no data.
+    /// </summary>
+    private List<IDataGridColumn<TData>> GetExportColumns() => GetVisibleDataColumns();
+
+    /// <summary>
+    /// Gets the rows the export writes.
+    /// </summary>
+    private IReadOnlyList<TData> GetExportRows()
+    {
+        if (ExportScope == DataGridExportScope.CurrentPage)
+        {
+            return CurrentPageRows();
+        }
+
+        if (_exportRows != null)
+        {
+            return _exportRows;
+        }
+
+        // An ItemsProvider only returned the page that was asked for, so that is all there is to
+        // export. Say so once rather than silently handing back a short file.
+        if (ItemsProvider != null && !warnedAboutProviderExportScope)
+        {
+            warnedAboutProviderExportScope = true;
+            DataGridLog.ExportLimitedToLoadedPage(Logger);
+        }
+
+        return CurrentPageRows();
+    }
+
+    private IReadOnlyList<TData> CurrentPageRows() =>
+        _processedData as IReadOnlyList<TData> ?? _processedData.ToList();
+
+    private async Task DownloadCsvAsync(string csv)
+    {
+        var fileName = ExportFileName;
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            fileName = "export.csv";
+        }
+        else if (!fileName.EndsWith(".csv", StringComparison.OrdinalIgnoreCase))
+        {
+            fileName += ".csv";
+        }
+
+        try
+        {
+            downloadModule ??= await Js.InvokeAsync<IJSObjectReference>("import",
+                "./_content/BlazorBlueprint.Components/js/file-download.js");
+
+            // The byte-order mark is what makes Excel read the file as UTF-8 rather than as the
+            // local codepage, which is why accented names arrive mangled without it.
+            await downloadModule.InvokeVoidAsync(
+                "downloadText", fileName, "\uFEFF" + csv, "text/csv;charset=utf-8");
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
+        {
+            // No browser to download into — prerendering, or a circuit that has gone away.
         }
     }
 
@@ -3554,6 +4365,18 @@ public partial class BbDataGrid<TData> : ComponentBase, IAsyncDisposable where T
             try
             {
                 await clipboardModule.DisposeAsync();
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
+            {
+                // Expected during circuit disconnect
+            }
+        }
+
+        if (downloadModule != null)
+        {
+            try
+            {
+                await downloadModule.DisposeAsync();
             }
             catch (Exception ex) when (ex is JSDisconnectedException or JSException or TaskCanceledException or ObjectDisposedException)
             {

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridEditColumn.razor
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridEditColumn.razor
@@ -1,0 +1,2 @@
+@namespace BlazorBlueprint.Components
+@typeparam TData where TData : class

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridEditColumn.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridEditColumn.razor.cs
@@ -1,0 +1,99 @@
+using System.Linq.Expressions;
+using BlazorBlueprint.Primitives.DataGrid;
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// Defines the column that starts, commits and cancels a row edit.
+/// Shows an Edit button on a row at rest, and Save and Cancel buttons on the row being edited.
+/// </summary>
+/// <remarks>
+/// Needs <c>EditMode</c> set on the grid; without it the buttons do nothing. The column is not
+/// hideable, resizable or reorderable, for the same reason the select and expand columns are not:
+/// it is a control, not data.
+/// </remarks>
+/// <typeparam name="TData">The type of data items in the grid.</typeparam>
+public partial class BbDataGridEditColumn<TData> : ComponentBase, IDataGridColumn<TData>
+    where TData : class
+{
+    /// <summary>
+    /// The column id used by every edit column.
+    /// </summary>
+    internal const string EditColumnId = "__edit";
+
+    /// <summary>
+    /// Column width. Defaults to a width that fits the Save and Cancel buttons.
+    /// </summary>
+    [Parameter]
+    public string? Width { get; set; } = "120px";
+
+    /// <summary>
+    /// Whether this column is pinned to an edge of the scrollable viewport.
+    /// Default is <see cref="ColumnPinning.None"/>.
+    /// </summary>
+    /// <remarks>
+    /// Pin it right on a wide grid, so the Save button stays reachable without scrolling back.
+    /// </remarks>
+    [Parameter]
+    public ColumnPinning Pinned { get; set; } = ColumnPinning.None;
+
+    /// <summary>
+    /// The parent DataGrid component. Set via cascading parameter.
+    /// </summary>
+    [CascadingParameter]
+    internal BbDataGrid<TData>? ParentGrid { get; set; }
+
+    // IDataGridColumn implementation
+
+    public string ColumnId => EditColumnId;
+
+    string? IDataGridColumn<TData>.Title => null;
+
+    bool IDataGridColumn<TData>.Sortable => false;
+
+    bool IDataGridColumn<TData>.Filterable => false;
+
+    bool IDataGridColumn<TData>.Visible => true;
+
+    string? IDataGridColumn<TData>.Width => Width;
+
+    bool IDataGridColumn<TData>.Hideable => false;
+
+    bool IDataGridColumn<TData>.Resizable => false;
+
+    bool IDataGridColumn<TData>.Reorderable => false;
+
+    ColumnPinning IDataGridColumn<TData>.Pinned => Pinned;
+
+    RenderFragment<DataGridCellContext<TData>>? IDataGridColumn<TData>.CellTemplate => null;
+
+    RenderFragment<DataGridHeaderContext<TData>>? IDataGridColumn<TData>.HeaderTemplate => null;
+
+    string? IDataGridColumn<TData>.CellClass => null;
+
+    string? IDataGridColumn<TData>.HeaderClass => null;
+
+    bool IDataGridColumn<TData>.NoWrap => true;
+
+    AggregateFunction IDataGridColumn<TData>.Aggregate => AggregateFunction.None;
+
+    public object? GetValue(TData item) => null;
+
+    public int Compare(TData x, TData y) => 0;
+
+    public LambdaExpression? GetSortExpression() => null;
+
+    public LambdaExpression? GetFilterExpression() => null;
+
+    protected override void OnInitialized()
+    {
+        if (ParentGrid == null)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(BbDataGridEditColumn<TData>)} must be placed inside a {nameof(BbDataGrid<TData>)} component.");
+        }
+
+        ParentGrid.RegisterColumn(this);
+    }
+}

--- a/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridPropertyColumn.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/BbDataGridPropertyColumn.razor.cs
@@ -19,6 +19,7 @@ public partial class BbDataGridPropertyColumn<TData, TProp> : ComponentBase, IDa
 {
     private string? resolvedTitle;
     private Func<TData, TProp>? compiledProperty;
+    private Func<TData, object?>? compiledSortAndFilterBy;
 
     /// <summary>
     /// Explicit unique identifier for this column. When not set, falls back to the
@@ -46,6 +47,38 @@ public partial class BbDataGridPropertyColumn<TData, TProp> : ComponentBase, IDa
     /// </summary>
     [Parameter]
     public string? Format { get; set; }
+
+    /// <summary>
+    /// Projects the value this column sorts and filters on, when that differs from
+    /// <see cref="Property"/>. Leave unset to sort and filter on the property itself.
+    /// </summary>
+    /// <remarks>
+    /// Set this when the cell displays something other than the raw property — the common case
+    /// being a <see cref="CellTemplate"/> that resolves a key to a label. Without it the header
+    /// click orders by the key the user cannot see, which reads as a broken grid:
+    /// <code>
+    /// &lt;BbDataGridPropertyColumn Property="x =&gt; x.StatusId" Title="Status" Sortable
+    ///                           SortAndFilterBy="x =&gt; statuses[x.StatusId].StatusName"&gt;
+    /// </code>
+    /// <para>
+    /// One parameter covers both sorting and filtering deliberately. Two separate selectors can
+    /// disagree, and a grid that orders by one value while filtering on another is hard to explain
+    /// and harder to debug. Grouping and CSV export use this value too, so all four agree.
+    /// </para>
+    /// <para>
+    /// This is an expression, not a delegate, so a grid backed by a server-side
+    /// <c>ItemsProvider</c> over <see cref="IQueryable{T}"/> can translate it to SQL. Keep the body
+    /// translatable — a dictionary lookup or a method call your provider cannot translate throws at
+    /// query time rather than falling back silently. For a lookup the server cannot perform, join
+    /// the label into the query and point <see cref="Property"/> at it instead.
+    /// </para>
+    /// <para>
+    /// <see cref="Format"/> is not applied to this value; the selector returns exactly what is
+    /// sorted and filtered on.
+    /// </para>
+    /// </remarks>
+    [Parameter]
+    public Expression<Func<TData, object?>>? SortAndFilterBy { get; set; }
 
     /// <summary>
     /// Whether this column can be sorted. Default is false.
@@ -193,6 +226,22 @@ public partial class BbDataGridPropertyColumn<TData, TProp> : ComponentBase, IDa
     public RenderFragment<TData>? CellTemplate { get; set; }
 
     /// <summary>
+    /// Renders this column's cell while its row is being edited. Leave unset for a column the
+    /// user should not change.
+    /// </summary>
+    /// <remarks>
+    /// The template receives the row's item, so it binds to it directly:
+    /// <code>
+    /// &lt;EditTemplate&gt;&lt;BbInput @bind-Value="context.Name" /&gt;&lt;/EditTemplate&gt;
+    /// </code>
+    /// The binding writes to the item as the user types. A cancel puts the old values back, so
+    /// nothing needs copying by hand. Needs <c>EditMode</c> set on the grid; without it the
+    /// template is never rendered.
+    /// </remarks>
+    [Parameter]
+    public RenderFragment<TData>? EditTemplate { get; set; }
+
+    /// <summary>
     /// Custom header content. If provided, replaces the header title text only — the grid
     /// still renders its own sort indicator, filter icon, pin icon, column menu and resize
     /// handle around it, so a <see cref="Sortable"/> or <see cref="Groupable"/> column keeps
@@ -249,6 +298,11 @@ public partial class BbDataGridPropertyColumn<TData, TProp> : ComponentBase, IDa
             ? context => CellTemplate(context.Item)
             : null;
 
+    RenderFragment<DataGridCellContext<TData>>? IDataGridColumn<TData>.EditTemplate =>
+        EditTemplate != null
+            ? context => EditTemplate(context.Item)
+            : null;
+
     RenderFragment<DataGridHeaderContext<TData>>? IDataGridColumn<TData>.HeaderTemplate =>
         HeaderTemplate != null
             ? _ => HeaderTemplate
@@ -290,17 +344,68 @@ public partial class BbDataGridPropertyColumn<TData, TProp> : ComponentBase, IDa
         return compiledProperty(item);
     }
 
+    public object? GetSortAndFilterValue(TData item)
+    {
+        if (SortAndFilterBy == null)
+        {
+            return GetRawValue(item);
+        }
+
+        compiledSortAndFilterBy ??= SortAndFilterBy.Compile();
+        return compiledSortAndFilterBy(item);
+    }
+
+    public LambdaExpression? GetSortAndFilterExpression() => SortAndFilterBy;
+
     public int Compare(TData x, TData y)
     {
+        if (SortAndFilterBy != null)
+        {
+            return CompareValues(GetSortAndFilterValue(x), GetSortAndFilterValue(y));
+        }
+
         compiledProperty ??= Property.Compile();
         var xVal = compiledProperty(x);
         var yVal = compiledProperty(y);
         return Comparer<TProp>.Default.Compare(xVal, yVal);
     }
 
-    public LambdaExpression? GetSortExpression() => Property;
+    /// <summary>
+    /// Orders two boxed values from <see cref="SortAndFilterBy"/>, whose static type is object.
+    /// Nulls order first. Two values of the same type order by <see cref="IComparable"/>, which for
+    /// strings is the culture-aware order the user expects. Only values of differing types fall back
+    /// to an ordinal string comparison, so a mixed selector still produces a stable order rather
+    /// than throwing.
+    /// </summary>
+    private static int CompareValues(object? x, object? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return 0;
+        }
 
-    public LambdaExpression? GetFilterExpression() => Filterable ? Property : null;
+        if (x == null)
+        {
+            return -1;
+        }
+
+        if (y == null)
+        {
+            return 1;
+        }
+
+        if (x is IComparable comparable && x.GetType() == y.GetType())
+        {
+            return comparable.CompareTo(y);
+        }
+
+        return string.Compare(x.ToString(), y.ToString(), StringComparison.Ordinal);
+    }
+
+    public LambdaExpression? GetSortExpression() => SortAndFilterBy ?? (LambdaExpression)Property;
+
+    public LambdaExpression? GetFilterExpression() =>
+        Filterable ? SortAndFilterBy ?? (LambdaExpression)Property : null;
 
     // IFilterableColumn implementation
 

--- a/src/BlazorBlueprint.Components/Components/DataGrid/DataGridExportScope.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/DataGridExportScope.cs
@@ -1,0 +1,23 @@
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// Defines which rows a DataGrid export writes.
+/// </summary>
+public enum DataGridExportScope
+{
+    /// <summary>
+    /// Every row that survives the current filters, search and sort, across all pages.
+    /// This is the default, because exporting only the page on screen is the usual complaint
+    /// about grid export.
+    /// </summary>
+    /// <remarks>
+    /// A grid backed by an <c>ItemsProvider</c> only holds the page it fetched, so it exports
+    /// that page and logs a warning. Fetch the full set yourself and export it if you need more.
+    /// </remarks>
+    FilteredRows,
+
+    /// <summary>
+    /// Only the rows on the page currently on screen.
+    /// </summary>
+    CurrentPage
+}

--- a/src/BlazorBlueprint.Components/Components/DataGrid/DataGridLog.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/DataGridLog.cs
@@ -14,4 +14,11 @@ internal static partial class DataGridLog
                   "a combination that cannot group client-side, so no rows will render. Supply a " +
                   "GroupedItemsProvider to group server-side, or turn off Virtualize.")]
     public static partial void GroupingUnsupportedInVirtualizedProvider(ILogger logger, string columnId);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "DataGrid export wrote only the page currently loaded, because the grid uses an " +
+                  "ItemsProvider and never holds more than one page. Set ExportScope to CurrentPage " +
+                  "to make that explicit, or fetch the full set yourself and export it.")]
+    public static partial void ExportLimitedToLoadedPage(ILogger logger);
 }

--- a/src/BlazorBlueprint.Components/Components/DataGrid/DataGridRowCommitContext.cs
+++ b/src/BlazorBlueprint.Components/Components/DataGrid/DataGridRowCommitContext.cs
@@ -1,0 +1,24 @@
+namespace BlazorBlueprint.Components;
+
+/// <summary>
+/// Passed to a DataGrid's row-commit callback, carrying the edited item and letting the handler
+/// keep the row in edit.
+/// </summary>
+/// <typeparam name="TData">The type of data items in the grid.</typeparam>
+public class DataGridRowCommitContext<TData> where TData : class
+{
+    /// <summary>
+    /// Gets the item that was edited, with the user's changes already applied to it.
+    /// </summary>
+    public required TData Item { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether to keep the row in edit instead of closing it.
+    /// </summary>
+    /// <remarks>
+    /// Set this when the save fails — a server rejection, a conflict, a rule the grid cannot
+    /// check — so the user keeps their typing and can correct it. The values stay on the item
+    /// either way; this only decides whether the row closes.
+    /// </remarks>
+    public bool Cancel { get; set; }
+}

--- a/src/BlazorBlueprint.Components/Localization/DefaultBbLocalizer.cs
+++ b/src/BlazorBlueprint.Components/Localization/DefaultBbLocalizer.cs
@@ -78,6 +78,11 @@ public class DefaultBbLocalizer : IBbLocalizer
         ["DataGrid.FilterPlaceholder"] = "Filter {0}",
         ["DataGrid.ColumnMenu"] = "{0} column options",
         ["DataGrid.GroupByColumn"] = "Group by {0}",
+        ["DataGrid.AddGroupByColumn"] = "Then group by {0}",
+        ["DataGrid.GroupingBreadcrumbLabel"] = "Grouped by",
+        ["DataGrid.RemoveGroupLevel"] = "Stop grouping by {0}",
+        ["DataGrid.MoveGroupLevelOut"] = "Move {0} out one level",
+        ["DataGrid.ClearGrouping"] = "Clear grouping",
         ["DataGrid.UngroupColumn"] = "Remove grouping",
         ["DataGrid.PinnedColumnTooltip"] = "This column is pinned and cannot be moved",
         ["DataGrid.ActiveFilters"] = "{0} active filter(s)",
@@ -101,6 +106,11 @@ public class DefaultBbLocalizer : IBbLocalizer
         ["DataGrid.FilterColumnClear"] = "Clear",
         ["DataGrid.FilterColumnApply"] = "Apply",
         ["DataGrid.SearchPlaceholder"] = "Search...",
+        ["DataGrid.Export"] = "Export",
+        ["DataGrid.EditRow"] = "Edit row",
+        ["DataGrid.SaveRow"] = "Save",
+        ["DataGrid.CancelRowEdit"] = "Cancel",
+        ["DataGrid.ExportAriaLabel"] = "Export rows to CSV",
 
         // DataTable
         ["DataTable.Loading"] = "Loading...",

--- a/src/BlazorBlueprint.Components/wwwroot/js/file-download.js
+++ b/src/BlazorBlueprint.Components/wwwroot/js/file-download.js
@@ -1,0 +1,20 @@
+// Triggers a browser download for text generated on the .NET side.
+//
+// The text is turned into a Blob and handed to a temporary anchor, which is the only route that
+// works in every supported browser without a server round trip. The object URL is revoked on the
+// next tick: revoking it synchronously cancels the download in Safari.
+export function downloadText(fileName, text, mimeType) {
+    const blob = new Blob([text], { type: mimeType || 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = fileName || 'download.txt';
+    anchor.style.display = 'none';
+
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/BbDataGrid.razor.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/BbDataGrid.razor.cs
@@ -58,6 +58,32 @@ public partial class BbDataGrid<TData> : ComponentBase, IDisposable where TData 
     public SelectionMode SelectionMode { get; set; } = SelectionMode.None;
 
     /// <summary>
+    /// Tests whether a row is currently being edited, so the row can give Enter and Escape to the
+    /// editor instead of to its own selection shortcuts. Leave unset when rows are not editable.
+    /// </summary>
+    [Parameter]
+    public Func<TData, bool>? IsRowEditing { get; set; }
+
+    /// <summary>
+    /// Commits the row being edited, invoked when the user presses Enter inside it.
+    /// </summary>
+    [Parameter]
+    public Func<Task>? OnCommitEdit { get; set; }
+
+    /// <summary>
+    /// Discards the edits on the row being edited, invoked when the user presses Escape inside it.
+    /// </summary>
+    [Parameter]
+    public Func<Task>? OnCancelEdit { get; set; }
+
+    /// <summary>
+    /// How clicking a row changes the selection.
+    /// Default is <see cref="DataGridSelectionBehavior.Toggle"/>.
+    /// </summary>
+    [Parameter]
+    public DataGridSelectionBehavior SelectionBehavior { get; set; } = DataGridSelectionBehavior.Toggle;
+
+    /// <summary>
     /// Event callback invoked when sorting changes.
     /// </summary>
     [Parameter]
@@ -186,6 +212,10 @@ public partial class BbDataGrid<TData> : ComponentBase, IDisposable where TData 
         parametersChanged = true;
 
         context.SelectionMode = SelectionMode;
+        context.SelectionBehavior = SelectionBehavior;
+        context.IsRowEditing = IsRowEditing;
+        context.OnCommitEdit = OnCommitEdit;
+        context.OnCancelEdit = OnCancelEdit;
         context.EnableKeyboardNavigation = EnableKeyboardNavigation;
         EffectiveState.Selection.Mode = SelectionMode;
 
@@ -224,6 +254,10 @@ public partial class BbDataGrid<TData> : ComponentBase, IDisposable where TData 
         context = new DataGridContext<TData>(EffectiveState)
         {
             SelectionMode = SelectionMode,
+            SelectionBehavior = SelectionBehavior,
+            IsRowEditing = IsRowEditing,
+            OnCommitEdit = OnCommitEdit,
+            OnCancelEdit = OnCancelEdit,
             EnableKeyboardNavigation = EnableKeyboardNavigation
         };
 

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/BbDataGridRow.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/BbDataGridRow.razor
@@ -8,6 +8,7 @@
     aria-selected="@(IsSelected ? "true" : "false")"
     tabindex="@(IsKeyboardNavigable ? 0 : -1)"
     class="@ComputedClass"
+    data-editing="@(IsRowEditing ? "true" : null)"
     @onclick="HandleClick"
     @oncontextmenu="HandleContextMenu"
     @oncontextmenu:preventDefault="@HasContextMenuHandler"
@@ -55,11 +56,15 @@
 
     private bool IsSelectable => Context != null && Context.SelectionMode != Table.SelectionMode.None;
 
+    private bool IsRowEditing => Item != null && Context?.IsRowEditing?.Invoke(Item) == true;
+
     private bool IsExpandable => Context?.OnToggleExpand != null;
 
     private bool IsDataRow => Item != null;
 
     private bool NeedsClickIntercept => IsDataRow && (IsSelectable || Context?.OnRowClick != null);
+
+    private bool IsEditable => IsDataRow && Context?.IsRowEditing != null;
 
     private bool IsKeyboardNavigable => IsDataRow && Context != null && Context.EnableKeyboardNavigation;
 
@@ -73,7 +78,7 @@
         {
             try
             {
-                if (IsKeyboardNavigable && !spaceKeyHandlerAttached)
+                if ((IsKeyboardNavigable || IsEditable) && !spaceKeyHandlerAttached)
                 {
                     navModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>(
                         "import", "./_content/BlazorBlueprint.Primitives/js/primitives/table-row-nav.js");
@@ -102,7 +107,7 @@
 
     private bool HasContextMenuHandler => Context?.OnRowContextMenu != null;
 
-    private async Task HandleClick()
+    private async Task HandleClick(MouseEventArgs e)
     {
         if (Item != null && Context != null)
         {
@@ -123,7 +128,9 @@
 
             if (IsSelectable)
             {
-                Context.ToggleRowSelection(Item);
+                // MetaKey covers Cmd on macOS, where Ctrl+Click opens the context menu instead.
+                Context.ApplyRowSelectionInput(
+                    Item, new RowSelectionModifiers(e.ShiftKey, e.CtrlKey || e.MetaKey));
             }
         }
     }
@@ -158,6 +165,26 @@
 
         if (Item != null)
         {
+            // A row being edited owns Enter and Escape: they commit and discard. The row's
+            // selection and expansion shortcuts would otherwise fire while the user is typing.
+            if (IsRowEditing)
+            {
+                if (e.Key == "Escape" && Context?.OnCancelEdit != null)
+                {
+                    await Context.OnCancelEdit();
+                }
+                else if (e.Key == "Enter" && !e.ShiftKey && Context?.OnCommitEdit != null)
+                {
+                    // An input that only writes its value back on change has not done so yet:
+                    // this handler runs before the browser fires that change. Blurring it forces
+                    // the value through, so Enter does not drop the field the user was in.
+                    await BlurFocusedInput();
+                    await Context.OnCommitEdit();
+                }
+
+                return;
+            }
+
             if (e.Key == " ")
             {
                 if (IsSelectable)
@@ -180,6 +207,26 @@
                     Context!.ToggleRowSelection(Item);
                 }
             }
+        }
+    }
+
+    private async Task BlurFocusedInput()
+    {
+        try
+        {
+            navModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/BlazorBlueprint.Primitives/js/primitives/table-row-nav.js");
+
+            if (await navModule.InvokeAsync<bool>("blurFocusedInput", elementRef))
+            {
+                // Let the change event the blur just fired reach Blazor and update the model
+                // before the commit reads it.
+                await Task.Yield();
+            }
+        }
+        catch
+        {
+            // No browser to blur in — prerendering, or a circuit that has gone away.
         }
     }
 

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridContext.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridContext.cs
@@ -28,6 +28,12 @@ public class DataGridContext<TData> : PrimitiveContextWithEvents<DataGridState<T
     public SelectionMode SelectionMode { get; set; } = SelectionMode.None;
 
     /// <summary>
+    /// Gets or sets how clicking a row changes the selection.
+    /// Default is <see cref="DataGridSelectionBehavior.Toggle"/>.
+    /// </summary>
+    public DataGridSelectionBehavior SelectionBehavior { get; set; } = DataGridSelectionBehavior.Toggle;
+
+    /// <summary>
     /// Gets or sets whether the grid is currently loading data.
     /// </summary>
     public bool IsLoading { get; set; }
@@ -51,6 +57,21 @@ public class DataGridContext<TData> : PrimitiveContextWithEvents<DataGridState<T
     /// Callback invoked when a row is selected.
     /// </summary>
     public Action<TData>? OnRowSelect { get; set; }
+
+    /// <summary>
+    /// Tests whether a row is currently being edited. Null when the grid has no edit mode.
+    /// </summary>
+    public Func<TData, bool>? IsRowEditing { get; set; }
+
+    /// <summary>
+    /// Commits the row being edited. Null when the grid has no edit mode.
+    /// </summary>
+    public Func<Task>? OnCommitEdit { get; set; }
+
+    /// <summary>
+    /// Discards the edits on the row being edited. Null when the grid has no edit mode.
+    /// </summary>
+    public Func<Task>? OnCancelEdit { get; set; }
 
     /// <summary>
     /// Callback invoked when the current page changes.
@@ -156,9 +177,88 @@ public class DataGridContext<TData> : PrimitiveContextWithEvents<DataGridState<T
     /// <summary>
     /// Toggles the selection state of a row.
     /// </summary>
+    /// <remarks>
+    /// This ignores <see cref="SelectionBehavior"/> and always toggles, so a select-column
+    /// checkbox keeps working the way a checkbox should. Row clicks go through
+    /// <see cref="ApplyRowSelectionInput"/> instead.
+    /// </remarks>
     public void ToggleRowSelection(TData item)
     {
-        UpdateState(state => state.Selection.Toggle(item));
+        UpdateState(state =>
+        {
+            state.Selection.Toggle(item);
+            state.Selection.Anchor = item;
+        });
+
+        OnRowSelect?.Invoke(item);
+        OnSelectionChange?.Invoke(State.Selection.SelectedItems);
+    }
+
+    /// <summary>
+    /// Applies a row click to the selection, honouring <see cref="SelectionBehavior"/> and the
+    /// modifier keys that were held.
+    /// </summary>
+    /// <remarks>
+    /// Under <see cref="DataGridSelectionBehavior.Toggle"/> the modifiers are ignored and the row
+    /// simply flips, which is the long-standing behaviour. Under
+    /// <see cref="DataGridSelectionBehavior.Replace"/>:
+    /// <list type="bullet">
+    /// <item><description>a plain click selects only that row, or clears the selection when that
+    /// row was already the only one selected;</description></item>
+    /// <item><description>Shift+Click selects the range from the anchor to that row;</description></item>
+    /// <item><description>Ctrl+Click adds or removes that row and leaves the rest alone.</description></item>
+    /// </list>
+    /// Range and additive selection need <see cref="SelectionMode.Multiple"/>; under
+    /// <see cref="SelectionMode.Single"/> every click is treated as a plain click.
+    /// </remarks>
+    /// <param name="item">The clicked row.</param>
+    /// <param name="modifiers">The modifier keys held during the click.</param>
+    public void ApplyRowSelectionInput(TData item, RowSelectionModifiers modifiers)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        if (SelectionMode == SelectionMode.None)
+        {
+            return;
+        }
+
+        if (SelectionBehavior == DataGridSelectionBehavior.Toggle)
+        {
+            ToggleRowSelection(item);
+            return;
+        }
+
+        var multiple = SelectionMode == SelectionMode.Multiple;
+
+        UpdateState(state =>
+        {
+            var selection = state.Selection;
+
+            if (multiple && modifiers.Extend)
+            {
+                // The anchor stays put, so holding Shift and clicking again re-extends from the
+                // same origin rather than walking the range along.
+                selection.SelectRange(ProcessedData, selection.Anchor, item);
+                return;
+            }
+
+            if (multiple && modifiers.Additive)
+            {
+                selection.Toggle(item);
+                selection.Anchor = item;
+                return;
+            }
+
+            // Plain click: collapse to this row, or clear when it was already the only one.
+            if (selection.SelectedCount == 1 && selection.IsSelected(item))
+            {
+                selection.Clear();
+                return;
+            }
+
+            selection.ReplaceWith(item);
+            selection.Anchor = item;
+        });
 
         OnRowSelect?.Invoke(item);
         OnSelectionChange?.Invoke(State.Selection.SelectedItems);
@@ -169,7 +269,11 @@ public class DataGridContext<TData> : PrimitiveContextWithEvents<DataGridState<T
     /// </summary>
     public void SelectRow(TData item)
     {
-        UpdateState(state => state.Selection.Select(item));
+        UpdateState(state =>
+        {
+            state.Selection.Select(item);
+            state.Selection.Anchor = item;
+        });
 
         OnRowSelect?.Invoke(item);
         OnSelectionChange?.Invoke(State.Selection.SelectedItems);

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridCsvWriter.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridCsvWriter.cs
@@ -1,0 +1,146 @@
+using System.Globalization;
+using System.Text;
+
+namespace BlazorBlueprint.Primitives.DataGrid;
+
+/// <summary>
+/// Renders DataGrid rows as CSV text, using each column's display value.
+/// </summary>
+/// <remarks>
+/// A column that sets a sort-and-filter selector exports that value, so a cell showing
+/// <c>Active</c> for a stored <c>3</c> exports <c>Active</c>. Every other column exports
+/// <see cref="IDataGridColumn{TData}.GetValue"/>, which already has the column's format applied.
+/// </remarks>
+public static class DataGridCsvWriter
+{
+    /// <summary>
+    /// The characters a spreadsheet reads as the start of a formula.
+    /// </summary>
+    /// <remarks>
+    /// A cell beginning with one of these is executed when the file is opened in Excel or Sheets,
+    /// so an attacker who can get text into a row can get code run on the machine of whoever
+    /// exports and opens the file. Prefixing the cell with an apostrophe makes the spreadsheet
+    /// treat it as text. The tab and carriage return are included because both can be used to
+    /// shift a formula past a naive check.
+    /// </remarks>
+    private static readonly char[] FormulaTriggers = { '=', '+', '-', '@', '\t', '\r' };
+
+    /// <summary>
+    /// Renders rows as CSV text.
+    /// </summary>
+    /// <typeparam name="TData">The type of data items.</typeparam>
+    /// <param name="rows">The rows to export, already filtered and sorted as the user sees them.</param>
+    /// <param name="columns">The columns to export, in display order. Pass only the visible ones.</param>
+    /// <param name="delimiter">The field delimiter. Defaults to a comma.</param>
+    /// <param name="includeHeader">Whether to write a header row of column titles. Defaults to true.</param>
+    /// <returns>The CSV text, with CRLF line endings.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when rows or columns is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when delimiter is null or empty.</exception>
+    public static string Write<TData>(
+        IEnumerable<TData> rows,
+        IReadOnlyList<IDataGridColumn<TData>> columns,
+        string delimiter = ",",
+        bool includeHeader = true) where TData : class
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        if (string.IsNullOrEmpty(delimiter))
+        {
+            throw new ArgumentException("The delimiter cannot be null or empty.", nameof(delimiter));
+        }
+
+        var builder = new StringBuilder();
+
+        if (includeHeader)
+        {
+            AppendRow(builder, columns.Select(c => c.Title ?? c.ColumnId), delimiter);
+        }
+
+        foreach (var row in rows)
+        {
+            AppendRow(builder, columns.Select(c => GetExportText(c, row)), delimiter);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Gets the text a column exports for one row: its sort-and-filter value when it has one,
+    /// otherwise its formatted display value.
+    /// </summary>
+    public static string? GetExportText<TData>(IDataGridColumn<TData> column, TData row) where TData : class
+    {
+        ArgumentNullException.ThrowIfNull(column);
+
+        var value = column.GetSortAndFilterExpression() != null
+            ? column.GetSortAndFilterValue(row)
+            : column.GetValue(row);
+
+        return value == null ? null : Convert.ToString(value, CultureInfo.CurrentCulture);
+    }
+
+    private static void AppendRow(StringBuilder builder, IEnumerable<string?> cells, string delimiter)
+    {
+        var first = true;
+        foreach (var cell in cells)
+        {
+            if (!first)
+            {
+                builder.Append(delimiter);
+            }
+
+            builder.Append(EscapeCell(cell, delimiter));
+            first = false;
+        }
+
+        builder.Append("\r\n");
+    }
+
+    /// <summary>
+    /// Quotes a cell when it would otherwise break the row, after neutralizing any leading
+    /// formula character.
+    /// </summary>
+    private static string EscapeCell(string? value, string delimiter)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var text = Sanitize(value);
+
+        var needsQuotes = text.Contains('"', StringComparison.Ordinal)
+            || text.Contains('\n', StringComparison.Ordinal)
+            || text.Contains('\r', StringComparison.Ordinal)
+            || text.Contains(delimiter, StringComparison.Ordinal);
+
+        return needsQuotes
+            ? string.Concat("\"", text.Replace("\"", "\"\"", StringComparison.Ordinal), "\"")
+            : text;
+    }
+
+    /// <summary>
+    /// Prefixes a cell with an apostrophe when a spreadsheet would read it as a formula.
+    /// </summary>
+    /// <remarks>
+    /// A value that parses as a number is left alone, so a negative amount such as
+    /// <c>-1,500.00</c> still exports as a number rather than as text. Anything else starting with
+    /// a trigger character is prefixed, which covers the attack shape (<c>=1+1</c>,
+    /// <c>-2+3+cmd|...</c>) without spoiling ordinary numeric columns.
+    /// </remarks>
+    private static string Sanitize(string value)
+    {
+        if (Array.IndexOf(FormulaTriggers, value[0]) < 0)
+        {
+            return value;
+        }
+
+        if (double.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out _))
+        {
+            return value;
+        }
+
+        return string.Concat("'", value);
+    }
+}

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridDataExtensions.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridDataExtensions.cs
@@ -38,6 +38,8 @@ public static class DataGridDataExtensions
                 continue;
             }
 
+            sortExpression = NormalizeKeySelector(sortExpression);
+
             if (orderedQuery == null)
             {
                 orderedQuery = sortDef.Direction == SortDirection.Ascending
@@ -108,6 +110,27 @@ public static class DataGridDataExtensions
         });
 
         return list;
+    }
+
+    /// <summary>
+    /// Strips the boxing <c>Convert</c> node from a key selector declared to return
+    /// <see cref="object"/>, rebuilding the lambda with the underlying type.
+    /// </summary>
+    /// <remarks>
+    /// A column's <c>SortAndFilterBy</c> is typed <c>Expression&lt;Func&lt;TData, object&gt;&gt;</c>
+    /// so any value type can be returned from it. Ordering by <c>object</c> is not translatable —
+    /// EF Core cannot emit <c>ORDER BY</c> for it, and in-memory <c>OrderBy</c> would compare
+    /// boxed references. Restoring the real type makes both work.
+    /// </remarks>
+    private static LambdaExpression NormalizeKeySelector(LambdaExpression selector)
+    {
+        if (selector.Body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary
+            && unary.Type == typeof(object))
+        {
+            return Expression.Lambda(unary.Operand, selector.Parameters);
+        }
+
+        return selector;
     }
 
     // Helper methods to call OrderBy/ThenBy with a runtime LambdaExpression

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridEditMode.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridEditMode.cs
@@ -1,0 +1,22 @@
+// In the BlazorBlueprint.Primitives namespace rather than BlazorBlueprint.Primitives.DataGrid,
+// alongside SortDirection and DataGridSelectionBehavior: an app that imports
+// BlazorBlueprint.Components cannot also import BlazorBlueprint.Primitives.DataGrid without making
+// the name BbDataGrid ambiguous, so an enum a consumer has to name in markup goes here.
+namespace BlazorBlueprint.Primitives;
+
+/// <summary>
+/// Defines how a DataGrid lets a user edit rows in place.
+/// </summary>
+public enum DataGridEditMode
+{
+    /// <summary>
+    /// Rows cannot be edited. This is the default.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// A whole row goes into edit at once: every editable cell becomes an input, and the changes
+    /// are committed or discarded together.
+    /// </summary>
+    Row
+}

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridGroupRow.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridGroupRow.cs
@@ -13,6 +13,28 @@ public class DataGridGroupRow<TData> where TData : class
     public object? Key { get; init; }
 
     /// <summary>
+    /// Gets the ordered keys identifying this group, outermost first.
+    /// </summary>
+    /// <remarks>
+    /// This is what collapsed state is keyed by. A raw key is ambiguous once grouping nests: a
+    /// group keyed <c>Active</c> exists under every department, and collapsing one would collapse
+    /// them all. Defaults to a single-segment path built from <see cref="Key"/>.
+    /// </remarks>
+    public GroupPath Path { get; init; } = GroupPath.Root;
+
+    /// <summary>
+    /// Gets how deep this group sits, zero-based. The outermost level is 0.
+    /// </summary>
+    public int Depth { get; init; }
+
+    /// <summary>
+    /// Gets the groups nested directly inside this one, outermost first, or an empty list for the
+    /// innermost level.
+    /// </summary>
+    public IReadOnlyList<DataGridGroupRow<TData>> Children { get; init; } =
+        Array.Empty<DataGridGroupRow<TData>>();
+
+    /// <summary>
     /// Gets the ID of the column that was grouped by.
     /// </summary>
     public required string ColumnId { get; init; }
@@ -28,7 +50,8 @@ public class DataGridGroupRow<TData> where TData : class
     public int ItemCount { get; init; }
 
     /// <summary>
-    /// Gets the data items belonging to this group.
+    /// Gets the data items belonging to this group, including those in every nested group beneath
+    /// it, so aggregates roll up rather than counting only the leaf level.
     /// </summary>
     public required IReadOnlyList<TData> Items { get; init; }
 

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridGroupState.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridGroupState.cs
@@ -2,97 +2,314 @@ namespace BlazorBlueprint.Primitives.DataGrid;
 
 /// <summary>
 /// Manages grouping state for a DataGrid.
-/// Tracks which groups are collapsed and the active group definition.
+/// Tracks the ordered group levels and which groups are collapsed.
 /// </summary>
 public class DataGridGroupState
 {
-    private readonly HashSet<object> collapsedKeys = new();
+    private readonly HashSet<GroupPath> collapsedPaths = new();
+    private readonly List<GroupDefinition> activeGroups = new();
 
     /// <summary>
-    /// Gets or sets the active group definition, or null if no grouping is active.
+    /// Gets the active group levels, outermost first. Empty when no grouping is active.
     /// </summary>
-    public GroupDefinition? ActiveGroup { get; private set; }
+    public IReadOnlyList<GroupDefinition> ActiveGroups => activeGroups;
 
     /// <summary>
-    /// Gets whether a group definition is currently active.
+    /// Gets the outermost active group definition, or null if no grouping is active.
     /// </summary>
-    public bool HasGroups => ActiveGroup != null;
+    /// <remarks>
+    /// Kept for grids written against single-level grouping. Read
+    /// <see cref="ActiveGroups"/> to see every level.
+    /// </remarks>
+    public GroupDefinition? ActiveGroup => activeGroups.Count > 0 ? activeGroups[0] : null;
 
     /// <summary>
-    /// Gets the set of collapsed group keys.
+    /// Gets whether any group definition is currently active.
     /// </summary>
-    public IReadOnlyCollection<object> CollapsedKeys => collapsedKeys;
+    public bool HasGroups => activeGroups.Count > 0;
 
     /// <summary>
-    /// Gets a version counter that increments whenever the active group definition changes.
+    /// Gets how many levels of grouping are active.
+    /// </summary>
+    public int Depth => activeGroups.Count;
+
+    /// <summary>
+    /// Gets the set of collapsed group paths.
+    /// </summary>
+    public IReadOnlyCollection<GroupPath> CollapsedPaths => collapsedPaths;
+
+    /// <summary>
+    /// Gets the keys of collapsed outermost groups.
+    /// </summary>
+    /// <remarks>
+    /// Kept for grids written against single-level grouping, where a key identified a group on its
+    /// own. Read <see cref="CollapsedPaths"/> to see collapsed groups at every level.
+    /// </remarks>
+    public IReadOnlyCollection<object> CollapsedKeys =>
+        collapsedPaths.Where(p => p.Depth == 0 && p.Key != null).Select(p => p.Key!).ToList();
+
+    /// <summary>
+    /// Gets a version counter that increments whenever the active group definitions change.
     /// Used by the grid component to detect grouping changes made directly against this state.
     /// </summary>
     public int Version { get; private set; }
 
     /// <summary>
-    /// Sets the active group definition.
+    /// Replaces all grouping with a single level.
     /// </summary>
     /// <param name="group">The group definition, or null to clear grouping.</param>
     public void SetGroup(GroupDefinition? group)
     {
-        ActiveGroup = group;
-        collapsedKeys.Clear();
+        activeGroups.Clear();
+        if (group != null)
+        {
+            activeGroups.Add(group);
+        }
+
+        collapsedPaths.Clear();
         Version++;
     }
 
     /// <summary>
-    /// Clears the active group definition and all collapsed state.
+    /// Replaces all grouping with the given levels, outermost first.
+    /// </summary>
+    /// <remarks>
+    /// A column appearing more than once is kept only at its first position: grouping by the same
+    /// column twice would produce a level where every group holds exactly one child group.
+    /// </remarks>
+    /// <param name="groups">The group definitions, outermost first. Null or empty clears grouping.</param>
+    public void SetGroups(IEnumerable<GroupDefinition>? groups)
+    {
+        activeGroups.Clear();
+
+        if (groups != null)
+        {
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var group in groups)
+            {
+                if (group != null && seen.Add(group.ColumnId))
+                {
+                    activeGroups.Add(group);
+                }
+            }
+        }
+
+        collapsedPaths.Clear();
+        Version++;
+    }
+
+    /// <summary>
+    /// Adds a level of grouping inside the existing levels.
+    /// </summary>
+    /// <remarks>
+    /// Does nothing when the column already groups at some level. Collapsed state is cleared,
+    /// because every existing path is now one level short of identifying a group.
+    /// </remarks>
+    /// <param name="group">The group definition to add as the innermost level.</param>
+    /// <returns>True when the level was added.</returns>
+    public bool AddGroup(GroupDefinition group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        if (activeGroups.Any(g => string.Equals(g.ColumnId, group.ColumnId, StringComparison.Ordinal)))
+        {
+            return false;
+        }
+
+        activeGroups.Add(group);
+        collapsedPaths.Clear();
+        Version++;
+        return true;
+    }
+
+    /// <summary>
+    /// Removes the grouping level for a column, keeping the other levels in order.
+    /// </summary>
+    /// <param name="columnId">The column to stop grouping by.</param>
+    /// <returns>True when a level was removed.</returns>
+    public bool RemoveGroup(string columnId)
+    {
+        var removed = activeGroups.RemoveAll(
+            g => string.Equals(g.ColumnId, columnId, StringComparison.Ordinal)) > 0;
+
+        if (removed)
+        {
+            collapsedPaths.Clear();
+            Version++;
+        }
+
+        return removed;
+    }
+
+    /// <summary>
+    /// Moves a grouping level to a new position, with remove-then-insert semantics.
+    /// </summary>
+    /// <param name="columnId">The column whose level should move.</param>
+    /// <param name="newIndex">
+    /// The zero-based position among the remaining levels. Values outside the range are clamped.
+    /// </param>
+    /// <returns>True when the level moved.</returns>
+    public bool MoveGroup(string columnId, int newIndex)
+    {
+        var currentIndex = activeGroups.FindIndex(
+            g => string.Equals(g.ColumnId, columnId, StringComparison.Ordinal));
+
+        if (currentIndex < 0)
+        {
+            return false;
+        }
+
+        var group = activeGroups[currentIndex];
+        activeGroups.RemoveAt(currentIndex);
+        newIndex = Math.Clamp(newIndex, 0, activeGroups.Count);
+        activeGroups.Insert(newIndex, group);
+
+        if (currentIndex == newIndex)
+        {
+            return false;
+        }
+
+        collapsedPaths.Clear();
+        Version++;
+        return true;
+    }
+
+    /// <summary>
+    /// Gets the zero-based level a column groups at, or -1 when it does not group.
+    /// </summary>
+    /// <param name="columnId">The column to look for.</param>
+    /// <returns>The level, or -1.</returns>
+    public int GetLevel(string columnId) =>
+        activeGroups.FindIndex(g => string.Equals(g.ColumnId, columnId, StringComparison.Ordinal));
+
+    /// <summary>
+    /// Gets whether a column groups at any level.
+    /// </summary>
+    /// <param name="columnId">The column to look for.</param>
+    /// <returns>True when the column groups.</returns>
+    public bool IsGroupedBy(string columnId) => GetLevel(columnId) >= 0;
+
+    /// <summary>
+    /// Clears all group definitions and all collapsed state.
     /// </summary>
     public void ClearGroup()
     {
-        ActiveGroup = null;
-        collapsedKeys.Clear();
+        activeGroups.Clear();
+        collapsedPaths.Clear();
         Version++;
     }
 
     /// <summary>
-    /// Checks whether a group is collapsed.
+    /// Checks whether a group is collapsed in its own right.
     /// </summary>
+    /// <remarks>
+    /// This does not consider ancestors. A group inside a collapsed parent is not itself collapsed,
+    /// it is simply not rendered — use <see cref="IsHiddenByCollapse"/> for that question. Keeping
+    /// the two apart is what lets a subtree remember its own expansion while its parent is shut.
+    /// </remarks>
+    /// <param name="path">The group path to check.</param>
+    /// <returns>True if the group is collapsed.</returns>
+    public bool IsCollapsed(GroupPath path) => collapsedPaths.Contains(path);
+
+    /// <summary>
+    /// Checks whether an outermost group is collapsed.
+    /// </summary>
+    /// <remarks>
+    /// Kept for grids written against single-level grouping.
+    /// </remarks>
     /// <param name="key">The group key to check.</param>
-    /// <returns>True if the group is collapsed, false otherwise.</returns>
-    public bool IsCollapsed(object key) => collapsedKeys.Contains(key);
+    /// <returns>True if the group is collapsed.</returns>
+    public bool IsCollapsed(object key) => collapsedPaths.Contains(new GroupPath(key));
+
+    /// <summary>
+    /// Checks whether any ancestor of a group is collapsed, which is what hides it from the render
+    /// list even when it is expanded itself.
+    /// </summary>
+    /// <param name="path">The group path to check.</param>
+    /// <returns>True when an ancestor is collapsed.</returns>
+    public bool IsHiddenByCollapse(GroupPath path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        // Walk up rather than materializing descendants: the number of ancestors is the nesting
+        // depth, which is small, whereas the number of descendants is unbounded.
+        for (var parent = path.Parent(); parent.Keys.Count > 0; parent = parent.Parent())
+        {
+            if (collapsedPaths.Contains(parent))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Toggles the collapsed state of a group.
     /// </summary>
-    /// <param name="key">The group key to toggle.</param>
-    public void Toggle(object key)
+    /// <param name="path">The group path to toggle.</param>
+    public void Toggle(GroupPath path)
     {
-        if (!collapsedKeys.Remove(key))
+        ArgumentNullException.ThrowIfNull(path);
+
+        if (!collapsedPaths.Remove(path))
         {
-            collapsedKeys.Add(key);
+            collapsedPaths.Add(path);
         }
     }
+
+    /// <summary>
+    /// Toggles the collapsed state of an outermost group.
+    /// </summary>
+    /// <remarks>
+    /// Kept for grids written against single-level grouping.
+    /// </remarks>
+    /// <param name="key">The group key to toggle.</param>
+    public void Toggle(object key) => Toggle(new GroupPath(key));
 
     /// <summary>
     /// Expands all groups by clearing the collapsed set.
     /// </summary>
-    public void ExpandAll() => collapsedKeys.Clear();
+    public void ExpandAll() => collapsedPaths.Clear();
 
     /// <summary>
-    /// Collapses all groups by adding all provided keys to the collapsed set.
+    /// Collapses the given groups.
     /// </summary>
-    /// <param name="keys">The group keys to collapse.</param>
-    public void CollapseAll(IEnumerable<object> keys)
+    /// <param name="paths">The group paths to collapse.</param>
+    public void CollapseAll(IEnumerable<GroupPath> paths)
     {
-        foreach (var key in keys)
+        ArgumentNullException.ThrowIfNull(paths);
+
+        foreach (var path in paths)
         {
-            collapsedKeys.Add(key);
+            collapsedPaths.Add(path);
         }
     }
 
     /// <summary>
-    /// Clears all collapsed state and the active group definition.
+    /// Collapses the given outermost groups.
+    /// </summary>
+    /// <remarks>
+    /// Kept for grids written against single-level grouping.
+    /// </remarks>
+    /// <param name="keys">The group keys to collapse.</param>
+    public void CollapseAll(IEnumerable<object> keys)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+
+        foreach (var key in keys)
+        {
+            collapsedPaths.Add(new GroupPath(key));
+        }
+    }
+
+    /// <summary>
+    /// Clears all collapsed state and all group definitions.
     /// </summary>
     public void Clear()
     {
-        collapsedKeys.Clear();
-        ActiveGroup = null;
+        collapsedPaths.Clear();
+        activeGroups.Clear();
         Version++;
     }
 }

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridGroupedResult.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridGroupedResult.cs
@@ -37,7 +37,23 @@ public class DataGridGroupResult<TData> where TData : class
     /// <summary>
     /// Gets the group key value.
     /// </summary>
+    /// <remarks>
+    /// For a nested grouping this is the innermost key. Set <see cref="KeyPath"/> as well so the
+    /// grid knows which ancestors the group sits under.
+    /// </remarks>
     public object? Key { get; init; }
+
+    /// <summary>
+    /// Gets the ordered keys identifying this group, outermost first, for a nested grouping.
+    /// Null or empty for a single level, where <see cref="Key"/> is enough.
+    /// </summary>
+    /// <remarks>
+    /// The wire shape stays flat: one row per innermost group, each carrying its full path. That
+    /// is what <c>GROUP BY a, b</c> already returns, so a provider can project straight from a
+    /// query rather than reshaping the result into a tree. The grid rebuilds the tree from the
+    /// paths and re-emits the ancestor headers itself.
+    /// </remarks>
+    public IReadOnlyList<object?>? KeyPath { get; init; }
 
     /// <summary>
     /// Gets the items in this group.

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridItemsProvider.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridItemsProvider.cs
@@ -52,6 +52,20 @@ public class DataGridRequest
     public GroupDefinition? GroupDefinition { get; init; }
 
     /// <summary>
+    /// Gets every active group definition, outermost first. Empty when no grouping is active.
+    /// </summary>
+    /// <remarks>
+    /// Translate these into one <c>GROUP BY a, b</c> and return a flat row per innermost group,
+    /// each carrying its full <see cref="DataGridGroupResult{TData}.KeyPath"/>. The grid rebuilds
+    /// the header tree from those paths.
+    /// <para>
+    /// <see cref="GroupDefinition"/> holds the outermost level only, and is still set so a
+    /// provider written against single-level grouping keeps working.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<GroupDefinition> GroupDefinitions { get; init; } = Array.Empty<GroupDefinition>();
+
+    /// <summary>
     /// Gets the column IDs that need aggregate computation when grouping.
     /// Server-side providers should compute these aggregates per group.
     /// </summary>

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridRenderItem.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridRenderItem.cs
@@ -103,12 +103,25 @@ public class DataGridRenderItem<TData> where TData : class
     };
 
     /// <summary>
-    /// Creates a render item for a group header.
+    /// Creates a render item for a data row nested under group headers, carrying the depth it
+    /// should be indented to.
+    /// </summary>
+    public static DataGridRenderItem<TData> ForGroupedData(TData item, int depth) => new()
+    {
+        IsDataRow = true,
+        Item = item,
+        Depth = depth
+    };
+
+    /// <summary>
+    /// Creates a render item for a group header. The depth comes from the group itself, so a
+    /// nested header knows how far to indent.
     /// </summary>
     public static DataGridRenderItem<TData> ForGroup(DataGridGroupRow<TData> group) => new()
     {
         IsGroupHeader = true,
-        GroupRow = group
+        GroupRow = group,
+        Depth = group?.Depth ?? 0
     };
 
     /// <summary>

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridRowSnapshot.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridRowSnapshot.cs
@@ -1,0 +1,126 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace BlazorBlueprint.Primitives.DataGrid;
+
+/// <summary>
+/// Records the values of an item's public writable properties, so an edit can be undone.
+/// </summary>
+/// <remarks>
+/// Row editing binds straight to the item, which is what lets an edit template use an ordinary
+/// <c>@bind-Value</c>. That means a cancel has to put the old values back, and this is what holds
+/// them. Only public instance properties that can be both read and written are captured — a
+/// computed property has nothing to restore, and a private field is not something an edit template
+/// can have changed.
+/// </remarks>
+/// <typeparam name="TData">The type of data items.</typeparam>
+[SuppressMessage("Design", "CA1000:Do not declare static members on generic types",
+    Justification = "Capture is the only way to make a snapshot, and the type argument is already " +
+                    "implied by the item being passed in.")]
+public sealed class DataGridRowSnapshot<TData> where TData : class
+{
+    private static readonly PropertyInfo[] Properties = typeof(TData)
+        .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        .Where(p => p.CanRead && p.CanWrite && p.GetIndexParameters().Length == 0)
+        .ToArray();
+
+    private readonly Dictionary<string, object?> values;
+
+    private DataGridRowSnapshot(TData item, Dictionary<string, object?> values)
+    {
+        Item = item;
+        this.values = values;
+    }
+
+    /// <summary>
+    /// Gets the item the snapshot was taken from.
+    /// </summary>
+    public TData Item { get; }
+
+    /// <summary>
+    /// Takes a snapshot of an item's current values.
+    /// </summary>
+    /// <param name="item">The item to record.</param>
+    /// <returns>The snapshot.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when item is null.</exception>
+    public static DataGridRowSnapshot<TData> Capture(TData item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        var values = new Dictionary<string, object?>(Properties.Length, StringComparer.Ordinal);
+        foreach (var property in Properties)
+        {
+            try
+            {
+                values[property.Name] = property.GetValue(item);
+            }
+            catch (TargetInvocationException)
+            {
+                // A property that throws when read has no value worth restoring. Skipping it is
+                // better than failing the edit before the user has typed anything.
+            }
+        }
+
+        return new DataGridRowSnapshot<TData>(item, values);
+    }
+
+    /// <summary>
+    /// Puts the recorded values back on the item.
+    /// </summary>
+    /// <remarks>
+    /// Restores onto the same instance the snapshot came from, so anything else holding a
+    /// reference to that row sees the values revert too.
+    /// </remarks>
+    public void Restore()
+    {
+        foreach (var property in Properties)
+        {
+            if (!values.TryGetValue(property.Name, out var value))
+            {
+                continue;
+            }
+
+            try
+            {
+                property.SetValue(Item, value);
+            }
+            catch (TargetInvocationException)
+            {
+                // A setter that rejects a value it previously held leaves that property as the
+                // user left it. Better than abandoning the rest of the restore half-done.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets whether any recorded value differs from the item's current value.
+    /// </summary>
+    /// <returns>True when the item has been changed since the snapshot.</returns>
+    public bool HasChanges()
+    {
+        foreach (var property in Properties)
+        {
+            if (!values.TryGetValue(property.Name, out var original))
+            {
+                continue;
+            }
+
+            object? current;
+            try
+            {
+                current = property.GetValue(Item);
+            }
+            catch (TargetInvocationException)
+            {
+                continue;
+            }
+
+            if (!Equals(original, current))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridSelectionBehavior.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridSelectionBehavior.cs
@@ -1,0 +1,35 @@
+// Deliberately in the BlazorBlueprint.Primitives namespace rather than
+// BlazorBlueprint.Primitives.DataGrid, alongside SortDirection. An app that imports
+// BlazorBlueprint.Components cannot also import BlazorBlueprint.Primitives.DataGrid without
+// making the name BbDataGrid ambiguous, so an enum a consumer has to name in markup goes here.
+namespace BlazorBlueprint.Primitives;
+
+using BlazorBlueprint.Primitives.Table;
+
+
+/// <summary>
+/// Defines how clicking a row changes the selection.
+/// </summary>
+public enum DataGridSelectionBehavior
+{
+    /// <summary>
+    /// Each click flips one row on or off and leaves every other row alone.
+    /// Modifier keys are ignored. This is the default.
+    /// </summary>
+    Toggle,
+
+    /// <summary>
+    /// Clicking replaces the selection, the way a file explorer or a spreadsheet does.
+    /// A plain click selects only the clicked row, Shift+Click selects the range from the
+    /// anchor row, and Ctrl+Click (Cmd+Click on macOS) adds or removes one row without
+    /// disturbing the rest.
+    /// </summary>
+    /// <remarks>
+    /// Range and additive selection need <see cref="SelectionMode.Multiple"/>. Under
+    /// <see cref="SelectionMode.Single"/> every click behaves as a plain click.
+    /// Checkbox clicks in a select column keep <see cref="Toggle"/> semantics under this
+    /// behaviour too, because a checkbox that cleared the rest of the selection would be
+    /// unusable.
+    /// </remarks>
+    Replace
+}

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridState.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridState.cs
@@ -167,14 +167,20 @@ public class DataGridState<TData> where TData : class
             });
         }
 
-        if (Grouping.ActiveGroup != null)
+        foreach (var group in Grouping.ActiveGroups)
         {
-            snapshot.GroupDefinition = new GroupDefinitionSnapshot
+            snapshot.GroupDefinitions.Add(new GroupDefinitionSnapshot
             {
-                ColumnId = Grouping.ActiveGroup.ColumnId,
-                GroupSortDirection = Grouping.ActiveGroup.GroupSortDirection
-            };
+                ColumnId = group.ColumnId,
+                GroupSortDirection = group.GroupSortDirection
+            });
         }
+
+        // Also written to the single-level field, so a snapshot taken here still restores in an
+        // app running a version that only knows about one grouping level.
+        snapshot.GroupDefinition = snapshot.GroupDefinitions.Count > 0
+            ? snapshot.GroupDefinitions[0]
+            : null;
 
         return snapshot;
     }
@@ -209,13 +215,21 @@ public class DataGridState<TData> where TData : class
             });
         }
 
-        if (snapshot.GroupDefinition != null)
+        // A snapshot written before nested grouping existed only carries the single field, so
+        // fall back to it rather than restoring a grid with no grouping at all.
+        var groupSnapshots = snapshot.GroupDefinitions.Count > 0
+            ? snapshot.GroupDefinitions
+            : snapshot.GroupDefinition != null
+                ? new List<GroupDefinitionSnapshot> { snapshot.GroupDefinition }
+                : new List<GroupDefinitionSnapshot>();
+
+        if (groupSnapshots.Count > 0)
         {
-            Grouping.SetGroup(new GroupDefinition
+            Grouping.SetGroups(groupSnapshots.Select(g => new GroupDefinition
             {
-                ColumnId = snapshot.GroupDefinition.ColumnId,
-                GroupSortDirection = snapshot.GroupDefinition.GroupSortDirection
-            });
+                ColumnId = g.ColumnId,
+                GroupSortDirection = g.GroupSortDirection
+            }));
         }
         else
         {

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridStateSnapshot.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/DataGridStateSnapshot.cs
@@ -31,9 +31,19 @@ public class DataGridStateSnapshot
     public List<ColumnFilterSnapshot> ColumnFilters { get; set; } = new();
 
     /// <summary>
-    /// Gets or sets the group definition snapshot.
+    /// Gets or sets the outermost group definition snapshot.
     /// </summary>
+    /// <remarks>
+    /// Written and read alongside <see cref="GroupDefinitions"/> so a snapshot saved by this
+    /// version still restores in one written against single-level grouping, and one saved by that
+    /// older version still restores here.
+    /// </remarks>
     public GroupDefinitionSnapshot? GroupDefinition { get; set; }
+
+    /// <summary>
+    /// Gets or sets every group definition snapshot, outermost first.
+    /// </summary>
+    public List<GroupDefinitionSnapshot> GroupDefinitions { get; set; } = new();
 }
 
 /// <summary>

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/GroupPath.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/GroupPath.cs
@@ -1,0 +1,164 @@
+using System.Globalization;
+
+namespace BlazorBlueprint.Primitives.DataGrid;
+
+/// <summary>
+/// Identifies one group in a nested grouping by the ordered keys leading to it, from the
+/// outermost level inward.
+/// </summary>
+/// <remarks>
+/// A raw key is not enough to identify a nested group: grouping by Department then Status puts a
+/// group keyed <c>Active</c> under every department, and a flat set of collapsed keys would
+/// collapse all of them together. The full path disambiguates them.
+/// <para>
+/// Equality is by value over the whole path, so a path rebuilt on the next render matches the one
+/// stored in the collapsed set. Keys are compared with <see cref="object.Equals(object?)"/>, and a
+/// null key is a legitimate path segment — rows whose grouped column is null form their own group.
+/// </para>
+/// </remarks>
+public sealed class GroupPath : IEquatable<GroupPath>
+{
+    private readonly object?[] keys;
+    private readonly int hash;
+
+    /// <summary>
+    /// Creates a path from an ordered set of keys, outermost first.
+    /// </summary>
+    /// <param name="keys">The keys, outermost group first.</param>
+    /// <exception cref="ArgumentNullException">Thrown when keys is null.</exception>
+    public GroupPath(params object?[] keys)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+
+        this.keys = (object?[])keys.Clone();
+
+        var accumulated = new HashCode();
+        foreach (var key in this.keys)
+        {
+            accumulated.Add(key);
+        }
+
+        hash = accumulated.ToHashCode();
+    }
+
+    /// <summary>
+    /// Creates a path from an ordered sequence of keys, outermost first.
+    /// </summary>
+    /// <param name="keys">The keys, outermost group first.</param>
+    public GroupPath(IEnumerable<object?> keys)
+        : this((keys ?? throw new ArgumentNullException(nameof(keys))).ToArray())
+    {
+    }
+
+    /// <summary>
+    /// Gets the keys in this path, outermost group first.
+    /// </summary>
+    public IReadOnlyList<object?> Keys => keys;
+
+    /// <summary>
+    /// Gets how deep this group sits, zero-based. The outermost level is depth 0.
+    /// </summary>
+    public int Depth => keys.Length - 1;
+
+    /// <summary>
+    /// Gets the key of this group itself — the last segment of the path.
+    /// </summary>
+    public object? Key => keys.Length > 0 ? keys[^1] : null;
+
+    /// <summary>
+    /// Gets an empty path, which is the parent of every outermost group.
+    /// </summary>
+    public static GroupPath Root { get; } = new();
+
+    /// <summary>
+    /// Returns a new path one level deeper, ending in <paramref name="key"/>.
+    /// </summary>
+    /// <param name="key">The key of the child group.</param>
+    /// <returns>The child path.</returns>
+    public GroupPath Append(object? key)
+    {
+        var extended = new object?[keys.Length + 1];
+        Array.Copy(keys, extended, keys.Length);
+        extended[^1] = key;
+        return new GroupPath(extended);
+    }
+
+    /// <summary>
+    /// Returns the path of this group's parent, or <see cref="Root"/> when this is an outermost
+    /// group.
+    /// </summary>
+    /// <returns>The parent path.</returns>
+    public GroupPath Parent()
+    {
+        if (keys.Length == 0)
+        {
+            return Root;
+        }
+
+        return new GroupPath(keys[..^1]);
+    }
+
+    /// <summary>
+    /// Gets whether <paramref name="other"/> is this path or sits under it.
+    /// </summary>
+    /// <param name="other">The path to test.</param>
+    /// <returns>True when other starts with this path.</returns>
+    public bool IsAncestorOfOrSelf(GroupPath other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        if (other.keys.Length < keys.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < keys.Length; i++)
+        {
+            if (!Equals(keys[i], other.keys[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(GroupPath? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (hash != other.hash || keys.Length != other.keys.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < keys.Length; i++)
+        {
+            if (!Equals(keys[i], other.keys[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => Equals(obj as GroupPath);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => hash;
+
+    /// <inheritdoc />
+    public override string ToString() =>
+        string.Join(" › ", keys.Select(k => Convert.ToString(k, CultureInfo.CurrentCulture) ?? "(none)"));
+}

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/IDataGridColumn.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/IDataGridColumn.cs
@@ -96,6 +96,32 @@ public interface IDataGridColumn<TData> where TData : class
     public object? GetRawValue(TData item) => GetValue(item);
 
     /// <summary>
+    /// Gets the value this column sorts, filters, groups and exports on.
+    /// Defaults to <see cref="GetRawValue"/>.
+    /// </summary>
+    /// <remarks>
+    /// A column that displays something other than its raw property — the common case being a cell
+    /// template that resolves a key to a label — overrides this so the grid orders and filters by
+    /// what the user reads rather than by the key behind it.
+    /// </remarks>
+    /// <param name="item">The data item.</param>
+    /// <returns>The value to sort and filter by, boxed as object.</returns>
+    public object? GetSortAndFilterValue(TData item) => GetRawValue(item);
+
+    /// <summary>
+    /// Gets the lambda that projects the value this column sorts and filters on, or null when the
+    /// column sorts and filters on its own property.
+    /// </summary>
+    /// <remarks>
+    /// Returned as an expression rather than a compiled delegate so a server-side
+    /// <see cref="DataGridItemsProvider{TData}"/> backed by <see cref="IQueryable{T}"/> can still
+    /// translate it. The grid uses this in preference to reflecting the column's property when it
+    /// is set.
+    /// </remarks>
+    /// <returns>The projection lambda, or null.</returns>
+    public LambdaExpression? GetSortAndFilterExpression() => null;
+
+    /// <summary>
     /// Compares two data items based on this column's values.
     /// Used for in-memory sorting.
     /// </summary>
@@ -120,6 +146,17 @@ public interface IDataGridColumn<TData> where TData : class
     /// Gets the custom cell template for this column.
     /// </summary>
     public RenderFragment<DataGridCellContext<TData>>? CellTemplate { get; }
+
+    /// <summary>
+    /// Gets the template that renders this column's cell while its row is being edited, or null
+    /// when the column is not editable.
+    /// </summary>
+    /// <remarks>
+    /// The template binds straight to the item, so an ordinary <c>@bind-Value</c> works. A column
+    /// without one keeps showing its normal cell while the rest of the row is in edit, which is
+    /// what a read-only column such as an id or a computed total should do.
+    /// </remarks>
+    public RenderFragment<DataGridCellContext<TData>>? EditTemplate => null;
 
     /// <summary>
     /// Gets the custom header template for this column.

--- a/src/BlazorBlueprint.Primitives/Primitives/DataGrid/RowSelectionModifiers.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/DataGrid/RowSelectionModifiers.cs
@@ -1,0 +1,19 @@
+namespace BlazorBlueprint.Primitives.DataGrid;
+
+/// <summary>
+/// The modifier keys held during a row click, which decide how
+/// <see cref="DataGridSelectionBehavior.Replace"/> changes the selection.
+/// </summary>
+/// <param name="Extend">
+/// True when Shift was held: select the range from the anchor row to the clicked row.
+/// </param>
+/// <param name="Additive">
+/// True when Ctrl (or Cmd on macOS) was held: add or remove the clicked row only.
+/// </param>
+public readonly record struct RowSelectionModifiers(bool Extend, bool Additive)
+{
+    /// <summary>
+    /// Gets the modifiers for a click with no modifier key held.
+    /// </summary>
+    public static RowSelectionModifiers None => new(false, false);
+}

--- a/src/BlazorBlueprint.Primitives/Primitives/Filtering/FilterDefinitionExtensions.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/Filtering/FilterDefinitionExtensions.cs
@@ -68,6 +68,104 @@ public static class FilterDefinitionExtensions
     }
 
     /// <summary>
+    /// Evaluates a single condition against a value that has already been read from the item,
+    /// instead of looking a property up by name.
+    /// </summary>
+    /// <remarks>
+    /// Use this when the value being filtered is not a plain property of the item — for example a
+    /// DataGrid column that displays a looked-up label and filters on that label rather than on the
+    /// key it was resolved from. An incomplete condition (one whose value the user has not entered
+    /// yet) matches everything, which is the same behaviour as <see cref="ToFunc{T}"/>.
+    /// </remarks>
+    /// <param name="condition">The condition to evaluate.</param>
+    /// <param name="value">The already-projected value to test.</param>
+    /// <param name="fieldType">
+    /// The field type, used to pick whole-day semantics for date comparisons. Pass null to compare
+    /// the value as-is.
+    /// </param>
+    /// <returns>True if the value satisfies the condition.</returns>
+    public static bool MatchesValue(this FilterCondition condition, object? value, FilterFieldType? fieldType = null) =>
+        EvaluateConditionValue(value, condition, fieldType);
+
+    /// <summary>
+    /// Builds a LINQ predicate that applies a condition to the value produced by
+    /// <paramref name="selector"/>, instead of to a property looked up by name.
+    /// </summary>
+    /// <remarks>
+    /// This is the <see cref="IQueryable{T}"/> counterpart of
+    /// <see cref="MatchesValue"/>. The selector is inlined into the returned expression, so a
+    /// provider such as EF Core translates it to SQL as long as the selector itself is translatable.
+    /// A selector declared as <c>Expression&lt;Func&lt;T, object&gt;&gt;</c> boxes a value type
+    /// through a <c>Convert</c> node; that node is removed so the comparison is built against the
+    /// real type.
+    /// </remarks>
+    /// <typeparam name="T">The type of objects to filter.</typeparam>
+    /// <param name="condition">The condition to apply.</param>
+    /// <param name="selector">A one-parameter lambda taking a <typeparamref name="T"/> and returning the value to test.</param>
+    /// <param name="fieldType">
+    /// The field type, used to pick whole-day semantics for date comparisons. Pass null to compare
+    /// the value as-is.
+    /// </param>
+    /// <returns>An expression tree representing the condition.</returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="selector"/> does not take exactly one parameter of type <typeparamref name="T"/>.
+    /// </exception>
+    public static Expression<Func<T, bool>> ToExpressionForSelector<T>(
+        this FilterCondition condition, LambdaExpression selector, FilterFieldType? fieldType = null)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+
+        if (selector.Parameters.Count != 1 || !selector.Parameters[0].Type.IsAssignableFrom(typeof(T)))
+        {
+            throw new ArgumentException(
+                $"The selector must take exactly one parameter of type {typeof(T).Name}.", nameof(selector));
+        }
+
+        var parameter = Expression.Parameter(typeof(T), "x");
+        var body = new ParameterRebinder(selector.Parameters[0], parameter).Visit(selector.Body)!;
+        body = UnwrapConvert(body);
+
+        var conditionExpression = BuildConditionExpressionCore(body, body.Type, condition, fieldType)
+            ?? Expression.Constant(true);
+
+        return Expression.Lambda<Func<T, bool>>(conditionExpression, parameter);
+    }
+
+    /// <summary>
+    /// Removes the boxing <c>Convert</c> node a lambda declared to return <see cref="object"/>
+    /// wraps a value type in, so comparisons are built against the underlying type.
+    /// </summary>
+    private static Expression UnwrapConvert(Expression body)
+    {
+        while (body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary
+               && unary.Type == typeof(object))
+        {
+            body = unary.Operand;
+        }
+
+        return body;
+    }
+
+    /// <summary>
+    /// Replaces one parameter with another throughout an expression tree, so a caller-supplied
+    /// lambda body can be inlined under a different parameter.
+    /// </summary>
+    private sealed class ParameterRebinder : ExpressionVisitor
+    {
+        private readonly ParameterExpression source;
+        private readonly ParameterExpression target;
+
+        public ParameterRebinder(ParameterExpression source, ParameterExpression target)
+        {
+            this.source = source;
+            this.target = target;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node) =>
+            node == source ? target : base.VisitParameter(node);
+    }
+
+    /// <summary>
     /// Serializes the filter definition to a JSON string.
     /// </summary>
     public static string ToJson(this FilterDefinition filter) =>
@@ -125,8 +223,11 @@ public static class FilterDefinitionExtensions
             return false;
         }
 
-        var rawValue = prop.GetValue(item);
+        return EvaluateConditionValue(prop.GetValue(item), condition, fieldType);
+    }
 
+    private static bool EvaluateConditionValue(object? rawValue, FilterCondition condition, FilterFieldType? fieldType)
+    {
         // Incomplete condition: user hasn't entered a value yet — ignore (match all)
         // to align with ToExpression behavior and avoid filtering out all rows mid-edit.
         if (IsIncompleteCondition(condition))
@@ -564,8 +665,16 @@ public static class FilterDefinitionExtensions
             return Expression.Constant(false);
         }
 
-        var propAccess = Expression.Property(parameter, property);
-        var propType = property.PropertyType;
+        return BuildConditionExpressionCore(
+            Expression.Property(parameter, property), property.PropertyType, condition, fieldType);
+    }
+
+    private static Expression? BuildConditionExpressionCore(
+        Expression propAccess,
+        Type propType,
+        FilterCondition condition,
+        FilterFieldType? fieldType)
+    {
         var isNullable = Nullable.GetUnderlyingType(propType) != null || !propType.IsValueType;
 
         // For Date/DateTime field types, use "whole day" semantics for comparison operators
@@ -631,7 +740,7 @@ public static class FilterDefinitionExtensions
         };
     }
 
-    private static Expression BuildIsEmptyExpression(MemberExpression propAccess, Type propType, bool isNullable)
+    private static Expression BuildIsEmptyExpression(Expression propAccess, Type propType, bool isNullable)
     {
         if (propType == typeof(string))
         {
@@ -647,7 +756,7 @@ public static class FilterDefinitionExtensions
         return Expression.Constant(false);
     }
 
-    private static Expression BuildBoolExpression(MemberExpression propAccess, Type propType, bool expected)
+    private static Expression BuildBoolExpression(Expression propAccess, Type propType, bool expected)
     {
         if (propType == typeof(bool))
         {
@@ -672,7 +781,7 @@ public static class FilterDefinitionExtensions
     }
 
     private static Expression BuildComparisonExpression(
-        MemberExpression propAccess, Type propType, object? value, ExpressionType comparison)
+        Expression propAccess, Type propType, object? value, ExpressionType comparison)
     {
         var underlyingType = Nullable.GetUnderlyingType(propType) ?? propType;
         var convertedValue = ConvertValue(value, underlyingType);
@@ -707,7 +816,7 @@ public static class FilterDefinitionExtensions
     }
 
     private static Expression BuildStringMethodExpression(
-        MemberExpression propAccess, Type propType, object? value, string methodName)
+        Expression propAccess, Type propType, object? value, string methodName)
     {
         // Use ToLower(CultureInfo.InvariantCulture) + single-param overloads for EF Core/IQueryable
         // translation compatibility. The StringComparison overloads are not translatable to SQL.
@@ -765,7 +874,7 @@ public static class FilterDefinitionExtensions
     }
 
     private static BinaryExpression BuildBetweenExpression(
-        MemberExpression propAccess, Type propType, object? valueStart, object? valueEnd)
+        Expression propAccess, Type propType, object? valueStart, object? valueEnd)
     {
         var gte = BuildComparisonExpression(propAccess, propType, valueStart, ExpressionType.GreaterThanOrEqual);
         var lte = BuildComparisonExpression(propAccess, propType, valueEnd, ExpressionType.LessThanOrEqual);
@@ -773,7 +882,7 @@ public static class FilterDefinitionExtensions
     }
 
     private static Expression BuildInLastExpression(
-        MemberExpression propAccess, Type propType, FilterCondition condition)
+        Expression propAccess, Type propType, FilterCondition condition)
     {
         var dateTarget = ResolveDateTimeTarget(propAccess, propType, out var isNullable);
         if (dateTarget == null)
@@ -819,7 +928,7 @@ public static class FilterDefinitionExtensions
     }
 
     private static Expression BuildInNextExpression(
-        MemberExpression propAccess, Type propType, FilterCondition condition)
+        Expression propAccess, Type propType, FilterCondition condition)
     {
         var dateTarget = ResolveDateTimeTarget(propAccess, propType, out var isNullable);
         if (dateTarget == null)
@@ -869,7 +978,7 @@ public static class FilterDefinitionExtensions
     }
 
     private static Expression BuildDatePresetExpression(
-        MemberExpression propAccess, Type propType, FilterCondition condition, bool negate)
+        Expression propAccess, Type propType, FilterCondition condition, bool negate)
     {
         var dateTarget = ResolveDateTimeTarget(propAccess, propType, out var isNullable);
         if (dateTarget == null)
@@ -912,8 +1021,8 @@ public static class FilterDefinitionExtensions
     /// Handles DateTime, DateTime?, DateTimeOffset, and DateTimeOffset? by accessing .LocalDateTime
     /// on DateTimeOffset types.
     /// </summary>
-    private static MemberExpression? ResolveDateTimeTarget(
-        MemberExpression propAccess, Type propType, out bool isNullable)
+    private static Expression? ResolveDateTimeTarget(
+        Expression propAccess, Type propType, out bool isNullable)
     {
         isNullable = false;
 
@@ -945,7 +1054,7 @@ public static class FilterDefinitionExtensions
     }
 
     private static Expression BuildInExpression(
-        MemberExpression propAccess, Type propType, object? filterValue, bool negate)
+        Expression propAccess, Type propType, object? filterValue, bool negate)
     {
         if (filterValue is not IEnumerable<string> values)
         {

--- a/src/BlazorBlueprint.Primitives/Primitives/Table/SelectionState.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/Table/SelectionState.cs
@@ -20,6 +20,17 @@ public class SelectionState<TData> where TData : class
     public SelectionMode Mode { get; set; } = SelectionMode.None;
 
     /// <summary>
+    /// Gets or sets the anchor row that a range selection extends from.
+    /// </summary>
+    /// <remarks>
+    /// Shift+Click extends from the last anchor, not from the last selected row. The two differ
+    /// after a Ctrl+Click, and using the wrong one is what makes range selection feel wrong rather
+    /// than plainly broken. A plain click and a Ctrl+Click both move the anchor; a Shift+Click
+    /// leaves it where it is, so repeated Shift+Clicks re-extend from the same origin.
+    /// </remarks>
+    public TData? Anchor { get; set; }
+
+    /// <summary>
     /// Gets the number of selected items.
     /// </summary>
     public int SelectedCount => selectedItems.Count;
@@ -134,9 +145,95 @@ public class SelectionState<TData> where TData : class
     }
 
     /// <summary>
+    /// Replaces the whole selection with a single item.
+    /// Has no effect in <see cref="SelectionMode.None"/>.
+    /// </summary>
+    /// <param name="item">The only item that should end up selected.</param>
+    /// <exception cref="ArgumentNullException">Thrown when item is null.</exception>
+    public void ReplaceWith(TData item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        if (Mode == SelectionMode.None)
+        {
+            return;
+        }
+
+        selectedItems.Clear();
+        selectedItems.Add(item);
+    }
+
+    /// <summary>
+    /// Replaces the selection with the inclusive range of <paramref name="rows"/> between
+    /// <paramref name="from"/> and <paramref name="to"/>, in either order.
+    /// Only works in <see cref="SelectionMode.Multiple"/>.
+    /// </summary>
+    /// <remarks>
+    /// If either end is not present in <paramref name="rows"/> — a stale anchor left behind by a
+    /// page change or a filter, for instance — the selection falls back to
+    /// <paramref name="to"/> alone rather than selecting nothing or throwing.
+    /// </remarks>
+    /// <param name="rows">The rows in display order.</param>
+    /// <param name="from">The anchor end of the range.</param>
+    /// <param name="to">The clicked end of the range.</param>
+    /// <exception cref="ArgumentNullException">Thrown when rows or to is null.</exception>
+    public void SelectRange(IEnumerable<TData> rows, TData? from, TData to)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        ArgumentNullException.ThrowIfNull(to);
+
+        if (Mode != SelectionMode.Multiple)
+        {
+            ReplaceWith(to);
+            return;
+        }
+
+        var ordered = rows as IList<TData> ?? rows.ToList();
+        var toIndex = IndexOf(ordered, to);
+        var fromIndex = from != null ? IndexOf(ordered, from) : -1;
+
+        if (toIndex < 0 || fromIndex < 0)
+        {
+            ReplaceWith(to);
+            return;
+        }
+
+        var start = Math.Min(fromIndex, toIndex);
+        var end = Math.Max(fromIndex, toIndex);
+
+        selectedItems.Clear();
+        for (var i = start; i <= end; i++)
+        {
+            selectedItems.Add(ordered[i]);
+        }
+    }
+
+    /// <summary>
+    /// Finds a row's position using the same equality the selection uses, so an item key comparer
+    /// still matches a row that was re-materialized between renders.
+    /// </summary>
+    private int IndexOf(IList<TData> rows, TData target)
+    {
+        var comparer = selectedItems.Comparer;
+        for (var i = 0; i < rows.Count; i++)
+        {
+            if (comparer.Equals(rows[i], target))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
     /// Clears all selections.
     /// </summary>
-    public void Clear() => selectedItems.Clear();
+    public void Clear()
+    {
+        selectedItems.Clear();
+        Anchor = null;
+    }
 
     /// <summary>
     /// Checks if all items in a collection are selected.

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/table-row-nav.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/table-row-nav.js
@@ -101,8 +101,18 @@ export function preventSpaceKeyScroll(element) {
     // C# HandleKeyDown is never invoked for interactive-child events.
     const bubbleHandler = (e) => {
         if (element._bbInteractiveKeyDown) {
-            e.stopPropagation();
             element._bbInteractiveKeyDown = false;
+
+            // A row being edited needs Enter and Escape to reach Blazor, because that is how the
+            // edit is committed or discarded from inside an input. Stopping propagation here
+            // would block every Blazor handler in the row, not just the row's own, because Blazor
+            // listens at the document. The row's C# handler knows it is editing and does not run
+            // its selection shortcuts for these keys.
+            if (element.dataset.editing === 'true' && (e.key === 'Enter' || e.key === 'Escape')) {
+                return;
+            }
+
+            e.stopPropagation();
         }
     };
 
@@ -164,4 +174,25 @@ export function moveFocusToNextRow(element) {
         nextRow = nextRow.nextElementSibling;
     }
     nextRow?.focus();
+}
+
+/**
+ * Blurs whatever is focused inside the row, so an input that only writes its value back on
+ * change has done so before the row is committed.
+ *
+ * Pressing Enter runs the row's keydown handler before the browser fires the input's change
+ * event, so committing straight away would drop whatever the user typed into the field they were
+ * still in. Blurring first forces that change through.
+ *
+ * @param {HTMLElement} rowElement - The <tr> row element
+ * @returns {boolean} True when something inside the row was focused and has been blurred.
+ */
+export function blurFocusedInput(rowElement) {
+    const active = document.activeElement;
+    if (!rowElement || !active || active === document.body || !rowElement.contains(active)) {
+        return false;
+    }
+
+    active.blur();
+    return true;
 }

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -814,6 +814,11 @@
   - Item : TData [EditorRequired]
   - ParentGrid : BbDataGrid<TData> [CascadingParameter]
 
+### BbDataGridEditColumn`1 (BlazorBlueprint.Components)
+  - Pinned : ColumnPinning
+  - Width : String
+  - ParentGrid : BbDataGrid<TData> [CascadingParameter]
+
 ### BbDataGridExpandColumn`1 (BlazorBlueprint.Components)
   - DetailRows : RenderFragment<TData>
   - Pinned : ColumnPinning
@@ -858,6 +863,7 @@
   - CellClass : String
   - CellClassFunc : Func<TData, String>
   - CellTemplate : RenderFragment<TData>
+  - EditTemplate : RenderFragment<TData>
   - FilterOptions : IEnumerable<SelectOption<String>>
   - FilterType : FilterFieldType?
   - Filterable : Boolean
@@ -873,6 +879,7 @@
   - Property : Expression<Func<TData, TProp>> [EditorRequired]
   - Reorderable : Boolean
   - Resizable : Boolean
+  - SortAndFilterBy : Expression<Func<TData, Object>>
   - Sortable : Boolean
   - Title : String
   - Visible : Boolean
@@ -924,10 +931,15 @@
   - DefaultExpandAll : Boolean
   - DefaultExpandDepth : Int32?
   - DetailTemplate : RenderFragment<TData>
+  - EditMode : DataGridEditMode
+  - EditOnRowClick : Boolean
   - EmptyTemplate : RenderFragment
   - EnableKeyboardNavigation : Boolean
   - ExpandedNodes : HashSet<String>
   - ExpandedNodesChanged : EventCallback<HashSet<String>>
+  - ExportDelimiter : String
+  - ExportFileName : String
+  - ExportScope : DataGridExportScope
   - FilterBarClass : String
   - GroupBy : Expression<Func<TData, Object>>
   - GroupHeaderTemplate : RenderFragment<DataGridGroupContext<TData>>
@@ -953,13 +965,16 @@
   - OnColumnReorder : EventCallback<ValueTuple<String, Int32>>
   - OnColumnResize : EventCallback<ValueTuple<String, String>>
   - OnExpandAll : EventCallback
+  - OnExport : EventCallback<String>
   - OnFilter : EventCallback<IReadOnlyDictionary<String, FilterCondition>>
   - OnGroupCollapse : EventCallback<DataGridGroupRow<TData>>
   - OnGroupExpand : EventCallback<DataGridGroupRow<TData>>
   - OnNodeCollapse : EventCallback<TData>
   - OnNodeExpand : EventCallback<TData>
+  - OnRowCancel : EventCallback<TData>
   - OnRowClick : EventCallback<TData>
   - OnRowCollapse : EventCallback<TData>
+  - OnRowCommit : EventCallback<DataGridRowCommitContext<TData>>
   - OnRowExpand : EventCallback<TData>
   - OnSort : EventCallback<IReadOnlyList<SortDefinition>>
   - OverscanCount : Int32
@@ -974,9 +989,12 @@
   - SearchText : String
   - SearchTextChanged : EventCallback<String>
   - SelectedItemsChanged : EventCallback<IReadOnlyCollection<TData>>
+  - SelectionBehavior : DataGridSelectionBehavior
   - SelectionMode : DataTableSelectionMode
   - ShowExpandAll : Boolean
+  - ShowExport : Boolean
   - ShowFilterBar : Boolean
+  - ShowGroupingBreadcrumb : Boolean
   - ShowPagination : Boolean
   - ShowSearch : Boolean
   - State : DataGridState<TData>
@@ -3922,6 +3940,10 @@
 ### DashboardBackground (BlazorBlueprint.Components)
   - None = 0
   - Grid = 1
+
+### DataGridExportScope (BlazorBlueprint.Components)
+  - FilteredRows = 0
+  - CurrentPage = 1
 
 ### DataGridSelectAllScope (BlazorBlueprint.Components)
   - Prompt = 0

--- a/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
@@ -202,12 +202,15 @@
   - ChildContent : RenderFragment
   - Class : String
   - EnableKeyboardNavigation : Boolean
+  - IsRowEditing : Func<TData, Boolean>
   - Items : IEnumerable<TData>
   - ItemsProvider : DataGridItemsProvider<TData>
   - ManualPagination : Boolean
+  - OnCancelEdit : Func<Task>
   - OnColumnReorder : EventCallback<ValueTuple<String, Int32>>
   - OnColumnResize : EventCallback<ValueTuple<String, String>>
   - OnColumnVisibilityChange : EventCallback<ValueTuple<String, Boolean>>
+  - OnCommitEdit : Func<Task>
   - OnPageChange : EventCallback<Int32>
   - OnPageSizeChange : EventCallback<Int32>
   - OnRowClick : EventCallback<TData>
@@ -216,6 +219,7 @@
   - OnSelectionChange : EventCallback<IReadOnlyCollection<TData>>
   - OnSortChange : EventCallback<IReadOnlyList<SortDefinition>>
   - OnToggleExpand : EventCallback<TData>
+  - SelectionBehavior : DataGridSelectionBehavior
   - SelectionMode : SelectionMode
   - State : DataGridState<TData>
   - StateChanged : EventCallback<DataGridState<TData>>
@@ -925,6 +929,14 @@
   - Left = 1
   - Right = 2
 
+### DataGridEditMode (BlazorBlueprint.Primitives)
+  - None = 0
+  - Row = 1
+
+### DataGridSelectionBehavior (BlazorBlueprint.Primitives)
+  - Toggle = 0
+  - Replace = 1
+
 ### DatePreset (BlazorBlueprint.Primitives.Filtering)
   - Today = 0
   - Yesterday = 1
@@ -1112,6 +1124,7 @@
   - CellClassFunc : Func<TData, String> { get; }
   - CellTemplate : RenderFragment<DataGridCellContext<TData>> { get; }
   - ColumnId : String { get; }
+  - EditTemplate : RenderFragment<DataGridCellContext<TData>> { get; }
   - Filterable : Boolean { get; }
   - Groupable : Boolean { get; }
   - HeaderClass : String { get; }
@@ -1129,6 +1142,8 @@
   - Compare(TData x, TData y) : Int32
   - GetFilterExpression() : LambdaExpression
   - GetRawValue(TData item) : Object
+  - GetSortAndFilterExpression() : LambdaExpression
+  - GetSortAndFilterValue(TData item) : Object
   - GetSortExpression() : LambdaExpression
   - GetValue(TData item) : Object
 

--- a/tests/BlazorBlueprint.Tests/DataGrid/CsvExportTests.cs
+++ b/tests/BlazorBlueprint.Tests/DataGrid/CsvExportTests.cs
@@ -1,0 +1,327 @@
+using System.Globalization;
+using System.Linq.Expressions;
+using BlazorBlueprint.Primitives.DataGrid;
+using Microsoft.AspNetCore.Components;
+using Xunit;
+
+namespace BlazorBlueprint.Tests.DataGrid;
+
+/// <summary>
+/// Covers CSV export: display values rather than raw keys, correct quoting, and the formula
+/// sanitizing that stops a cell from executing when the file is opened in a spreadsheet.
+/// </summary>
+public class CsvExportTests
+{
+    private sealed class Employee
+    {
+        public string Name { get; init; } = "";
+
+        public int StatusId { get; init; }
+
+        public decimal Salary { get; init; }
+    }
+
+    private static readonly Dictionary<int, string> StatusNames = new()
+    {
+        [1] = "Pending",
+        [2] = "Active"
+    };
+
+    private sealed class Column : IDataGridColumn<Employee>
+    {
+        private readonly Func<Employee, object?> value;
+        private readonly Expression<Func<Employee, object?>>? selector;
+        private readonly Func<Employee, object?>? compiledSelector;
+
+        public Column(
+            string columnId,
+            string? title,
+            Func<Employee, object?> value,
+            Expression<Func<Employee, object?>>? selector = null)
+        {
+            ColumnId = columnId;
+            Title = title;
+            this.value = value;
+            this.selector = selector;
+            compiledSelector = selector?.Compile();
+        }
+
+        public string ColumnId { get; }
+
+        public string? Title { get; }
+
+        public bool Sortable => true;
+
+        public bool Filterable => true;
+
+        public bool Visible => true;
+
+        public string? Width => null;
+
+        public bool Hideable => true;
+
+        public bool Resizable => true;
+
+        public bool Reorderable => true;
+
+        public ColumnPinning Pinned => ColumnPinning.None;
+
+        public RenderFragment<DataGridCellContext<Employee>>? CellTemplate => null;
+
+        public RenderFragment<DataGridHeaderContext<Employee>>? HeaderTemplate => null;
+
+        public string? CellClass => null;
+
+        public string? HeaderClass => null;
+
+        public bool NoWrap => false;
+
+        public AggregateFunction Aggregate => AggregateFunction.None;
+
+        public object? GetValue(Employee item) => value(item);
+
+        public object? GetSortAndFilterValue(Employee item) =>
+            compiledSelector != null ? compiledSelector(item) : GetValue(item);
+
+        public LambdaExpression? GetSortAndFilterExpression() => selector;
+
+        public int Compare(Employee x, Employee y) => 0;
+
+        public LambdaExpression? GetSortExpression() => null;
+
+        public LambdaExpression? GetFilterExpression() => null;
+    }
+
+    private static List<IDataGridColumn<Employee>> NameAndStatusColumns() => new()
+    {
+        new Column("name", "Name", e => e.Name),
+        new Column("status", "Status", e => e.StatusId, e => StatusNames[e.StatusId])
+    };
+
+    // --- Shape ---------------------------------------------------------------------
+
+    [Fact]
+    public void WritesAHeaderRowOfColumnTitles()
+    {
+        var csv = DataGridCsvWriter.Write(Array.Empty<Employee>(), NameAndStatusColumns());
+
+        Assert.Equal("Name,Status\r\n", csv);
+    }
+
+    [Fact]
+    public void OmitsTheHeaderRowWhenAsked()
+    {
+        var rows = new[] { new Employee { Name = "Ana", StatusId = 2 } };
+
+        var csv = DataGridCsvWriter.Write(rows, NameAndStatusColumns(), includeHeader: false);
+
+        Assert.Equal("Ana,Active\r\n", csv);
+    }
+
+    [Fact]
+    public void FallsBackToTheColumnIdWhenAColumnHasNoTitle()
+    {
+        var columns = new List<IDataGridColumn<Employee>> { new Column("name", null, e => e.Name) };
+
+        var csv = DataGridCsvWriter.Write(Array.Empty<Employee>(), columns);
+
+        Assert.Equal("name\r\n", csv);
+    }
+
+    [Fact]
+    public void HonoursACustomDelimiter()
+    {
+        var rows = new[] { new Employee { Name = "Ana", StatusId = 2 } };
+
+        var csv = DataGridCsvWriter.Write(rows, NameAndStatusColumns(), delimiter: ";");
+
+        Assert.Equal("Name;Status\r\nAna;Active\r\n", csv);
+    }
+
+    [Fact]
+    public void RejectsAnEmptyDelimiter()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            DataGridCsvWriter.Write(Array.Empty<Employee>(), NameAndStatusColumns(), delimiter: ""));
+    }
+
+    // --- Display values ------------------------------------------------------------
+
+    [Fact]
+    public void ExportsTheDisplayValueNotTheKeyForAColumnWithASelector()
+    {
+        var rows = new[]
+        {
+            new Employee { Name = "Ana", StatusId = 2 },
+            new Employee { Name = "Bo", StatusId = 1 }
+        };
+
+        var csv = DataGridCsvWriter.Write(rows, NameAndStatusColumns());
+
+        Assert.Equal("Name,Status\r\nAna,Active\r\nBo,Pending\r\n", csv);
+    }
+
+    [Fact]
+    public void ExportsTheFormattedValueForAColumnWithoutASelector()
+    {
+        var columns = new List<IDataGridColumn<Employee>>
+        {
+            new Column("salary", "Salary", e => e.Salary.ToString("N0", CultureInfo.InvariantCulture))
+        };
+        var rows = new[] { new Employee { Salary = 113876m } };
+
+        var csv = DataGridCsvWriter.Write(rows, columns);
+
+        Assert.Equal("Salary\r\n\"113,876\"\r\n", csv);
+    }
+
+    [Fact]
+    public void WritesAnEmptyFieldForANullValue()
+    {
+        var columns = new List<IDataGridColumn<Employee>>
+        {
+            new Column("name", "Name", _ => null),
+            new Column("status", "Status", e => e.StatusId)
+        };
+        var rows = new[] { new Employee { StatusId = 7 } };
+
+        var csv = DataGridCsvWriter.Write(rows, columns);
+
+        Assert.Equal("Name,Status\r\n,7\r\n", csv);
+    }
+
+    // --- Quoting -------------------------------------------------------------------
+
+    [Fact]
+    public void QuotesAValueContainingTheDelimiter()
+    {
+        var columns = new List<IDataGridColumn<Employee>> { new Column("name", "Name", e => e.Name) };
+        var rows = new[] { new Employee { Name = "Wilson, James" } };
+
+        var csv = DataGridCsvWriter.Write(rows, columns);
+
+        Assert.Equal("Name\r\n\"Wilson, James\"\r\n", csv);
+    }
+
+    [Fact]
+    public void DoublesAndQuotesAnEmbeddedQuote()
+    {
+        var columns = new List<IDataGridColumn<Employee>> { new Column("name", "Name", e => e.Name) };
+        var rows = new[] { new Employee { Name = "James \"Jim\" Wilson" } };
+
+        var csv = DataGridCsvWriter.Write(rows, columns);
+
+        Assert.Equal("Name\r\n\"James \"\"Jim\"\" Wilson\"\r\n", csv);
+    }
+
+    [Fact]
+    public void QuotesAValueContainingANewline()
+    {
+        var columns = new List<IDataGridColumn<Employee>> { new Column("name", "Name", e => e.Name) };
+        var rows = new[] { new Employee { Name = "Line one\nLine two" } };
+
+        var csv = DataGridCsvWriter.Write(rows, columns);
+
+        Assert.Equal("Name\r\n\"Line one\nLine two\"\r\n", csv);
+    }
+
+    [Fact]
+    public void DoesNotQuoteAValueContainingACommaWhenTheDelimiterIsASemicolon()
+    {
+        var columns = new List<IDataGridColumn<Employee>> { new Column("name", "Name", e => e.Name) };
+        var rows = new[] { new Employee { Name = "Wilson, James" } };
+
+        var csv = DataGridCsvWriter.Write(rows, columns, delimiter: ";");
+
+        Assert.Equal("Name\r\nWilson, James\r\n", csv);
+    }
+
+    // --- CSV injection -------------------------------------------------------------
+
+    [Theory]
+    [InlineData("=1+1")]
+    [InlineData("+HYPERLINK(\"http://evil\")")]
+    [InlineData("@SUM(A1)")]
+    [InlineData("-2+3+cmd|' /C calc'!A0")]
+    [InlineData("\tleading tab")]
+    public void PrefixesAFormulaCellWithAnApostrophe(string dangerous)
+    {
+        var columns = new List<IDataGridColumn<Employee>> { new Column("name", "Name", e => e.Name) };
+        var rows = new[] { new Employee { Name = dangerous } };
+
+        var csv = DataGridCsvWriter.Write(rows, columns, includeHeader: false);
+
+        // The cell may also be quoted, but the apostrophe must come first inside the field.
+        var field = csv.TrimEnd('\r', '\n').TrimStart('"');
+        Assert.StartsWith("'", field, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("-1500")]
+    [InlineData("+42")]
+    [InlineData("-0.5")]
+    public void LeavesANegativeOrSignedNumberAlone(string numeric)
+    {
+        var columns = new List<IDataGridColumn<Employee>> { new Column("name", "Name", e => e.Name) };
+        var rows = new[] { new Employee { Name = numeric } };
+
+        var csv = DataGridCsvWriter.Write(rows, columns, includeHeader: false);
+
+        Assert.Equal(numeric + "\r\n", csv);
+    }
+
+    [Fact]
+    public void LeavesAnOrdinaryValueAlone()
+    {
+        var columns = new List<IDataGridColumn<Employee>> { new Column("name", "Name", e => e.Name) };
+        var rows = new[] { new Employee { Name = "James Wilson" } };
+
+        var csv = DataGridCsvWriter.Write(rows, columns, includeHeader: false);
+
+        Assert.Equal("James Wilson\r\n", csv);
+    }
+
+    [Fact]
+    public void SanitizesTheDisplayValueOfASelectorColumnToo()
+    {
+        // The selector is the attacker-reachable path for a lookup column, so it must be
+        // sanitized on the same footing as a plain property.
+        var lookup = new Dictionary<int, string> { [1] = "=cmd|' /C calc'!A0" };
+        var columns = new List<IDataGridColumn<Employee>>
+        {
+            new Column("status", "Status", e => e.StatusId, e => lookup[e.StatusId])
+        };
+        var rows = new[] { new Employee { StatusId = 1 } };
+
+        var csv = DataGridCsvWriter.Write(rows, columns, includeHeader: false);
+
+        Assert.Equal("'=cmd|' /C calc'!A0\r\n", csv);
+    }
+
+    // --- Column selection ----------------------------------------------------------
+
+    [Fact]
+    public void WritesColumnsInTheOrderGiven()
+    {
+        var columns = new List<IDataGridColumn<Employee>>
+        {
+            new Column("status", "Status", e => e.StatusId, e => StatusNames[e.StatusId]),
+            new Column("name", "Name", e => e.Name)
+        };
+        var rows = new[] { new Employee { Name = "Ana", StatusId = 2 } };
+
+        var csv = DataGridCsvWriter.Write(rows, columns);
+
+        Assert.Equal("Status,Name\r\nActive,Ana\r\n", csv);
+    }
+
+    [Fact]
+    public void WritesNothingButANewlineWhenThereAreNoColumns()
+    {
+        var rows = new[] { new Employee { Name = "Ana" } };
+
+        var csv = DataGridCsvWriter.Write(rows, Array.Empty<IDataGridColumn<Employee>>());
+
+        Assert.Equal("\r\n\r\n", csv);
+    }
+}

--- a/tests/BlazorBlueprint.Tests/DataGrid/NestedGroupingTests.cs
+++ b/tests/BlazorBlueprint.Tests/DataGrid/NestedGroupingTests.cs
@@ -1,0 +1,322 @@
+using BlazorBlueprint.Primitives;
+using BlazorBlueprint.Primitives.DataGrid;
+using Xunit;
+
+namespace BlazorBlueprint.Tests.DataGrid;
+
+/// <summary>
+/// Covers the state behind multi-level grouping: paths that identify a nested group without
+/// colliding, and the level list that decides the nesting order.
+/// </summary>
+public class NestedGroupingTests
+{
+    private static readonly string[] DeptThenStatus = { "dept", "status" };
+
+    private static readonly string[] StatusThenDept = { "status", "dept" };
+
+    private static readonly string[] DeptThenYear = { "dept", "year" };
+
+    private static readonly string[] StatusYearDept = { "status", "year", "dept" };
+
+    private static readonly string[] YearOnly = { "year" };
+
+    // --- GroupPath ------------------------------------------------------------------
+
+    [Fact]
+    public void TwoPathsWithTheSameKeysAreEqual()
+    {
+        var left = new GroupPath("Sales", "Active");
+        var right = new GroupPath("Sales", "Active");
+
+        Assert.Equal(left, right);
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+    }
+
+    [Fact]
+    public void TheSameLeafKeyUnderDifferentParentsIsADifferentPath()
+    {
+        // This is the whole reason paths exist: a flat set of keys would collapse the "Active"
+        // group under every department at once.
+        var underSales = new GroupPath("Sales", "Active");
+        var underSupport = new GroupPath("Support", "Active");
+
+        Assert.NotEqual(underSales, underSupport);
+    }
+
+    [Fact]
+    public void APathTracksItsOwnDepthAndLeafKey()
+    {
+        var path = new GroupPath("Sales", "Active", "2026");
+
+        Assert.Equal(2, path.Depth);
+        Assert.Equal("2026", path.Key);
+        Assert.Equal(new GroupPath("Sales", "Active"), path.Parent());
+    }
+
+    [Fact]
+    public void AppendReturnsAChildPathAndLeavesTheOriginalAlone()
+    {
+        var parent = new GroupPath("Sales");
+        var child = parent.Append("Active");
+
+        Assert.Equal(new GroupPath("Sales", "Active"), child);
+        Assert.Equal(new GroupPath("Sales"), parent);
+    }
+
+    [Fact]
+    public void ANullKeyIsALegitimateSegment()
+    {
+        var withNull = new GroupPath("Sales", null);
+
+        Assert.Equal(new GroupPath("Sales", null), withNull);
+        Assert.NotEqual(new GroupPath("Sales"), withNull);
+    }
+
+    [Fact]
+    public void RootIsAnAncestorOfEveryPath()
+    {
+        Assert.True(GroupPath.Root.IsAncestorOfOrSelf(new GroupPath("Sales", "Active")));
+        Assert.Equal(GroupPath.Root, new GroupPath("Sales").Parent());
+    }
+
+    [Fact]
+    public void AncestryOnlyMatchesAPrefix()
+    {
+        var sales = new GroupPath("Sales");
+
+        Assert.True(sales.IsAncestorOfOrSelf(new GroupPath("Sales", "Active")));
+        Assert.True(sales.IsAncestorOfOrSelf(sales));
+        Assert.False(sales.IsAncestorOfOrSelf(new GroupPath("Support", "Active")));
+        Assert.False(new GroupPath("Sales", "Active").IsAncestorOfOrSelf(sales));
+    }
+
+    // --- Levels ---------------------------------------------------------------------
+
+    [Fact]
+    public void SetGroupsKeepsTheGivenOrder()
+    {
+        var state = new DataGridGroupState();
+
+        state.SetGroups(new[] { Level("dept"), Level("status") });
+
+        Assert.Equal(DeptThenStatus, state.ActiveGroups.Select(g => g.ColumnId));
+        Assert.Equal(2, state.Depth);
+        Assert.Equal("dept", state.ActiveGroup!.ColumnId);
+    }
+
+    [Fact]
+    public void SetGroupsDropsARepeatedColumn()
+    {
+        // Grouping by the same column twice would produce a level where every group holds
+        // exactly one child group.
+        var state = new DataGridGroupState();
+
+        state.SetGroups(new[] { Level("dept"), Level("status"), Level("dept") });
+
+        Assert.Equal(DeptThenStatus, state.ActiveGroups.Select(g => g.ColumnId));
+    }
+
+    [Fact]
+    public void AddGroupNestsInsideTheExistingLevels()
+    {
+        var state = new DataGridGroupState();
+        state.SetGroup(Level("dept"));
+
+        Assert.True(state.AddGroup(Level("status")));
+
+        Assert.Equal(DeptThenStatus, state.ActiveGroups.Select(g => g.ColumnId));
+    }
+
+    [Fact]
+    public void AddGroupIgnoresAColumnThatAlreadyGroups()
+    {
+        var state = new DataGridGroupState();
+        state.SetGroup(Level("dept"));
+
+        Assert.False(state.AddGroup(Level("dept")));
+        Assert.Single(state.ActiveGroups);
+    }
+
+    [Fact]
+    public void RemoveGroupKeepsTheOtherLevelsInOrder()
+    {
+        var state = new DataGridGroupState();
+        state.SetGroups(new[] { Level("dept"), Level("status"), Level("year") });
+
+        Assert.True(state.RemoveGroup("status"));
+
+        Assert.Equal(DeptThenYear, state.ActiveGroups.Select(g => g.ColumnId));
+    }
+
+    [Fact]
+    public void MoveGroupChangesWhichColumnGroupsOutermost()
+    {
+        var state = new DataGridGroupState();
+        state.SetGroups(new[] { Level("dept"), Level("status") });
+
+        Assert.True(state.MoveGroup("status", 0));
+
+        Assert.Equal(StatusThenDept, state.ActiveGroups.Select(g => g.ColumnId));
+    }
+
+    [Fact]
+    public void MoveGroupClampsAnIndexPastTheEnd()
+    {
+        var state = new DataGridGroupState();
+        state.SetGroups(new[] { Level("dept"), Level("status"), Level("year") });
+
+        state.MoveGroup("dept", 99);
+
+        Assert.Equal(StatusYearDept, state.ActiveGroups.Select(g => g.ColumnId));
+    }
+
+    [Fact]
+    public void GetLevelReportsWhereAColumnGroups()
+    {
+        var state = new DataGridGroupState();
+        state.SetGroups(new[] { Level("dept"), Level("status") });
+
+        Assert.Equal(0, state.GetLevel("dept"));
+        Assert.Equal(1, state.GetLevel("status"));
+        Assert.Equal(-1, state.GetLevel("salary"));
+        Assert.True(state.IsGroupedBy("status"));
+        Assert.False(state.IsGroupedBy("salary"));
+    }
+
+    [Fact]
+    public void ChangingTheLevelsClearsCollapsedState()
+    {
+        // Every stored path is one level short of identifying a group once a level is added, so
+        // keeping them would collapse the wrong groups.
+        var state = new DataGridGroupState();
+        state.SetGroup(Level("dept"));
+        state.Toggle(new GroupPath("Sales"));
+        Assert.True(state.IsCollapsed(new GroupPath("Sales")));
+
+        state.AddGroup(Level("status"));
+
+        Assert.Empty(state.CollapsedPaths);
+    }
+
+    // --- Collapse -------------------------------------------------------------------
+
+    [Fact]
+    public void CollapsingOneNestedGroupLeavesItsSiblingUnderAnotherParentAlone()
+    {
+        var state = new DataGridGroupState();
+        state.SetGroups(new[] { Level("dept"), Level("status") });
+
+        state.Toggle(new GroupPath("Sales", "Active"));
+
+        Assert.True(state.IsCollapsed(new GroupPath("Sales", "Active")));
+        Assert.False(state.IsCollapsed(new GroupPath("Support", "Active")));
+    }
+
+    [Fact]
+    public void AGroupInsideACollapsedParentIsHiddenButNotItselfCollapsed()
+    {
+        // Keeping the two apart is what lets a subtree remember its own expansion while the
+        // parent is shut.
+        var state = new DataGridGroupState();
+        state.SetGroups(new[] { Level("dept"), Level("status") });
+
+        state.Toggle(new GroupPath("Sales"));
+
+        Assert.False(state.IsCollapsed(new GroupPath("Sales", "Active")));
+        Assert.True(state.IsHiddenByCollapse(new GroupPath("Sales", "Active")));
+        Assert.False(state.IsHiddenByCollapse(new GroupPath("Support", "Active")));
+    }
+
+    [Fact]
+    public void AnAncestorAtAnyDepthHidesADescendant()
+    {
+        var state = new DataGridGroupState();
+        state.SetGroups(new[] { Level("dept"), Level("status"), Level("year") });
+
+        state.Toggle(new GroupPath("Sales"));
+
+        Assert.True(state.IsHiddenByCollapse(new GroupPath("Sales", "Active", "2026")));
+    }
+
+    [Fact]
+    public void ATopLevelGroupIsNeverHiddenByCollapse()
+    {
+        var state = new DataGridGroupState();
+        state.SetGroup(Level("dept"));
+        state.Toggle(new GroupPath("Sales"));
+
+        Assert.False(state.IsHiddenByCollapse(new GroupPath("Sales")));
+    }
+
+    [Fact]
+    public void ExpandAllClearsEveryLevel()
+    {
+        var state = new DataGridGroupState();
+        state.SetGroups(new[] { Level("dept"), Level("status") });
+        state.CollapseAll(new[] { new GroupPath("Sales"), new GroupPath("Sales", "Active") });
+
+        state.ExpandAll();
+
+        Assert.Empty(state.CollapsedPaths);
+    }
+
+    // --- Single-level compatibility -------------------------------------------------
+
+    [Fact]
+    public void TheKeyBasedApiStillCollapsesATopLevelGroup()
+    {
+        var state = new DataGridGroupState();
+        state.SetGroup(Level("dept"));
+
+        state.Toggle("Sales");
+
+        Assert.True(state.IsCollapsed("Sales"));
+        Assert.True(state.IsCollapsed(new GroupPath("Sales")));
+        Assert.Contains("Sales", state.CollapsedKeys);
+    }
+
+    [Fact]
+    public void SetGroupReplacesEveryLevel()
+    {
+        var state = new DataGridGroupState();
+        state.SetGroups(new[] { Level("dept"), Level("status") });
+
+        state.SetGroup(Level("year"));
+
+        Assert.Equal(YearOnly, state.ActiveGroups.Select(g => g.ColumnId));
+    }
+
+    [Fact]
+    public void VersionAdvancesWheneverTheLevelsChange()
+    {
+        var state = new DataGridGroupState();
+        var start = state.Version;
+
+        state.SetGroup(Level("dept"));
+        var afterSet = state.Version;
+        state.AddGroup(Level("status"));
+        var afterAdd = state.Version;
+        state.RemoveGroup("status");
+
+        Assert.True(afterSet > start);
+        Assert.True(afterAdd > afterSet);
+        Assert.True(state.Version > afterAdd);
+    }
+
+    [Fact]
+    public void TogglingCollapseDoesNotAdvanceTheVersion()
+    {
+        // The version tells the grid its grouping shape changed. A collapse changes what is
+        // rendered, not the shape, and advancing it would force a needless data refresh.
+        var state = new DataGridGroupState();
+        state.SetGroup(Level("dept"));
+        var version = state.Version;
+
+        state.Toggle(new GroupPath("Sales"));
+
+        Assert.Equal(version, state.Version);
+    }
+
+    private static GroupDefinition Level(string columnId) =>
+        new() { ColumnId = columnId, GroupSortDirection = SortDirection.Ascending };
+}

--- a/tests/BlazorBlueprint.Tests/DataGrid/RowEditingTests.cs
+++ b/tests/BlazorBlueprint.Tests/DataGrid/RowEditingTests.cs
@@ -1,0 +1,159 @@
+using BlazorBlueprint.Primitives.DataGrid;
+using Xunit;
+
+namespace BlazorBlueprint.Tests.DataGrid;
+
+/// <summary>
+/// Covers the snapshot behind row editing: row edits bind straight to the item, so cancelling has
+/// to put the original values back on that same instance.
+/// </summary>
+public class RowEditingTests
+{
+    private sealed class Employee
+    {
+        public string Name { get; set; } = "";
+
+        public int Salary { get; set; }
+
+        public DateTime? Reviewed { get; set; }
+
+        public string Initials => Name.Length > 0 ? Name[..1] : "";
+
+        public string WriteOnly { private get; set; } = "";
+
+        public string ReadWriteOnly() => WriteOnly;
+    }
+
+    private sealed class Throwing
+    {
+        private string backing = "";
+
+        public string Safe { get; set; } = "";
+
+        public string Explodes
+        {
+            get => throw new InvalidOperationException(backing);
+            set => throw new InvalidOperationException(value);
+        }
+    }
+
+    [Fact]
+    public void RestorePutsEveryChangedValueBack()
+    {
+        var employee = new Employee { Name = "Ana", Salary = 100, Reviewed = new DateTime(2026, 1, 1) };
+        var snapshot = DataGridRowSnapshot<Employee>.Capture(employee);
+
+        employee.Name = "Bo";
+        employee.Salary = 200;
+        employee.Reviewed = null;
+
+        snapshot.Restore();
+
+        Assert.Equal("Ana", employee.Name);
+        Assert.Equal(100, employee.Salary);
+        Assert.Equal(new DateTime(2026, 1, 1), employee.Reviewed);
+    }
+
+    [Fact]
+    public void RestoreWritesBackToTheSameInstance()
+    {
+        // Anything else holding a reference to the row must see the values revert too, which is
+        // why the snapshot restores in place rather than handing back a copy.
+        var employee = new Employee { Name = "Ana" };
+        var alias = employee;
+        var snapshot = DataGridRowSnapshot<Employee>.Capture(employee);
+
+        employee.Name = "Bo";
+        snapshot.Restore();
+
+        Assert.Same(employee, snapshot.Item);
+        Assert.Equal("Ana", alias.Name);
+    }
+
+    [Fact]
+    public void HasChangesIsFalseUntilSomethingIsEdited()
+    {
+        var employee = new Employee { Name = "Ana", Salary = 100 };
+        var snapshot = DataGridRowSnapshot<Employee>.Capture(employee);
+
+        Assert.False(snapshot.HasChanges());
+
+        employee.Salary = 101;
+
+        Assert.True(snapshot.HasChanges());
+    }
+
+    [Fact]
+    public void HasChangesGoesBackToFalseAfterARestore()
+    {
+        var employee = new Employee { Name = "Ana" };
+        var snapshot = DataGridRowSnapshot<Employee>.Capture(employee);
+
+        employee.Name = "Bo";
+        snapshot.Restore();
+
+        Assert.False(snapshot.HasChanges());
+    }
+
+    [Fact]
+    public void EditingToTheSameValueIsNotAChange()
+    {
+        var employee = new Employee { Name = "Ana" };
+        var snapshot = DataGridRowSnapshot<Employee>.Capture(employee);
+
+        employee.Name = "Bo";
+        employee.Name = "Ana";
+
+        Assert.False(snapshot.HasChanges());
+    }
+
+    [Fact]
+    public void AComputedPropertyIsIgnoredBecauseThereIsNothingToRestore()
+    {
+        var employee = new Employee { Name = "Ana" };
+        var snapshot = DataGridRowSnapshot<Employee>.Capture(employee);
+
+        employee.Name = "Bo";
+
+        // Initials has no setter, so restoring Name is what puts it right.
+        snapshot.Restore();
+
+        Assert.Equal("A", employee.Initials);
+    }
+
+    [Fact]
+    public void APropertyThatThrowsDoesNotAbandonTheRestore()
+    {
+        var item = new Throwing { Safe = "before" };
+        var snapshot = DataGridRowSnapshot<Throwing>.Capture(item);
+
+        item.Safe = "after";
+        snapshot.Restore();
+
+        Assert.Equal("before", item.Safe);
+    }
+
+    [Fact]
+    public void CaptureRejectsANullItem()
+    {
+        Assert.Throws<ArgumentNullException>(() => DataGridRowSnapshot<Employee>.Capture(null!));
+    }
+
+    [Fact]
+    public void TwoSnapshotsOfTheSameItemAreIndependent()
+    {
+        // Starting a second edit after committing the first must not rewind past the commit.
+        var employee = new Employee { Name = "Ana" };
+        var first = DataGridRowSnapshot<Employee>.Capture(employee);
+
+        employee.Name = "Bo";
+        var second = DataGridRowSnapshot<Employee>.Capture(employee);
+        employee.Name = "Cy";
+
+        second.Restore();
+        Assert.Equal("Bo", employee.Name);
+
+        first.Restore();
+        Assert.Equal("Ana", employee.Name);
+    }
+}

--- a/tests/BlazorBlueprint.Tests/DataGrid/SelectionBehaviorTests.cs
+++ b/tests/BlazorBlueprint.Tests/DataGrid/SelectionBehaviorTests.cs
@@ -1,0 +1,301 @@
+using BlazorBlueprint.Primitives;
+using BlazorBlueprint.Primitives.DataGrid;
+using BlazorBlueprint.Primitives.Table;
+using Xunit;
+
+namespace BlazorBlueprint.Tests.DataGrid;
+
+/// <summary>
+/// Covers <see cref="DataGridSelectionBehavior.Replace"/>: the click, Shift+Click and Ctrl+Click
+/// conventions a user brings from a file explorer, and the anchor row that Shift+Click extends
+/// from.
+/// </summary>
+public class SelectionBehaviorTests
+{
+    private sealed class Row
+    {
+        public required string Name { get; init; }
+
+        public override string ToString() => Name;
+    }
+
+    private static readonly int[] OneThenThree = { 1, 3 };
+
+    private static List<Row> CreateRows() => new()
+    {
+        new Row { Name = "a" },
+        new Row { Name = "b" },
+        new Row { Name = "c" },
+        new Row { Name = "d" },
+        new Row { Name = "e" }
+    };
+
+    private static DataGridContext<Row> CreateContext(
+        List<Row> rows,
+        DataGridSelectionBehavior behavior,
+        SelectionMode mode = SelectionMode.Multiple)
+    {
+        var state = new DataGridState<Row>();
+        state.Selection.Mode = mode;
+
+        return new DataGridContext<Row>(state)
+        {
+            ProcessedData = rows,
+            SelectionMode = mode,
+            SelectionBehavior = behavior
+        };
+    }
+
+    private static string SelectedNames(DataGridContext<Row> context) =>
+        string.Concat(context.State.Selection.SelectedItems
+            .Select(r => r.Name)
+            .OrderBy(n => n, StringComparer.Ordinal));
+
+    // --- Toggle keeps today's behaviour --------------------------------------------
+
+    [Fact]
+    public void ToggleBehaviourFlipsOneRowAndLeavesTheRestAlone()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Toggle);
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+        context.ApplyRowSelectionInput(rows[2], RowSelectionModifiers.None);
+
+        Assert.Equal("ac", SelectedNames(context));
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+
+        Assert.Equal("c", SelectedNames(context));
+    }
+
+    [Fact]
+    public void ToggleBehaviourIgnoresModifierKeys()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Toggle);
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+        context.ApplyRowSelectionInput(rows[3], new RowSelectionModifiers(Extend: true, Additive: false));
+
+        // A range would have selected a, b, c and d. Toggle just adds d.
+        Assert.Equal("ad", SelectedNames(context));
+    }
+
+    // --- Replace: plain click ------------------------------------------------------
+
+    [Fact]
+    public void PlainClickReplacesTheWholeSelection()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+        context.ApplyRowSelectionInput(rows[3], new RowSelectionModifiers(Extend: true, Additive: false));
+        Assert.Equal("abcd", SelectedNames(context));
+
+        context.ApplyRowSelectionInput(rows[2], RowSelectionModifiers.None);
+
+        Assert.Equal("c", SelectedNames(context));
+    }
+
+    [Fact]
+    public void PlainClickOnTheOnlySelectedRowClearsTheSelection()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+
+        context.ApplyRowSelectionInput(rows[1], RowSelectionModifiers.None);
+        Assert.Equal("b", SelectedNames(context));
+
+        context.ApplyRowSelectionInput(rows[1], RowSelectionModifiers.None);
+
+        Assert.Equal("", SelectedNames(context));
+    }
+
+    [Fact]
+    public void PlainClickOnASelectedRowInAWiderSelectionCollapsesToThatRow()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+        context.ApplyRowSelectionInput(rows[2], new RowSelectionModifiers(Extend: true, Additive: false));
+        Assert.Equal("abc", SelectedNames(context));
+
+        // b is already selected, but it is not the only selection, so this collapses rather
+        // than clears.
+        context.ApplyRowSelectionInput(rows[1], RowSelectionModifiers.None);
+
+        Assert.Equal("b", SelectedNames(context));
+    }
+
+    // --- Replace: Shift+Click ------------------------------------------------------
+
+    [Fact]
+    public void ShiftClickSelectsTheRangeFromTheAnchor()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+
+        context.ApplyRowSelectionInput(rows[1], RowSelectionModifiers.None);
+        context.ApplyRowSelectionInput(rows[3], new RowSelectionModifiers(Extend: true, Additive: false));
+
+        Assert.Equal("bcd", SelectedNames(context));
+    }
+
+    [Fact]
+    public void ShiftClickSelectsTheRangeWhenClickingUpwards()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+
+        context.ApplyRowSelectionInput(rows[3], RowSelectionModifiers.None);
+        context.ApplyRowSelectionInput(rows[1], new RowSelectionModifiers(Extend: true, Additive: false));
+
+        Assert.Equal("bcd", SelectedNames(context));
+    }
+
+    [Fact]
+    public void RepeatedShiftClicksReExtendFromTheSameAnchor()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+        context.ApplyRowSelectionInput(rows[3], new RowSelectionModifiers(Extend: true, Additive: false));
+        Assert.Equal("abcd", SelectedNames(context));
+
+        // The anchor stays at a, so shrinking the range works rather than walking it along.
+        context.ApplyRowSelectionInput(rows[1], new RowSelectionModifiers(Extend: true, Additive: false));
+
+        Assert.Equal("ab", SelectedNames(context));
+    }
+
+    [Fact]
+    public void ShiftClickWithNoAnchorSelectsOnlyTheClickedRow()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+
+        context.ApplyRowSelectionInput(rows[2], new RowSelectionModifiers(Extend: true, Additive: false));
+
+        Assert.Equal("c", SelectedNames(context));
+    }
+
+    [Fact]
+    public void ShiftClickAfterAStaleAnchorSelectsOnlyTheClickedRow()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+
+        // The page changed under the selection: the anchor is no longer among the visible rows.
+        context.ProcessedData = rows.Skip(2).ToList();
+
+        context.ApplyRowSelectionInput(rows[3], new RowSelectionModifiers(Extend: true, Additive: false));
+
+        Assert.Equal("d", SelectedNames(context));
+    }
+
+    // --- Replace: Ctrl+Click -------------------------------------------------------
+
+    [Fact]
+    public void CtrlClickAddsARowWithoutDisturbingTheRest()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+        context.ApplyRowSelectionInput(rows[3], new RowSelectionModifiers(Extend: false, Additive: true));
+
+        Assert.Equal("ad", SelectedNames(context));
+    }
+
+    [Fact]
+    public void CtrlClickRemovesAnAlreadySelectedRow()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+        context.ApplyRowSelectionInput(rows[2], new RowSelectionModifiers(Extend: true, Additive: false));
+        Assert.Equal("abc", SelectedNames(context));
+
+        context.ApplyRowSelectionInput(rows[1], new RowSelectionModifiers(Extend: false, Additive: true));
+
+        Assert.Equal("ac", SelectedNames(context));
+    }
+
+    [Fact]
+    public void CtrlClickMovesTheAnchorSoAFollowingShiftClickExtendsFromIt()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+        context.ApplyRowSelectionInput(rows[2], new RowSelectionModifiers(Extend: false, Additive: true));
+        Assert.Equal("ac", SelectedNames(context));
+
+        // The anchor is c, not a. Extending to e must give c, d, e — not a through e.
+        context.ApplyRowSelectionInput(rows[4], new RowSelectionModifiers(Extend: true, Additive: false));
+
+        Assert.Equal("cde", SelectedNames(context));
+    }
+
+    // --- Modes ---------------------------------------------------------------------
+
+    [Fact]
+    public void SingleModeTreatsEveryClickAsAPlainClick()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace, SelectionMode.Single);
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+        context.ApplyRowSelectionInput(rows[3], new RowSelectionModifiers(Extend: true, Additive: true));
+
+        Assert.Equal("d", SelectedNames(context));
+    }
+
+    [Fact]
+    public void NoneModeSelectsNothing()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace, SelectionMode.None);
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+
+        Assert.Equal("", SelectedNames(context));
+    }
+
+    // --- Checkboxes stay toggle ----------------------------------------------------
+
+    [Fact]
+    public void ToggleRowSelectionStaysToggleUnderReplaceSoCheckboxesKeepWorking()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+
+        context.ToggleRowSelection(rows[0]);
+        context.ToggleRowSelection(rows[2]);
+
+        Assert.Equal("ac", SelectedNames(context));
+    }
+
+    // --- Callbacks -----------------------------------------------------------------
+
+    [Fact]
+    public void SelectionChangeIsReportedOncePerClick()
+    {
+        var rows = CreateRows();
+        var context = CreateContext(rows, DataGridSelectionBehavior.Replace);
+        var reported = new List<int>();
+        context.OnSelectionChange = items => reported.Add(items.Count);
+
+        context.ApplyRowSelectionInput(rows[0], RowSelectionModifiers.None);
+        context.ApplyRowSelectionInput(rows[2], new RowSelectionModifiers(Extend: true, Additive: false));
+
+        Assert.Equal(OneThenThree, reported);
+    }
+}

--- a/tests/BlazorBlueprint.Tests/DataGrid/SortAndFilterByTests.cs
+++ b/tests/BlazorBlueprint.Tests/DataGrid/SortAndFilterByTests.cs
@@ -1,0 +1,362 @@
+using System.Linq.Expressions;
+using BlazorBlueprint.Primitives.DataGrid;
+using BlazorBlueprint.Primitives.Filtering;
+using BlazorBlueprint.Primitives;
+using Xunit;
+
+namespace BlazorBlueprint.Tests.DataGrid;
+
+/// <summary>
+/// Covers a column that sorts and filters on a value it does not store — the case behind
+/// <c>SortAndFilterBy</c>, where a cell template resolves a key to a label and the grid must
+/// order and filter by the label the user reads rather than by the key.
+/// </summary>
+public class SortAndFilterByTests
+{
+    private sealed class Ticket
+    {
+        public int StatusId { get; init; }
+
+        public string Title { get; init; } = "";
+
+        public DateTime Raised { get; init; }
+    }
+
+    private static readonly int[] ActiveCancelledPendingOrder = { 2, 3, 1 };
+
+    private static readonly int[] PendingCancelledActiveOrder = { 1, 3, 2 };
+
+    private static readonly int[] CancelledOnly = { 3 };
+
+    private static readonly int[] ActiveOnly = { 2 };
+
+    private static readonly int[] CancelledThenActive = { 3, 2 };
+
+    private static readonly string[] TitlesAscending = { "Laptop slow", "Printer jammed", "VPN drops" };
+
+    private static readonly Dictionary<int, string> StatusNames = new()
+    {
+        [1] = "Pending",
+        [2] = "Active",
+        [3] = "Cancelled"
+    };
+
+    /// <summary>
+    /// A column whose sort and filter value is a projection rather than its own property.
+    /// Mirrors what <c>BbDataGridPropertyColumn.SortAndFilterBy</c> produces.
+    /// </summary>
+    private sealed class ProjectedColumn : IDataGridColumn<Ticket>
+    {
+        private readonly Expression<Func<Ticket, object?>>? selector;
+        private readonly Func<Ticket, object?>? compiled;
+
+        public ProjectedColumn(string columnId, Expression<Func<Ticket, object?>>? selector = null)
+        {
+            ColumnId = columnId;
+            this.selector = selector;
+            compiled = selector?.Compile();
+        }
+
+        public string ColumnId { get; }
+
+        public string? Title => ColumnId;
+
+        public bool Sortable => true;
+
+        public bool Filterable => true;
+
+        public bool Visible => true;
+
+        public string? Width => null;
+
+        public bool Hideable => true;
+
+        public bool Resizable => true;
+
+        public bool Reorderable => true;
+
+        public ColumnPinning Pinned => ColumnPinning.None;
+
+        public Microsoft.AspNetCore.Components.RenderFragment<DataGridCellContext<Ticket>>? CellTemplate => null;
+
+        public Microsoft.AspNetCore.Components.RenderFragment<DataGridHeaderContext<Ticket>>? HeaderTemplate => null;
+
+        public string? CellClass => null;
+
+        public string? HeaderClass => null;
+
+        public bool NoWrap => false;
+
+        public AggregateFunction Aggregate => AggregateFunction.None;
+
+        public object? GetValue(Ticket item) => item.StatusId;
+
+        public object? GetRawValue(Ticket item) => item.StatusId;
+
+        public object? GetSortAndFilterValue(Ticket item) =>
+            compiled != null ? compiled(item) : GetRawValue(item);
+
+        public LambdaExpression? GetSortAndFilterExpression() => selector;
+
+        public int Compare(Ticket x, Ticket y)
+        {
+            if (selector == null)
+            {
+                return x.StatusId.CompareTo(y.StatusId);
+            }
+
+            return Comparer<string>.Default.Compare(
+                GetSortAndFilterValue(x)?.ToString(),
+                GetSortAndFilterValue(y)?.ToString());
+        }
+
+        public LambdaExpression? GetSortExpression() => selector;
+
+        public LambdaExpression? GetFilterExpression() => selector;
+    }
+
+    private static List<Ticket> CreateTickets() => new()
+    {
+        new Ticket { StatusId = 1, Title = "Printer jammed", Raised = new DateTime(2026, 1, 5, 9, 30, 0) },
+        new Ticket { StatusId = 3, Title = "Laptop slow", Raised = new DateTime(2026, 1, 6, 14, 0, 0) },
+        new Ticket { StatusId = 2, Title = "VPN drops", Raised = new DateTime(2026, 1, 7, 8, 15, 0) }
+    };
+
+    // --- Defaults ------------------------------------------------------------------
+
+    [Fact]
+    public void GetSortAndFilterValueFallsBackToRawValueWhenNoSelectorIsSet()
+    {
+        var column = new ProjectedColumn("status");
+        var ticket = new Ticket { StatusId = 3 };
+
+        Assert.Equal(3, column.GetSortAndFilterValue(ticket));
+        Assert.Null(column.GetSortAndFilterExpression());
+    }
+
+    // --- Sorting -------------------------------------------------------------------
+
+    [Fact]
+    public void InMemorySortOrdersByTheProjectedLabelNotTheKey()
+    {
+        var column = new ProjectedColumn("status", x => StatusNames[x.StatusId]);
+        var sortDefinitions = new List<SortDefinition>
+        {
+            new() { ColumnId = "status", Direction = SortDirection.Ascending }
+        };
+
+        var sorted = CreateTickets()
+            .ApplyMultiSort(sortDefinitions, new IDataGridColumn<Ticket>[] { column })
+            .ToList();
+
+        // Label order is Active, Cancelled, Pending — key order would be 1, 2, 3.
+        Assert.Equal(ActiveCancelledPendingOrder, sorted.Select(t => t.StatusId));
+    }
+
+    [Fact]
+    public void InMemorySortHonoursDescendingDirection()
+    {
+        var column = new ProjectedColumn("status", x => StatusNames[x.StatusId]);
+        var sortDefinitions = new List<SortDefinition>
+        {
+            new() { ColumnId = "status", Direction = SortDirection.Descending }
+        };
+
+        var sorted = CreateTickets()
+            .ApplyMultiSort(sortDefinitions, new IDataGridColumn<Ticket>[] { column })
+            .ToList();
+
+        Assert.Equal(PendingCancelledActiveOrder, sorted.Select(t => t.StatusId));
+    }
+
+    [Fact]
+    public void QueryableSortOrdersByTheProjectedLabelNotTheKey()
+    {
+        // The selector returns a string, so no boxing conversion is involved. This proves the
+        // queryable path reads the selector at all.
+        var column = new ProjectedColumn("title", x => x.Title);
+        var sortDefinitions = new List<SortDefinition>
+        {
+            new() { ColumnId = "title", Direction = SortDirection.Ascending }
+        };
+
+        var sorted = CreateTickets().AsQueryable()
+            .ApplyMultiSort(sortDefinitions, new IDataGridColumn<Ticket>[] { column })
+            .ToList();
+
+        Assert.Equal(TitlesAscending, sorted.Select(t => t.Title));
+    }
+
+    [Fact]
+    public void QueryableSortStripsTheBoxingConversionSoValueTypesStillOrder()
+    {
+        // Declaring the selector as Func<Ticket, object?> boxes the int through a Convert node.
+        // Ordering by object would compare boxed references; the grid must strip that node.
+        var column = new ProjectedColumn("raised", x => x.Raised);
+        var sortDefinitions = new List<SortDefinition>
+        {
+            new() { ColumnId = "raised", Direction = SortDirection.Descending }
+        };
+
+        var sorted = CreateTickets().AsQueryable()
+            .ApplyMultiSort(sortDefinitions, new IDataGridColumn<Ticket>[] { column })
+            .ToList();
+
+        Assert.Equal(ActiveCancelledPendingOrder, sorted.Select(t => t.StatusId));
+    }
+
+    // --- Filtering, in memory ------------------------------------------------------
+
+    [Fact]
+    public void MatchesValueComparesAgainstTheProjectedValue()
+    {
+        var column = new ProjectedColumn("status", x => StatusNames[x.StatusId]);
+        var condition = new FilterCondition
+        {
+            Field = "status",
+            Operator = FilterOperator.Equals,
+            Value = "Cancelled"
+        };
+
+        var matched = CreateTickets()
+            .Where(t => condition.MatchesValue(column.GetSortAndFilterValue(t)))
+            .ToList();
+
+        Assert.Equal(CancelledOnly, matched.Select(t => t.StatusId));
+    }
+
+    [Fact]
+    public void MatchesValueSupportsContains()
+    {
+        var column = new ProjectedColumn("status", x => StatusNames[x.StatusId]);
+        var condition = new FilterCondition
+        {
+            Field = "status",
+            Operator = FilterOperator.Contains,
+            Value = "cel"
+        };
+
+        var matched = CreateTickets()
+            .Where(t => condition.MatchesValue(column.GetSortAndFilterValue(t)))
+            .ToList();
+
+        Assert.Equal(CancelledOnly, matched.Select(t => t.StatusId));
+    }
+
+    [Fact]
+    public void MatchesValueTreatsAnIncompleteConditionAsMatchingEverything()
+    {
+        var condition = new FilterCondition
+        {
+            Field = "status",
+            Operator = FilterOperator.Equals,
+            Value = null
+        };
+
+        Assert.True(condition.MatchesValue("Pending"));
+    }
+
+    [Fact]
+    public void MatchesValueUsesWholeDaySemanticsForDateFields()
+    {
+        var condition = new FilterCondition
+        {
+            Field = "raised",
+            Operator = FilterOperator.Equals,
+            Value = new DateTime(2026, 1, 6, 0, 0, 0)
+        };
+
+        // 14:00 on the 6th must match a filter for "the 6th", despite the time component.
+        Assert.True(condition.MatchesValue(new DateTime(2026, 1, 6, 14, 0, 0), FilterFieldType.Date));
+        Assert.False(condition.MatchesValue(new DateTime(2026, 1, 7, 0, 0, 0), FilterFieldType.Date));
+    }
+
+    // --- Filtering, queryable ------------------------------------------------------
+
+    [Fact]
+    public void ToExpressionForSelectorFiltersOnTheProjectedValue()
+    {
+        Expression<Func<Ticket, object?>> selector = x => x.Title;
+        var condition = new FilterCondition
+        {
+            Field = "ignored",
+            Operator = FilterOperator.StartsWith,
+            Value = "VPN"
+        };
+
+        var matched = CreateTickets().AsQueryable()
+            .Where(condition.ToExpressionForSelector<Ticket>(selector))
+            .ToList();
+
+        Assert.Equal(ActiveOnly, matched.Select(t => t.StatusId));
+    }
+
+    [Fact]
+    public void ToExpressionForSelectorStripsTheBoxingConversionForValueTypes()
+    {
+        Expression<Func<Ticket, object?>> selector = x => x.StatusId;
+        var condition = new FilterCondition
+        {
+            Field = "ignored",
+            Operator = FilterOperator.GreaterThan,
+            Value = 1
+        };
+
+        var matched = CreateTickets().AsQueryable()
+            .Where(condition.ToExpressionForSelector<Ticket>(selector))
+            .ToList();
+
+        Assert.Equal(CancelledThenActive, matched.Select(t => t.StatusId));
+    }
+
+    [Fact]
+    public void ToExpressionForSelectorIgnoresTheConditionFieldName()
+    {
+        // The field name identifies the column, not a property. A selector-backed column has no
+        // property of that name, and the filter must still apply.
+        Expression<Func<Ticket, object?>> selector = x => x.Title;
+        var condition = new FilterCondition
+        {
+            Field = "no-such-property",
+            Operator = FilterOperator.Contains,
+            Value = "slow"
+        };
+
+        var matched = CreateTickets().AsQueryable()
+            .Where(condition.ToExpressionForSelector<Ticket>(selector))
+            .ToList();
+
+        Assert.Single(matched);
+    }
+
+    [Fact]
+    public void ToExpressionForSelectorRejectsALambdaWithTheWrongParameterCount()
+    {
+        Expression<Func<Ticket, int, object?>> twoParameters = (x, i) => x.StatusId + i;
+        var condition = new FilterCondition { Field = "status", Operator = FilterOperator.Equals, Value = 1 };
+
+        Assert.Throws<ArgumentException>(() => condition.ToExpressionForSelector<Ticket>(twoParameters));
+    }
+
+    [Fact]
+    public void ToExpressionForSelectorAndMatchesValueAgreeOnTheSameData()
+    {
+        Expression<Func<Ticket, object?>> selector = x => StatusNames[x.StatusId];
+        var compiled = selector.Compile();
+        var condition = new FilterCondition
+        {
+            Field = "status",
+            Operator = FilterOperator.NotEquals,
+            Value = "Active"
+        };
+
+        var tickets = CreateTickets();
+        var viaValue = tickets.Where(t => condition.MatchesValue(compiled(t))).Select(t => t.StatusId).ToList();
+        var viaExpression = tickets.AsQueryable()
+            .Where(condition.ToExpressionForSelector<Ticket>(selector))
+            .Select(t => t.StatusId)
+            .ToList();
+
+        Assert.Equal(viaValue, viaExpression);
+    }
+}


### PR DESCRIPTION
Implements the five-issue DataGrid sweep from `docs/plans/2026-08-27-datagrid-enhancements.md`, in the order the plan sets out. `#463` goes first because `#412` and `#498` both consume the selector it introduces — building grouping first would mean building that selector twice, the second time inside a recursive pass.

| Issue | What lands |
|---|---|
| [#463](https://github.com/blazorblueprintui/ui/issues/463) | `SortAndFilterBy` — sort and filter on the value a column displays |
| [#456](https://github.com/blazorblueprintui/ui/issues/456) | `SelectionBehavior.Replace` — file-explorer selection conventions |
| [#498](https://github.com/blazorblueprintui/ui/issues/498) | `ShowExport` — CSV export of the visible, sorted, filtered rows |
| [#412](https://github.com/blazorblueprintui/ui/issues/412) | Nested multi-level grouping |
| [#497](https://github.com/blazorblueprintui/ui/issues/497) | `EditMode.Row` — inline row editing |

`develop` PRs do not auto-close issues, so these need closing by hand after merge.

---

## `#463` — sort and filter on a value the column does not display

A column with a `CellTemplate` that resolves a key to a label still sorted and filtered on the raw property. The user saw `Active / Cancelled / Pending`, clicked the header, and the rows reordered by `StatusId`.

```razor
<BbDataGridPropertyColumn Property="x => x.StatusId" Title="Status" Sortable Filterable
                          SortAndFilterBy="x => statuses[x.StatusId].StatusName" />
```

One parameter, not separate `SortBy`/`FilterBy` — two selectors can disagree, and a grid that orders by one value while filtering on another is hard to explain and harder to debug. Sorting, per-column filtering, global search, grouping and CSV export all read it.

**Server-side.** It is an `Expression`, not a `Func`, so an `ItemsProvider` over `IQueryable` can translate it. The plan left this open; the expression form is what landed. The boxing `Convert` node a `Func<T, object>` wraps a value type in is stripped before `OrderBy`, or EF cannot emit `ORDER BY` and in-memory sorting would compare boxed references.

**The filtering route.** The existing filter path resolves a property by name through reflection, which a projection has no equivalent for. `FilterCondition` gains `MatchesValue` (in memory) and `ToExpressionForSelector` (`IQueryable`), and the condition-building helpers now take any `Expression` rather than only a `MemberExpression`.

## `#456` — enterprise row selection

`DataGridSelectionBehavior.Replace` gives the conventions a user brings from a file explorer:

| Input | Result |
|---|---|
| Click | select only this row; clear the selection if it was already the only one |
| Shift+Click | select the range from the anchor row |
| Ctrl / Cmd+Click | add or remove this row, leave the rest |

`Toggle` stays the default, so nothing changes for an existing grid.

The range extends from an explicit **anchor**, not from the last selected row. Those differ after a Ctrl+Click, and using the wrong one is what makes range selection feel wrong rather than plainly broken. Repeated Shift+Clicks re-extend from the same anchor, so a range can be grown and shrunk rather than walking along.

Select-column checkboxes and the Space/Enter keys keep toggle semantics under either behaviour — a checkbox that cleared the rest of the selection would be unusable.

## `#498` — export visible rows to CSV

`ShowExport` renders an Export button; `ExportToCsvAsync()` and `BuildCsv()` cover the programmatic cases. Exports the rows that survive the current search, filters and sort **across every page**, in the visible columns, in their current order, using each column's display value. Select, expand and edit columns are dropped.

**CSV injection.** A cell starting `=`, `+`, `-`, `@`, tab or CR is prefixed with an apostrophe, because a spreadsheet executes it as a formula otherwise. A value that parses as a number is left alone, so a negative amount still exports as a number rather than as text. There is a test per trigger character, because this is the kind of thing that reads as cosmetic to whoever refactors it next.

**Server-side data.** The issue asked for this to be decided rather than defaulted. A grid backed by an `ItemsProvider` only holds the page it fetched, so it exports that page and logs a warning naming `ExportScope`. Fetching everything behind the user's back is worse than saying so.

## `#412` — nested multi-level grouping

Grouping nests to any depth. `DataGridGroupState` holds an ordered list of levels rather than one definition, with the single-level members kept as shims.

**Collapsed state is keyed by `GroupPath`.** A raw key is ambiguous once grouping nests: a group keyed `Active` exists under every department, and a flat key set would collapse all of them together. Ancestor-collapse is computed by walking up at render rather than materialising descendants — the number of ancestors is the nesting depth, the number of descendants is unbounded.

**Aggregates roll up**, because each group carries every row beneath it rather than only its own level.

**Pagination was the hard part.** It counts data rows, not headers. When a page boundary lands inside a subtree, every open ancestor header is re-emitted at the top of the next page, so a row is never shown without the headers that say what it belongs to. Verified in the running app across a three-page grouping.

**Surface.** Past two levels a per-column menu is unusable, so a breadcrumb above the grid lists the levels in order with a control on each to drop it or move it outward (`ShowGroupingBreadcrumb`, default on). The column menu offers "Then group by" once something is already grouped.

**Server contract stays flat** — one row per innermost group carrying its full `KeyPath` — which is what `GROUP BY a, b` already returns, rather than inventing a recursive wire shape. `DataGridRequest` carries every level. Snapshots write both the new list and the old single field, so state round-trips in either direction against an older build.

## `#497` — inline row editing

`EditMode.Row` puts a whole row into edit: columns with an `EditTemplate` become inputs, and the changes commit or discard together. `BbDataGridEditColumn` renders Edit, Save and Cancel.

```razor
<BbDataGrid EditMode="DataGridEditMode.Row" OnRowCommit="Save">
    <BbDataGridPropertyColumn Property="x => x.Name">
        <EditTemplate><BbInput @bind-Value="context.Name" /></EditTemplate>
    </BbDataGridPropertyColumn>
    <BbDataGridEditColumn TData="Person" />
```

The template binds straight to the item, so an ordinary `@bind-Value` works. `DataGridRowSnapshot` records the row's values when editing starts and restores them **in place** on cancel, so anything else holding that row sees the values revert too.

Validation runs through the row's own `EditContext`, cascaded rather than wrapped in an `EditForm` — a `<form>` is not valid inside a table row, and the validator only needs the context. `OnRowCommit` can refuse the save and keep the row open with the user's typing intact.

Scoped to `Row` mode, as the plan allowed. `Cell` mode is where most of the complexity is and is not exposed.

### Two defects found while wiring the keyboard up

Both are fixed here rather than left behind:

- **The row's keydown interceptor blocked every Blazor handler in the row.** `table-row-nav.js` called `stopPropagation` for any keydown from an interactive child, which is enough to stop Blazor's document-level event delegation seeing it at all — not just the row's own handler. Enter and Escape never reached the editor. It now lets those two keys through for a row being edited, and the row's own handler gives them to the editor instead of to its selection shortcuts.
- **Committing on Enter dropped the field the user was in.** The row's keydown handler ran before the browser fired the focused input's `change` event, which is what `BbInput` writes its value back on by default. The row now blurs the field first, so Enter hands over what was just typed.

---

## Not included, and why

- **Row editing in hierarchy mode.** The hierarchy row renders through its own fragment. Documented as unsupported rather than half-wired.
- **`Virtualize` + `ItemsProvider` grouping.** Unchanged from `#411`, which suppresses the action and warns. Grouping there needs every row, which is the thing virtualization exists to avoid.
- **Pagination is not reset when the grouping levels change.** Matches the existing single-level behaviour; changing it is a separate call.

## Testing

75 new tests across four files — the sort/filter selector, selection behaviour, CSV writing and injection, nested group paths and levels, and the edit snapshot. Full solution builds clean; all tests pass. API surface snapshots reviewed and accepted.

Every one of the five was also driven in the running demo app rather than only unit-tested: sorting by the displayed label against the same column sorting by its key, Shift and Ctrl selection including the anchor moving, an actual CSV download checked for its BOM and its filtered contents, a three-page nested grouping checked for re-emitted ancestor headers and for per-path collapse, and the edit flow through Enter, Escape and a refused commit.

Demo sections, code snippets and API Reference entries added for all five.
