### PR TITLE
docs: API reference for AdditionalAttributes, and add it to BbDock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-08-29
+
+### Added
+
+- **Every component accepts arbitrary HTML attributes** — [#486](https://github.com/blazorblueprintui/ui/issues/486), contributed by [@HugoVG](https://github.com/HugoVG) in [#490](https://github.com/blazorblueprintui/ui/pull/490). Passing an attribute a component did not declare used to throw at runtime — *"does not have a property matching the name 'data-testid'"* — which meant a test hook, an `aria-*` correction or a newer HTML attribute was simply unavailable unless the library had thought of it first. 216 components gained `AdditionalAttributes`; 291 already had it. Coverage is now essentially complete, and anything valid in HTML reaches the rendered element.
+
+  The issue asked specifically for `data-testid`, and it would have been easy to add that one parameter. Capturing unmatched attributes instead costs the same and answers every future variation of the same request, which is why it is worth 299 files rather than one.
+
+  Consumer `Class` values are unaffected — they still merge through `ClassNames.cn` as before. A `class` supplied through the attribute splat is a different route and **replaces** the component's own classes rather than merging with them; prefer `Class` unless you specifically want to take the styling over.
+
+  **Not a breaking change**, despite the size. The API surface diff is 231 lines added and none removed or changed: nothing is renamed, retyped or dropped, and a component that previously threw on an unknown attribute now accepts it, which is strictly more permissive. It ships in a minor rather than waiting for a major.
+
+  Two related requests are **not** closed by this. [#480](https://github.com/blazorblueprintui/ui/issues/480) (chart click events) needs real event plumbing, not attribute passthrough, and [#485](https://github.com/blazorblueprintui/ui/issues/485) (`OnPaste` on `BbFileUpload`) is now buildable by a consumer but is not shipped. API Reference entries for the new parameters are still outstanding and are tracked as a separate documentation sweep.
+
+---
+
 ## 2026-08-27
 
 ### Added

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/AccordionDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/AccordionDemo.razor
@@ -299,6 +299,9 @@
                 <ApiParameter Name="Collapsible" Type="bool" Default="false">
                     Whether all items can be collapsed in Single mode. When false, one item always remains open.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbAccordionItem">
@@ -307,6 +310,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Disabled" Type="bool" Default="false">
                     Whether this item is disabled.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -319,11 +325,17 @@
                     component or ad-hoc SVG. The <code>bool</code> context is the open state.
                     When not set, the default rotating chevron is used.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbAccordionContent">
                 <ApiParameter Name="ForceMount" Type="bool" Default="true">
                     Whether to keep content in the DOM when collapsed. Enables CSS animations.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/AlertDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/AlertDemo.razor
@@ -384,6 +384,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Content of the alert. Should contain AlertTitle and AlertDescription.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/AlertDialogDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/AlertDialogDemo.razor
@@ -161,11 +161,17 @@
                 <ApiParameter Name="OnOpenChange" Type="EventCallback&lt;bool&gt;">
                     Callback when the open state changes.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="AlertDialogContent">
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for custom sizing or styling.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/AspectRatioDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/AspectRatioDemo.razor
@@ -151,6 +151,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes to apply to the container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/AttachmentDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/AttachmentDemo.razor
@@ -292,11 +292,17 @@
             <ApiParameter Name="Orientation" Type="AttachmentOrientation" Default="Horizontal">
                 Layout direction. Options: Horizontal, Vertical.
             </ApiParameter>
+            <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+            </ApiParameter>
         </ApiReference>
 
         <ApiReference ComponentName="AttachmentMedia">
             <ApiParameter Name="Variant" Type="AttachmentMediaVariant" Default="Icon">
                 Media rendering mode. Options: Icon, Image.
+            </ApiParameter>
+            <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
             </ApiParameter>
         </ApiReference>
 
@@ -306,6 +312,9 @@
             </ApiParameter>
             <ApiParameter Name="Size" Type="ButtonSize" Default="IconSmall">
                 Button size for the action control.
+            </ApiParameter>
+            <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
             </ApiParameter>
         </ApiReference>
 
@@ -318,6 +327,9 @@
             </ApiParameter>
             <ApiParameter Name="Class" Type="string?">
                 Additional CSS classes for the trigger overlay.
+            </ApiParameter>
+            <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                Additional HTML attributes applied to the root <code>&lt;a&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
             </ApiParameter>
         </ApiReference>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/AvatarDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/AvatarDemo.razor
@@ -336,6 +336,9 @@
                 <ApiParameter Name="Class" Type="string?">
                     Additional CSS classes for the avatar container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;span&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="AvatarImage">
@@ -348,11 +351,17 @@
                 <ApiParameter Name="Class" Type="string?">
                     Additional CSS classes for the image element.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;img&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="AvatarFallback">
                 <ApiParameter Name="Class" Type="string?">
                     Additional CSS classes for the fallback container. Useful for custom background colors.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;span&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/BadgeDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/BadgeDemo.razor
@@ -296,6 +296,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to display inside the badge (text, icons, numbers, etc.).
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/BubbleDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/BubbleDemo.razor
@@ -170,6 +170,9 @@
             <ApiParameter Name="Align" Type="BubbleAlign" Default="Start">
                 Bubble alignment. Options: Start, End.
             </ApiParameter>
+            <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+            </ApiParameter>
         </ApiReference>
 
         <ApiReference ComponentName="BubbleContent">
@@ -180,6 +183,9 @@
             <ApiParameter Name="Href" Type="string?">
                 Link target when rendering as an anchor.
             </ApiParameter>
+            <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                Additional HTML attributes applied to the root <code>&lt;a&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+            </ApiParameter>
         </ApiReference>
 
         <ApiReference ComponentName="BubbleReactions">
@@ -188,6 +194,9 @@
             </ApiParameter>
             <ApiParameter Name="Align" Type="BubbleReactionsAlign" Default="End">
                 Horizontal alignment along the bubble edge. Options: Start, End.
+            </ApiParameter>
+            <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
             </ApiParameter>
         </ApiReference>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CalendarDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CalendarDemo.razor
@@ -264,6 +264,9 @@
                 <ApiParameter Name="OnSelect" Type="EventCallback&lt;DateTime&gt;">
                     Callback when a date is selected.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CarouselDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CarouselDemo.razor
@@ -178,6 +178,9 @@
                 <ApiParameter Name="Loop" Type="bool" Default="false">
                     Enable infinite loop.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CheckboxGroupDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CheckboxGroupDemo.razor
@@ -101,6 +101,9 @@
                 <ApiParameter Name="Disabled" Type="bool" Default="false">
                     Disables all items in the group.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="CheckboxGroupItem">
@@ -112,6 +115,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Disabled" Type="bool" Default="false">
                     Disables this individual item.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ColorPickerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ColorPickerDemo.razor
@@ -244,6 +244,9 @@
                 <ApiParameter Name="Required" Type="bool" Default="false">
                     Whether the color picker is required.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ComboboxDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ComboboxDemo.razor
@@ -669,6 +669,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Content for compositional mode. Use ComboboxItem components as children.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="ComboboxItem&lt;TValue&gt;">
@@ -684,6 +687,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Custom content to render. When null, renders Text as plain text.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="ComboboxGroup">
@@ -695,6 +701,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Content for the group. Typically contains ComboboxItem components.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CommandDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CommandDemo.razor
@@ -641,6 +641,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the command container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="CommandDialog">
@@ -658,6 +661,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the dialog.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -680,11 +686,17 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the input.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="CommandList">
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the list container. Use to control max height (e.g., <code>max-h-[300px]</code>).
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -694,6 +706,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the group.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -716,17 +731,26 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the item.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="CommandSeparator">
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the separator.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="CommandShortcut">
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the shortcut text.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;span&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ContextMenuDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ContextMenuDemo.razor
@@ -171,6 +171,9 @@
                 <ApiParameter Name="Inset" Type="bool">
                     Adds left padding.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CurrencyInputDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/CurrencyInputDemo.razor
@@ -345,6 +345,9 @@
                 <ApiParameter Name="Disabled" Type="bool" Default="false">
                     Disables the input.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <div class="border rounded-lg p-6">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DashboardGridDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DashboardGridDemo.razor
@@ -795,6 +795,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the grid container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbDashboardWidget">
@@ -858,6 +861,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the widget card.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbDashboardWidgetHeader">
@@ -867,6 +873,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the header.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbDashboardWidgetContent">
@@ -875,6 +884,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the content area.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataGridDemo.razor
@@ -1404,6 +1404,9 @@
                 <ApiParameter Name="RefreshDataAsync()" Type="Task">
                     Public method. Re-reads the data source and re-renders. Call after mutating the Items collection in place, which the grid cannot detect by reference, or to force an ItemsProvider re-fetch. Collections implementing INotifyCollectionChanged (such as ObservableCollection) are subscribed to and refreshed automatically, so they do not need this. Call via a component reference (<code>@@ref</code>).
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DataGridPropertyColumn">
@@ -1622,6 +1625,9 @@
                 </ApiParameter>
                 <ApiParameter Name="TriggerClass" Type="string?">
                     Additional CSS classes applied to the trigger element.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataTableDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataTableDemo.razor
@@ -384,6 +384,9 @@
                 <ApiParameter Name="PageSizes" Type="int[]" Default="[5, 10, 20, 50, 100]">
                     The available page size options.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DataTableColumn">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataViewDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DataViewDemo.razor
@@ -641,6 +641,9 @@
                 <ApiParameter Name="OnFilter" Type="EventCallback&lt;string?&gt;">
                     Invoked when the global search value changes.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DataViewColumn">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DatePickerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DatePickerDemo.razor
@@ -321,6 +321,9 @@
                 <ApiParameter Name="Required" Type="bool" Default="false">
                     Whether the date picker is required.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DateRangePickerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DateRangePickerDemo.razor
@@ -343,6 +343,9 @@
                 <ApiParameter Name="Disabled" Type="bool" Default="false">
                     Disables the picker.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DateRange">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DateTimePickerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DateTimePickerDemo.razor
@@ -247,6 +247,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the trigger button.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DialogDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DialogDemo.razor
@@ -664,6 +664,9 @@
                 <ApiParameter Name="OnOpenChange" Type="EventCallback&lt;bool&gt;">
                     Event callback invoked when the dialog open state changes.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DialogContent">
@@ -691,11 +694,17 @@
                 <ApiParameter Name="OnEscapeKeyDown" Type="EventCallback&lt;KeyboardEventArgs&gt;">
                     Event callback invoked when the Escape key is pressed inside the dialog.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DialogTrigger">
                 <ApiParameter Name="AsChild" Type="bool" Default="true">
                     When true, passes trigger behavior to child components instead of rendering its own button.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -709,17 +718,26 @@
                 <ApiParameter Name="PreventClose" Type="bool" Default="false">
                     When true, prevents the default close behavior. Useful for validation before closing.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DialogHeader">
                 <ApiParameter Name="Class" Type="string?">
                     Additional CSS classes for the header container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DialogFooter">
                 <ApiParameter Name="Class" Type="string?">
                     Additional CSS classes for the footer container.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -730,11 +748,17 @@
                 <ApiParameter Name="As" Type="string" Default="&quot;h2&quot;">
                     The HTML element tag to render for the title.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DialogDescription">
                 <ApiParameter Name="Class" Type="string?">
                     Additional CSS classes for the description element.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DockDemo.razor
@@ -431,6 +431,9 @@ $ _</code></pre>
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the dock surface.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbDockPanel">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DrawerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DrawerDemo.razor
@@ -233,6 +233,9 @@
                 <ApiParameter Name="ShowHandle" Type="bool" Default="true">
                     Show drag handle.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DropdownMenuDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DropdownMenuDemo.razor
@@ -477,6 +477,9 @@
                 <ApiParameter Name="CloseOnClickOutside" Type="bool" Default="true">
                     Whether clicking outside closes the dropdown.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DropdownMenuItem">
@@ -495,6 +498,9 @@
                 <ApiParameter Name="CloseOnSelect" Type="bool" Default="true">
                     Whether to close the dropdown when this item is selected.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DropdownMenuCheckboxItem">
@@ -507,6 +513,9 @@
                 <ApiParameter Name="CloseOnSelect" Type="bool" Default="false">
                     Whether to close the dropdown when toggled.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DropdownMenuTrigger">
@@ -516,6 +525,9 @@
                 <ApiParameter Name="ActiveClass" Type="string?">
                     CSS classes applied when the dropdown is open. Default is <code>null</code> (no active style).
                     Use to highlight the trigger (e.g., <code>"bg-sidebar-accent"</code> in sidebars).
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DynamicFormDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DynamicFormDemo.razor
@@ -345,6 +345,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Additional content rendered inside the form (e.g., extra buttons).
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;form&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="FormSchema">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/EmptyDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/EmptyDemo.razor
@@ -197,6 +197,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes to apply to the container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/EventCalendarDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/EventCalendarDemo.razor
@@ -251,6 +251,9 @@
             <ApiParameter Name="Class" Type="string?" Default="null">
                 Additional CSS classes for the root element.
             </ApiParameter>
+            <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+            </ApiParameter>
         </ApiReference>
     </div>
 </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FieldDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FieldDemo.razor
@@ -458,17 +458,26 @@
                 <ApiParameter Name="IsInvalid" Type="bool" Default="false">
                     When true, cascades invalid state to child inputs automatically.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="FieldError">
                 <ApiParameter Name="Errors" Type="List&lt;string&gt;?">
                     List of error messages to display. Alternatively use ChildContent for a single message.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="FieldGroup">
                 <ApiParameter Name="Orientation" Type="FieldGroupOrientation" Default="Vertical">
                     Layout orientation: Vertical or Horizontal.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FilterBuilderDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FilterBuilderDemo.razor
@@ -362,6 +362,9 @@ var restored = FilterDefinitionExtensions.FromJson(json);</code></pre>
                 <ApiParameter Name="Class" Type="string?">
                     Additional CSS classes for the container element.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldCheckboxDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldCheckboxDemo.razor
@@ -252,6 +252,9 @@
                 <ApiParameter Name="AriaLabel" Type="string?" Default="null">
                     ARIA label for the control.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldCheckboxGroupDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldCheckboxGroupDemo.razor
@@ -148,6 +148,9 @@
                 <ApiParameter Name="Disabled" Type="bool" Default="false">Whether all items are disabled.</ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">CheckboxGroupItem components.</ApiParameter>
                 <ApiParameter Name="InputClass" Type="string?" Default="null">CSS classes for the inner group.</ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldComboboxDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldComboboxDemo.razor
@@ -446,6 +446,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
                     Content for compositional mode. Use ComboboxItem components as children.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldCurrencyInputDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldCurrencyInputDemo.razor
@@ -151,6 +151,9 @@
                 <ApiParameter Name="Required" Type="bool" Default="false">Whether the input is required.</ApiParameter>
                 <ApiParameter Name="EnableWheelStep" Type="bool" Default="false">Whether scrolling the mouse wheel over the focused input steps the value. Opt-in, because stepping calls preventDefault on the wheel event and so takes the scroll away from the page.</ApiParameter>
                 <ApiParameter Name="InputClass" Type="string?" Default="null">CSS classes for the inner input.</ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldDatePickerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldDatePickerDemo.razor
@@ -197,6 +197,9 @@
                 <ApiParameter Name="AriaLabel" Type="string?" Default="null">
                     ARIA label for the control.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldDateRangePickerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldDateRangePickerDemo.razor
@@ -130,6 +130,9 @@
                 <ApiParameter Name="AutoApply" Type="bool" Default="false">Apply the selection and close the popover as soon as a complete range is selected.</ApiParameter>
                 <ApiParameter Name="Disabled" Type="bool" Default="false">Whether the picker is disabled.</ApiParameter>
                 <ApiParameter Name="InputClass" Type="string?" Default="null">CSS classes for the inner trigger.</ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldDateTimePickerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldDateTimePickerDemo.razor
@@ -194,6 +194,9 @@
                 <ApiParameter Name="AriaLabel" Type="string?" Default="null">
                     ARIA label for the control.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldFileUploadDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldFileUploadDemo.razor
@@ -124,6 +124,9 @@
                 <ApiParameter Name="Required" Type="bool" Default="false">Whether the file upload is required.</ApiParameter>
                 <ApiParameter Name="DropzoneContent" Type="RenderFragment?" Default="null">Custom dropzone content.</ApiParameter>
                 <ApiParameter Name="InputClass" Type="string?" Default="null">CSS classes for the inner FileUpload.</ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldInputDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldInputDemo.razor
@@ -367,6 +367,9 @@
                 <ApiParameter Name="Name" Type="string?" Default="null">
                     HTML name attribute passed through to the inner InputField.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldInputOTPDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldInputOTPDemo.razor
@@ -127,6 +127,9 @@
                 <ApiParameter Name="Disabled" Type="bool" Default="false">Whether the input is disabled.</ApiParameter>
                 <ApiParameter Name="Required" Type="bool" Default="false">Whether the input is required.</ApiParameter>
                 <ApiParameter Name="InputClass" Type="string?" Default="null">CSS classes for each OTP input box.</ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldMaskedInputDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldMaskedInputDemo.razor
@@ -152,6 +152,9 @@
                 <ApiParameter Name="Disabled" Type="bool" Default="false">Whether the input is disabled.</ApiParameter>
                 <ApiParameter Name="Required" Type="bool" Default="false">Whether the input is required.</ApiParameter>
                 <ApiParameter Name="InputClass" Type="string?" Default="null">CSS classes for the inner input.</ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldMultiSelectDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldMultiSelectDemo.razor
@@ -418,6 +418,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
                     Content for compositional mode. Use MultiSelectItem components as children.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldNativeSelectDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldNativeSelectDemo.razor
@@ -200,6 +200,9 @@
                 <ApiParameter Name="AriaLabel" Type="string?" Default="null">
                     ARIA label for the control.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldNumericInputDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldNumericInputDemo.razor
@@ -243,6 +243,9 @@
                 <ApiParameter Name="AriaLabel" Type="string?" Default="null">
                     ARIA label for the control.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldRadioGroupDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldRadioGroupDemo.razor
@@ -172,6 +172,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
                     Content containing RadioGroupItem components.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldSelectDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldSelectDemo.razor
@@ -454,6 +454,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
                     Content containing SelectItem components. Ignored when Options is provided.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldSwitchDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldSwitchDemo.razor
@@ -187,6 +187,9 @@
                 <ApiParameter Name="AriaLabel" Type="string?" Default="null">
                     ARIA label for the control.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldTagInputDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldTagInputDemo.razor
@@ -116,6 +116,9 @@
                 <ApiParameter Name="Clearable" Type="bool" Default="false">Show a clear-all button.</ApiParameter>
                 <ApiParameter Name="Disabled" Type="bool" Default="false">Whether the input is disabled.</ApiParameter>
                 <ApiParameter Name="InputClass" Type="string?" Default="null">CSS classes for the inner container.</ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldTextareaDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldTextareaDemo.razor
@@ -187,6 +187,9 @@
                 <ApiParameter Name="AriaLabel" Type="string?" Default="null">
                     ARIA label for the control.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldTimePickerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormFieldTimePickerDemo.razor
@@ -208,6 +208,9 @@
                 <ApiParameter Name="AriaLabel" Type="string?" Default="null">
                     ARIA label for the control.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormWizardDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/FormWizardDemo.razor
@@ -443,6 +443,9 @@
                 <ApiParameter Name="NavigationClass" Type="string?" Default="null">
                     Additional CSS classes for the navigation area.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="WizardStep">
@@ -469,6 +472,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the step content wrapper.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/HoverCardDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/HoverCardDemo.razor
@@ -344,6 +344,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The child content. Should include HoverCardTrigger and HoverCardContent components.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="HoverCardTrigger">
                 <ApiParameter Name="AsChild" Type="bool" Default="true">
@@ -357,6 +360,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The child content to render within the trigger.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="HoverCardContent">
@@ -374,6 +380,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to render inside the hover card.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/InputDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/InputDemo.razor
@@ -450,6 +450,9 @@
                 <ApiParameter Name="Element" Type="ElementReference">
                     The underlying input element reference, e.g. for advanced JS interop.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;input&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/InputFieldDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/InputFieldDemo.razor
@@ -469,6 +469,9 @@
                 <ApiParameter Name="AriaInvalid" Type="bool?" Default="null">
                     Forces aria-invalid on the input. Combined with HasParseError so either condition triggers error styling.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;input&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/InputGroupDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/InputGroupDemo.razor
@@ -563,6 +563,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The child content containing InputGroupInput/InputGroupTextarea and InputGroupAddon components.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="InputGroupAddon">
@@ -574,6 +577,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The addon content (icons, buttons, text, or other elements).
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -626,6 +632,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes applied to the input element.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;input&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="InputGroupTextarea">
@@ -674,6 +683,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes applied to the textarea element.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;textarea&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="InputGroupButton">
@@ -707,6 +719,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The button text content.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="InputGroupText">
@@ -715,6 +730,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The text content (currency symbols, URL prefixes, units, etc.).
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;span&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/InputOTPDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/InputOTPDemo.razor
@@ -333,6 +333,9 @@
                 <ApiParameter Name="Name" Type="string?" Default="null">
                     HTML name attribute for the hidden input. Auto-derived from ValueExpression inside an EditForm.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ItemDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ItemDemo.razor
@@ -413,6 +413,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to be rendered inside the item.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="ItemGroup">
                 <ApiParameter Name="Class" Type="string?">
@@ -421,6 +424,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to be rendered inside the group.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="ItemContent">
                 <ApiParameter Name="Class" Type="string?">
@@ -428,6 +434,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to be rendered inside the container.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="ItemMedia">
@@ -440,6 +449,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to be rendered inside the media container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="ItemTitle">
                 <ApiParameter Name="Class" Type="string?">
@@ -447,6 +459,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to be rendered as the title.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="ItemDescription">
@@ -456,6 +471,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to be rendered as the description.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="ItemActions">
                 <ApiParameter Name="Class" Type="string?">
@@ -463,6 +481,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to be rendered inside the actions container.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="ItemHeader">
@@ -472,6 +493,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to be rendered in the header.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="ItemFooter">
                 <ApiParameter Name="Class" Type="string?">
@@ -480,10 +504,16 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to be rendered in the footer.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="ItemSeparator">
                 <ApiParameter Name="Class" Type="string?">
                     Additional CSS classes to apply to the separator.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/KbdDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/KbdDemo.razor
@@ -188,6 +188,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Custom content for the keyboard shortcut display. When provided, takes precedence over the Keys parameter.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;kbd&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/LabelDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/LabelDemo.razor
@@ -299,6 +299,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to display inside the label (text, icons, indicators, etc.).
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MarkdownEditorDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MarkdownEditorDemo.razor
@@ -249,6 +249,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes to apply to the editor container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MarkerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MarkerDemo.razor
@@ -174,6 +174,9 @@
             <ApiParameter Name="Class" Type="string?">
                 Additional CSS classes to apply to marker root.
             </ApiParameter>
+            <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                Additional HTML attributes applied to the root <code>&lt;a&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+            </ApiParameter>
         </ApiReference>
     </section>
 </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MaskedInputDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MaskedInputDemo.razor
@@ -271,6 +271,9 @@
                 <ApiParameter Name="Disabled" Type="bool">
                     Disables the input.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;input&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
 

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MenubarDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MenubarDemo.razor
@@ -226,6 +226,9 @@
                 <ApiParameter Name="TriggerClass" Type="string?" Default="null">
                     CSS classes to apply to all MenubarTrigger components.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="MenubarItem">
@@ -241,6 +244,9 @@
                 <ApiParameter Name="Shortcut" Type="string?" Default="null">
                     Keyboard shortcut to auto-register globally (e.g., "Ctrl+N", "F1").
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="MenubarCheckboxItem">
@@ -252,6 +258,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Disabled" Type="bool" Default="false">
                     Whether the checkbox item is disabled.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MessageDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MessageDemo.razor
@@ -278,6 +278,9 @@
             <ApiParameter Name="Class" Type="string?">
                 Additional CSS classes for the message root.
             </ApiParameter>
+            <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+            </ApiParameter>
         </ApiReference>
     </section>
 </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MultiSelectDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/MultiSelectDemo.razor
@@ -525,6 +525,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Content for compositional mode. Use MultiSelectItem components as children.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="MultiSelectItem&lt;TValue&gt;">
@@ -539,6 +542,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Custom content to render. When null, renders Text as plain text.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/NativeSelectDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/NativeSelectDemo.razor
@@ -259,6 +259,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The option and optgroup elements to display inside the select.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;select&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/NavigationMenuDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/NavigationMenuDemo.razor
@@ -329,6 +329,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to render inside the navigation menu. Typically contains NavigationMenuList.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;nav&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="NavigationMenuList">
@@ -337,6 +340,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The navigation menu items.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;ul&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -350,6 +356,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content of the menu item (trigger, content, or link).
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;li&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="NavigationMenuTrigger">
@@ -359,6 +368,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content of the trigger button.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;button&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="NavigationMenuContent">
@@ -367,6 +379,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to render in the dropdown.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -383,11 +398,17 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content of the link.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="NavigationMenuIndicator">
                 <ApiParameter Name="Class" Type="string?">
                     Additional CSS classes to apply to the indicator.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -397,6 +418,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to render inside the viewport.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/NumericInputDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/NumericInputDemo.razor
@@ -343,6 +343,9 @@
                 <ApiParameter Name="Disabled" Type="bool">
                     Disables the input.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
 

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/PaginationDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/PaginationDemo.razor
@@ -236,6 +236,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
                     Custom child content. When null and TotalPages is set, renders the default layout automatically.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;nav&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="PaginationContent">
@@ -245,6 +248,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
                     The pagination items to render inside the list.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;ul&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="PaginationItem">
@@ -253,6 +259,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
                     The pagination control to render inside the item.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;li&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -278,11 +287,17 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
                     Content to render inside the link (typically a page number).
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;button&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="PaginationEllipsis">
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the ellipsis indicator.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;span&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -295,6 +310,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -320,6 +338,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="PaginationNext">
@@ -344,6 +365,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="PaginationLast">
@@ -355,6 +379,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -371,6 +398,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
                     Custom content to display when not using pagination state.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="PaginationPageDisplay">
@@ -382,6 +412,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
                     Custom content to display when not using pagination state.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -403,6 +436,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/PopoverDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/PopoverDemo.razor
@@ -215,6 +215,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The child content. Should include PopoverTrigger and PopoverContent components.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="PopoverTrigger">
                 <ApiParameter Name="AsChild" Type="bool" Default="true">
@@ -228,6 +231,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The child content to render within the trigger.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
             <ApiReference ComponentName="PopoverContent">
@@ -269,6 +275,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content to render inside the popover.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ProgressDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ProgressDemo.razor
@@ -212,6 +212,9 @@
                 <ApiParameter Name="IndicatorClass" Type="string?">
                     Additional CSS classes to apply to the progress indicator.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/RadioGroupDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/RadioGroupDemo.razor
@@ -280,6 +280,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content of the radio group. Should contain <code class="text-xs bg-muted px-1 py-0.5 rounded">RadioGroupItem</code> components.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="RadioGroupItem<TValue>">
@@ -300,6 +303,9 @@
                 </ApiParameter>
                 <ApiParameter Name="AriaLabel" Type="string?">
                     Accessible label for the radio item when no visible label is present.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/RangeSliderDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/RangeSliderDemo.razor
@@ -204,6 +204,9 @@
                 <ApiParameter Name="Disabled" Type="bool">
                     Disables the slider.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/RatingDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/RatingDemo.razor
@@ -193,6 +193,9 @@
                 <ApiParameter Name="IconTemplate" Type="RenderFragment<RatingIconContext>?">
                     Custom icon template.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ResizableDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ResizableDemo.razor
@@ -240,6 +240,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the panel group container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="ResizablePanel">
@@ -258,6 +261,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the panel.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="ResizableHandle">
@@ -266,6 +272,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the handle.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/RichTextEditorDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/RichTextEditorDemo.razor
@@ -400,6 +400,9 @@
                 <ApiParameter Name="AriaInvalid" Type="bool?" Default="null">
                     Whether the editor value is invalid.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ScrollAreaDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ScrollAreaDemo.razor
@@ -158,6 +158,9 @@
                     When true, automatically fills remaining vertical space in a flex column parent container,
                     excluding sibling elements. Takes precedence over Height and MaxHeight.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SelectDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SelectDemo.razor
@@ -397,6 +397,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Content for compositional mode. Should contain SelectTrigger and SelectContent.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="SelectTrigger&lt;TValue&gt;">
@@ -406,6 +409,9 @@
                 <ApiParameter Name="ActiveClass" Type="string?" Default="&quot;bg-accent text-accent-foreground&quot;">
                     CSS classes applied when the dropdown is open. Set to <code>null</code> or empty to disable.
                     Use to match the context (e.g., <code>"bg-sidebar-accent text-sidebar-accent-foreground"</code> in sidebars).
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -422,6 +428,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Custom content rendered as the item's display.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="SelectValue">
@@ -430,6 +439,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment&lt;string&gt;?">
                     Custom template for selected value display. Receives display text as context.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;span&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SeparatorDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SeparatorDemo.razor
@@ -181,6 +181,9 @@
                 <ApiParameter Name="Class" Type="string?">
                     Additional CSS classes to apply to the separator element.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SheetDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SheetDemo.razor
@@ -456,11 +456,17 @@
                 <ApiParameter Name="Modal" Type="bool" Default="true">
                     Whether the sheet can be dismissed by clicking the overlay or pressing Escape.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="SheetTrigger">
                 <ApiParameter Name="AsChild" Type="bool" Default="true">
                     When true, passes trigger behavior to child components instead of rendering its own button.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -486,6 +492,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for custom width or styling.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="SheetClose">
@@ -494,6 +503,9 @@
                 </ApiParameter>
                 <ApiParameter Name="PreventClose" Type="bool" Default="false">
                     When true, prevents the default close behavior. Only the OnClick handler is invoked.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SkeletonDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SkeletonDemo.razor
@@ -327,6 +327,9 @@
                 <ApiParameter Name="Height" Type="string?">
                     Explicit height applied as an inline style (e.g., "20px", "2rem").
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SliderDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SliderDemo.razor
@@ -165,6 +165,9 @@
                 <ApiParameter Name="ThumbClass" Type="string?">
                     Additional CSS classes for the thumb
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SortableDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SortableDemo.razor
@@ -300,6 +300,9 @@
             <ApiParameter Name="Class" Type="string?">
                 Additional CSS classes for the container element.
             </ApiParameter>
+            <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+            </ApiParameter>
         </ApiReference>
 
         <div class="rounded-lg border p-6">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SpinnerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SpinnerDemo.razor
@@ -180,6 +180,9 @@
                 <ApiParameter Name="AriaLabel" Type="string?" Default="Loading">
                     Accessible label for screen readers.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;svg&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SplitButtonDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SplitButtonDemo.razor
@@ -343,6 +343,9 @@
                 <ApiParameter Name="DropdownContent" Type="RenderFragment?" Default="null">
                     Content for the dropdown menu. Should contain BbSplitButtonItem components.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbSplitButtonItem">
@@ -354,6 +357,9 @@
                 </ApiParameter>
                 <ApiParameter Name="CloseOnSelect" Type="bool" Default="true">
                     Whether clicking this item closes the dropdown.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SwitchDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SwitchDemo.razor
@@ -411,6 +411,9 @@
                 <ApiParameter Name="ThumbContent" Type="RenderFragment&lt;bool&gt;?" Default="null">
                     Custom content to render inside the thumb. The context parameter is the checked state.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TabsDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TabsDemo.razor
@@ -352,6 +352,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the tabs container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="TabsList">
@@ -363,6 +366,9 @@
                 </ApiParameter>
                 <ApiParameter Name="SelectClass" Type="string?" Default="null">
                     Additional CSS classes for the responsive Select fallback.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -379,6 +385,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the tab trigger.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="TabsContent">
@@ -390,6 +399,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the tab content panel.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TagInputDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TagInputDemo.razor
@@ -296,6 +296,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ThemeDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ThemeDemo.razor
@@ -214,6 +214,9 @@ await ThemeService.ToggleDarkModeAsync();</code></pre>
                         color sections with independent selection indicators; <code>Combined</code> shows the
                         legacy single grid where selecting a base color resets the primary color.
                     </ApiParameter>
+                    <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                        Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                    </ApiParameter>
                 </ApiReference>
 
                 <ApiReference ComponentName="BbDarkModeToggle">
@@ -240,6 +243,9 @@ await ThemeService.ToggleDarkModeAsync();</code></pre>
                     </ApiParameter>
                     <ApiParameter Name="Size" Type="ButtonSize" Default="ButtonSize.Icon">
                         Button size.
+                    </ApiParameter>
+                    <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                        Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                     </ApiParameter>
                 </ApiReference>
             </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TimePickerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TimePickerDemo.razor
@@ -253,6 +253,9 @@
                 <ApiParameter Name="Required" Type="bool" Default="false">
                     Whether the time picker is required.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TimelineDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TimelineDemo.razor
@@ -1469,6 +1469,9 @@
                 <ApiParameter Name="Class" Type="string?">
                     Additional CSS classes for the timeline container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;ol&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="TimelineItem">
@@ -1495,6 +1498,9 @@
                 </ApiParameter>
                 <ApiParameter Name="TimeContent" Type="RenderFragment?">
                     Time/date content displayed in the left column.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;li&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ToastDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ToastDemo.razor
@@ -317,6 +317,9 @@
                 <ApiParameter Name="ShowCountdown" Type="bool" Default="false">
                     Show a visual countdown progress bar on all toasts. Individual toasts can override via ToastData.ShowCountdown.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="ToastData">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ToggleDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ToggleDemo.razor
@@ -190,6 +190,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the toggle button.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ToggleGroupDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/ToggleGroupDemo.razor
@@ -245,6 +245,9 @@
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for the group container.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="ToggleGroupItem&lt;TValue&gt;">
@@ -256,6 +259,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Class" Type="string?" Default="null">
                     Additional CSS classes for this item.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TooltipDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TooltipDemo.razor
@@ -433,6 +433,9 @@
                     <ApiParameter Name="Placement" Type="string" Default="&quot;top&quot;">
                         Position of tooltip: "top", "bottom", "left", "right", or variants like "top-start", "bottom-end".
                     </ApiParameter>
+                    <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                        Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                    </ApiParameter>
                 </ApiReference>
 
                 <ApiReference ComponentName="TooltipTrigger">
@@ -445,11 +448,17 @@
                     <ApiParameter Name="Focusable" Type="bool" Default="true">
                         Whether to add tabindex="0" for keyboard focus. Set false if child is already focusable.
                     </ApiParameter>
+                    <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                        Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                    </ApiParameter>
                 </ApiReference>
 
                 <ApiReference ComponentName="TooltipContent">
                     <ApiParameter Name="Class" Type="string?">
                         Additional CSS classes for the tooltip content container.
+                    </ApiParameter>
+                    <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                        Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                     </ApiParameter>
                 </ApiReference>
             </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TreeViewDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/TreeViewDemo.razor
@@ -605,6 +605,9 @@
                     <ApiParameter Name="Class" Type="string?" Default="null">
                         Additional CSS classes for the tree container.
                     </ApiParameter>
+                    <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                        Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                    </ApiParameter>
                 </ApiReference>
 
                 <ApiReference ComponentName="BbTreeItem">
@@ -637,6 +640,9 @@
                     </ApiParameter>
                     <ApiParameter Name="Class" Type="string?" Default="null">
                         Additional CSS classes for the node row.
+                    </ApiParameter>
+                    <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                        Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                     </ApiParameter>
                 </ApiReference>
             </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/AlertDialogPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/AlertDialogPrimitiveDemo.razor
@@ -180,11 +180,17 @@
                 <ApiParameter Name="OnOpenChange" Type="EventCallback&lt;bool&gt;">
                     Callback invoked when the open state changes.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbAlertDialogTrigger">
                 <ApiParameter Name="AsChild" Type="bool" Default="false">
                     When true, merges props onto the child element instead of rendering a wrapper.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -192,11 +198,17 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The content of the alert dialog.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbAlertDialogTitle">
                 <ApiParameter Name="As" Type="string" Default="&quot;h2&quot;">
                     HTML heading element tag to render.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -204,17 +216,26 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The description text content.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbAlertDialogAction">
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The action button content. Clicking closes the dialog.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbAlertDialogCancel">
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The cancel button content. Clicking closes the dialog.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/ContextMenuPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/ContextMenuPrimitiveDemo.razor
@@ -118,11 +118,17 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The trigger area content. Right-clicking this area opens the context menu.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbContextMenuContent">
                 <ApiParameter Name="Loop" Type="bool" Default="true">
                     Whether keyboard navigation wraps from last to first item.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -133,11 +139,17 @@
                 <ApiParameter Name="OnClick" Type="EventCallback">
                     Callback invoked when the item is activated.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbContextMenuLabel">
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Label text content. Labels are not interactive.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/DataGridPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/DataGridPrimitiveDemo.razor
@@ -951,6 +951,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The grid content (DataGridHeader, DataGridBody).
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;table&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DataGridHeaderCell&lt;TData&gt;">
@@ -972,6 +975,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The header cell content.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;th&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DataGridRow&lt;TData&gt;">
@@ -984,6 +990,9 @@
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The row content (DataGridCell elements).
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;tr&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="DataGridCell">
@@ -992,6 +1001,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     The cell content.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;td&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/DialogPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/DialogPrimitiveDemo.razor
@@ -277,6 +277,9 @@
                     <ApiParameter Name="ChildContent" Type="RenderFragment?">
                         The child content to render within the dialog context. Typically includes DialogTrigger, DialogPortal, and other dialog parts.
                     </ApiParameter>
+                    <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                        Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                    </ApiParameter>
                 </ApiReference>
 
                 <ApiReference ComponentName="DialogTrigger">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/HoverCardPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/HoverCardPrimitiveDemo.razor
@@ -316,6 +316,9 @@
                     <ApiParameter Name="ChildContent" Type="RenderFragment?">
                         Content rendered inside the hover card. Typically includes HoverCardTrigger and HoverCardContent.
                     </ApiParameter>
+                    <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                        Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                    </ApiParameter>
                 </ApiReference>
 
                 <ApiReference ComponentName="HoverCardTrigger">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/PopoverPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/PopoverPrimitiveDemo.razor
@@ -224,6 +224,9 @@
                     <ApiParameter Name="ChildContent" Type="RenderFragment?">
                         The child content to render within the popover context. Typically includes PopoverTrigger and PopoverContent.
                     </ApiParameter>
+                    <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                        Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                    </ApiParameter>
                 </ApiReference>
 
                 <ApiReference ComponentName="PopoverTrigger">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/ProgressPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/ProgressPrimitiveDemo.razor
@@ -134,11 +134,17 @@
                 <ApiParameter Name="GetValueLabel" Type="Func&lt;double, double, string&gt;?" Default="null">
                     Callback to generate a human-readable label. Receives <code class="text-xs bg-muted px-1 py-0.5 rounded">(value, max)</code> and returns a string for <code class="text-xs bg-muted px-1 py-0.5 rounded">aria-valuetext</code>.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbProgressIndicator">
                 <ApiParameter Name="ChildContent" Type="RenderFragment?" Default="null">
                     Optional child content rendered inside the indicator.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/ScrollAreaPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/ScrollAreaPrimitiveDemo.razor
@@ -148,11 +148,17 @@
                 <ApiParameter Name="Orientation" Type="ScrollAreaOrientation" Default="Vertical">
                     The scroll orientation. Options: Vertical, Horizontal, or Both.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbScrollAreaScrollbar">
                 <ApiParameter Name="Orientation" Type="ScrollAreaOrientation" Default="Vertical">
                     The scrollbar orientation. Must match the scroll direction it controls.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/SeparatorPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/SeparatorPrimitiveDemo.razor
@@ -122,6 +122,9 @@
                 <ApiParameter Name="Decorative" Type="bool" Default="true">
                     When true, renders <code class="text-xs bg-muted px-1 py-0.5 rounded">role="none"</code> and hides from assistive technology. When false, renders <code class="text-xs bg-muted px-1 py-0.5 rounded">role="separator"</code>.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/SheetPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/SheetPrimitiveDemo.razor
@@ -372,6 +372,9 @@
                     <ApiParameter Name="ChildContent" Type="RenderFragment?">
                         Content rendered inside the sheet context. Typically includes SheetTrigger, SheetPortal, and other sheet parts.
                     </ApiParameter>
+                    <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                        Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                    </ApiParameter>
                 </ApiReference>
 
                 <ApiReference ComponentName="SheetTrigger">

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/SliderPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/SliderPrimitiveDemo.razor
@@ -152,11 +152,17 @@
                 <ApiParameter Name="Orientation" Type="SliderOrientation" Default="SliderOrientation.Horizontal">
                     Orientation of the slider. Affects keyboard navigation and layout.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbSliderTrack">
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Content rendered inside the track (typically a <code class="text-xs bg-muted px-1 py-0.5 rounded">BbSliderRange</code>).
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
 
@@ -169,6 +175,9 @@
             <ApiReference ComponentName="BbSliderThumb">
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Optional content rendered inside the thumb.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/ToggleGroupPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/ToggleGroupPrimitiveDemo.razor
@@ -171,6 +171,9 @@
                 <ApiParameter Name="AriaLabel" Type="string?" Default="null">
                     Accessible label for the group.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbToggleGroupItem&lt;TValue&gt;">
@@ -179,6 +182,9 @@
                 </ApiParameter>
                 <ApiParameter Name="Disabled" Type="bool" Default="false">
                     Whether this individual item is disabled.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;button&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/TogglePrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/TogglePrimitiveDemo.razor
@@ -140,6 +140,9 @@
                 <ApiParameter Name="Disabled" Type="bool" Default="false">
                     Whether the toggle is disabled.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;button&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/TreeViewPrimitiveDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Primitives/TreeViewPrimitiveDemo.razor
@@ -325,6 +325,9 @@
                 <ApiParameter Name="OnNodeCollapse" Type="EventCallback&lt;string&gt;">
                     Callback when a node is collapsed.
                 </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="BbTreeItem">
@@ -342,6 +345,9 @@
                 </ApiParameter>
                 <ApiParameter Name="ChildContent" Type="RenderFragment?">
                     Child tree items nested under this node.
+                </ApiParameter>
+                <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
+                    Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
             </ApiReference>
         </div>

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor
@@ -7,7 +7,7 @@
 <CascadingValue Value="this" IsFixed="true">
     @ChildContent
 
-    <div @ref="rootRef" class="@CssClass" data-dock-root="@dockId">
+    <div @ref="rootRef" class="@CssClass" data-dock-root="@dockId" @attributes="AdditionalAttributes">
         @if (MaximizedGroup is not null)
         {
             <BbDockNode Node="MaximizedGroup" />

--- a/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Dock/BbDock.razor.cs
@@ -35,6 +35,12 @@ public partial class BbDock : ComponentBase, IAsyncDisposable
     public string? Class { get; set; }
 
     /// <summary>
+    /// Gets or sets additional HTML attributes to apply to the dock's root element.
+    /// </summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    /// <summary>
     /// Invoked after the layout changes (docking, floating, closing, reopening or reordering).
     /// </summary>
     [Parameter]

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -1304,6 +1304,7 @@
   - ChildContent : RenderFragment
 
 ### BbDock (BlazorBlueprint.Components)
+  - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
   - ChildContent : RenderFragment
   - Class : String
   - EmptyContent : RenderFragment


### PR DESCRIPTION
Follow-up to #490. That PR gave 216 components `AdditionalAttributes` and documented none of them, so the API reference has been telling people those components take fewer parameters than they do.

## What

- **226 `ApiParameter` entries across 112 demo pages.** Each one names the element the attributes actually land on rather than saying "the root element" generically. The target is read from the component source, so the primitive `DataGrid` documents `<table>` where the styled one documents `<div>`. All 226 were verified against source, with zero mismatches.
- **`BbDock` gains `AdditionalAttributes`**, applied to its root `<div>`. It was the only component that renders an element and still lacked the parameter.
- The `2026-08-29` changelog entry for #490.

The descriptions use `data-testid` and `aria-label` as the examples rather than `class` and `style`. A `class` supplied through the attribute splat **replaces** the component's own classes rather than merging through `ClassNames.cn`, and the documentation should not steer people into that.

## Deliberately not added

`BbDockPanel`, `BbDrawer`, `BbTooltipProvider`, `BbContextMenu`, `BbDropdownMenu`, `BbSheetPortal` and `BbDialogPortal` render no element of their own — they wrap their children in a `CascadingValue`, or hand content to the portal service. Capturing attributes there would discard them silently, which is the fault that had to be cleaned out of #490 before it merged. The rule worth keeping is **a component that renders an element takes attributes**, not "every component takes attributes".

`BbSliderThumb` already inherits the parameter from `BbPrimitiveBase`.

## Verification

Full solution builds clean. 166/166 tests pass. The API surface snapshot gained exactly one line — `BbDock.AdditionalAttributes` — and lost none.