### PR TITLE
fix: initial focus for trapped overlays, and stop HoverCard opening on programmatic focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-09-04
+
+### Added
+
+- **Dialogs, sheets and drawers can choose what gets focus when they open** — [#504](https://github.com/blazorblueprintui/ui/issues/504), reported externally against 3.15.0 and confirmed by decompiling the shipped package. The focus trap ended with an unconditional `focusableElements[0].focus()` and took no argument, so any dialog whose first tabbable descendant does something *on focus* — opening a dropdown, running a search — fired that side effect the moment the dialog opened. The only workaround available to a consumer was injecting a dummy `tabindex="0"` element, which adds a phantom tab stop.
+
+  `InitialFocus` on `BbDialogContent`, `BbSheetContent` and `BbDrawerContent` takes `FocusTrapInitialFocus.FirstFocusable` (the default, unchanged), `Container` to focus the panel itself as Radix does, or `None` to move nothing. `InitialFocusElement` names an element outright. The resolution order is explicit element, then `[data-autofocus]`, then the mode, then the first tabbable descendant.
+
+  `[data-autofocus]` was chosen rather than a new convention because the library **already** honours it — `portal.js` focuses it on a `blazorblueprint:visible` event, and `BbDropdownMenuContent` relies on that. The two mechanisms could previously both fire inside a dialog and race, with the winner decided by event ordering; they now agree on the same target.
+
+  `IFocusManager.TrapFocus` gained an overload rather than extra parameters, with a default interface implementation delegating to the original. Widening the existing signature would have broken anyone implementing the interface, which is not something a bug fix should cost. A custom `IFocusManager` keeps working unchanged, and opts into the new behaviour by overriding the overload.
+
+### Fixed
+
+- **`BbHoverCardTrigger` opened on any focus, including focus moved programmatically** — the other half of [#504](https://github.com/blazorblueprintui/ui/issues/504). Opening on focus is correct and required — WCAG 1.4.13 means a hover card must be keyboard reachable — but the handler could not tell a deliberate Tab from a focus trap or an explicit `.focus()`, so an unrelated dialog opening nearby popped the card open with no user intent behind it. Both the `AsChild` and `AsChild="false"` paths behaved this way.
+
+  **The obvious fix does not work, and the measurement is the useful part of this entry.** Gating on `:focus-visible` was implemented and tested in the running demo: Chrome reports it as **true** for a programmatic `.focus()` on the trigger's `div[tabindex="0"]`, including directly after a real mouse click. The card still opened. `BbTableRow.razor:58` had already recorded the same limitation from the other direction.
+
+  What ships instead keys off `Tab`: `element-utils.js` records the last `Tab` keydown at the document in the capture phase, and the trigger opens on focus only when a Tab landed within 500 ms — or when the focused element is a text field, where the intent is unambiguous. Tab is how a keyboard user reaches a trigger, and nothing moves focus programmatically *in response to* Tab, so it separates the two cases the selector cannot. Verified both ways in a real browser: a programmatic `.focus()` no longer opens the card, and a genuine Tab still does.
+
+  The check returns true whenever it cannot run — during prerendering, or with the JS module unavailable — because a keyboard user silently losing the card is a worse outcome than the bug being fixed.
+
+  `OpenDelay` still does **not** apply to the focus path, deliberately, and the report asking for it is the one place this diverges. The delay exists because a pointer sweeps across elements incidentally; Tab does not, so landing on a trigger is already deliberate. `OpenDelay` defaults to 700 ms, and making a keyboard user wait that long for what a mouse user gets by holding still is a straight accessibility regression.
+
+---
+
 ## 2026-08-29
 
 ### Added

--- a/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dialog/initial-focus.txt
+++ b/demos/BlazorBlueprint.Demo.Shared/CodeExamples/Components/Dialog/initial-focus.txt
@@ -1,0 +1,18 @@
+@* Focus the dialog itself, so the first field is not focused on open. *@
+<BbDialogContent InitialFocus="FocusTrapInitialFocus.Container">
+    <BbDialogHeader>
+        <BbDialogTitle>Search</BbDialogTitle>
+    </BbDialogHeader>
+    <BbInput @bind-Value="query" Placeholder="Type to search..." />
+</BbDialogContent>
+
+@* Or name the element to focus. data-autofocus wins over InitialFocus. *@
+<BbDialogContent>
+    <BbDialogHeader>
+        <BbDialogTitle>Confirm</BbDialogTitle>
+    </BbDialogHeader>
+    <BbInput @bind-Value="note" Placeholder="Optional note" />
+    <BbDialogFooter>
+        <BbButton data-autofocus>Confirm</BbButton>
+    </BbDialogFooter>
+</BbDialogContent>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DialogDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DialogDemo.razor
@@ -621,6 +621,69 @@
         <CodeBlock Source="Components/Dialog/non-dismissible.txt" />
     </div>
 
+    <!-- Initial Focus -->
+    <div class="space-y-4">
+        <h2 class="text-2xl font-semibold">Initial Focus <span class="text-xs font-normal text-primary bg-primary/10 px-1.5 py-0.5 rounded">New</span></h2>
+        <p class="text-sm text-muted-foreground">
+            By default the focus trap focuses the first tabbable element inside the dialog. When that
+            element does something on focus &mdash; opening a dropdown, running a search &mdash; the side
+            effect fires as soon as the dialog opens. Set
+            <code class="bg-muted px-1 py-0.5 rounded">InitialFocus="FocusTrapInitialFocus.Container"</code>
+            to focus the dialog itself instead, or put
+            <code class="bg-muted px-1 py-0.5 rounded">data-autofocus</code> on the element you want.
+            An element carrying <code class="bg-muted px-1 py-0.5 rounded">data-autofocus</code> wins over
+            <code class="bg-muted px-1 py-0.5 rounded">InitialFocus</code>.
+        </p>
+
+        <div class="flex flex-wrap gap-2">
+            <BbDialog>
+                <BbDialogTrigger>
+                    <BbButton Variant="ButtonVariant.Outline">Default (first field)</BbButton>
+                </BbDialogTrigger>
+                <BbDialogContent>
+                    <BbDialogHeader>
+                        <BbDialogTitle>Default</BbDialogTitle>
+                        <BbDialogDescription>The search field below has focus already.</BbDialogDescription>
+                    </BbDialogHeader>
+                    <BbInput @bind-Value="initialFocusQuery" Placeholder="Type to search..." />
+                </BbDialogContent>
+            </BbDialog>
+
+            <BbDialog>
+                <BbDialogTrigger>
+                    <BbButton Variant="ButtonVariant.Outline">Focus the container</BbButton>
+                </BbDialogTrigger>
+                <BbDialogContent InitialFocus="FocusTrapInitialFocus.Container">
+                    <BbDialogHeader>
+                        <BbDialogTitle>Container</BbDialogTitle>
+                        <BbDialogDescription>Nothing inside has focus. Tab moves to the field.</BbDialogDescription>
+                    </BbDialogHeader>
+                    <BbInput @bind-Value="initialFocusQuery" Placeholder="Type to search..." />
+                </BbDialogContent>
+            </BbDialog>
+
+            <BbDialog>
+                <BbDialogTrigger>
+                    <BbButton Variant="ButtonVariant.Outline">data-autofocus</BbButton>
+                </BbDialogTrigger>
+                <BbDialogContent>
+                    <BbDialogHeader>
+                        <BbDialogTitle>Named target</BbDialogTitle>
+                        <BbDialogDescription>The Confirm button has focus, not the field above it.</BbDialogDescription>
+                    </BbDialogHeader>
+                    <BbInput @bind-Value="initialFocusNote" Placeholder="Optional note" />
+                    <BbDialogFooter Class="mt-4">
+                        <BbDialogClose>
+                            <BbButton data-autofocus>Confirm</BbButton>
+                        </BbDialogClose>
+                    </BbDialogFooter>
+                </BbDialogContent>
+            </BbDialog>
+        </div>
+
+        <CodeBlock Source="Components/Dialog/initial-focus.txt" />
+    </div>
+
     <AccessibilityList>
         <AriaAttributes>
             <AccessibilityItem>Focus is automatically trapped within the dialog</AccessibilityItem>
@@ -696,6 +759,12 @@
                 </ApiParameter>
                 <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
                     Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
+                </ApiParameter>
+                <ApiParameter Name="InitialFocus" Type="FocusTrapInitialFocus" Default="FocusTrapInitialFocus.FirstFocusable">
+                    What the focus trap focuses on open. <code>FirstFocusable</code> focuses the first tabbable descendant, <code>Container</code> focuses the dialog itself, <code>None</code> moves nothing. An element carrying <code>data-autofocus</code> wins over this.
+                </ApiParameter>
+                <ApiParameter Name="InitialFocusElement" Type="ElementReference?">
+                    An explicit element to focus on open, beating both <code>InitialFocus</code> and <code>data-autofocus</code>. Ignored when it is not inside the dialog.
                 </ApiParameter>
             </ApiReference>
 
@@ -864,6 +933,9 @@
 </div>
 
 @code {
+    private string initialFocusQuery = string.Empty;
+    private string initialFocusNote = string.Empty;
+
     private bool isDialogOpen = false;
     private DateTime? dialogDatePickerValue;
     private string? selectedComboboxFramework;

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DrawerDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/DrawerDemo.razor
@@ -236,6 +236,12 @@
                 <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
                     Additional HTML attributes applied to the root <code>&lt;div&gt;</code> element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
+                <ApiParameter Name="InitialFocus" Type="FocusTrapInitialFocus" Default="FocusTrapInitialFocus.FirstFocusable">
+                    What the focus trap focuses on open. <code>FirstFocusable</code> focuses the first tabbable descendant, <code>Container</code> focuses the drawer itself, <code>None</code> moves nothing. An element carrying <code>data-autofocus</code> wins over this.
+                </ApiParameter>
+                <ApiParameter Name="InitialFocusElement" Type="ElementReference?">
+                    An explicit element to focus on open, beating both <code>InitialFocus</code> and <code>data-autofocus</code>. Ignored when it is not inside the drawer.
+                </ApiParameter>
             </ApiReference>
         </div>
     </section>

--- a/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SheetDemo.razor
+++ b/demos/BlazorBlueprint.Demo.Shared/Pages/Components/SheetDemo.razor
@@ -495,6 +495,12 @@
                 <ApiParameter Name="AdditionalAttributes" Type="Dictionary&lt;string, object&gt;?">
                     Additional HTML attributes applied to the component's root element (e.g. <code>data-testid</code>, <code>aria-label</code>).
                 </ApiParameter>
+                <ApiParameter Name="InitialFocus" Type="FocusTrapInitialFocus" Default="FocusTrapInitialFocus.FirstFocusable">
+                    What the focus trap focuses on open. <code>FirstFocusable</code> focuses the first tabbable descendant, <code>Container</code> focuses the sheet itself, <code>None</code> moves nothing. An element carrying <code>data-autofocus</code> wins over this.
+                </ApiParameter>
+                <ApiParameter Name="InitialFocusElement" Type="ElementReference?">
+                    An explicit element to focus on open, beating both <code>InitialFocus</code> and <code>data-autofocus</code>. Ignored when it is not inside the sheet.
+                </ApiParameter>
             </ApiReference>
 
             <ApiReference ComponentName="SheetClose">

--- a/docs/plans/2026-08-29-focus-trap-and-hovercard-focus.md
+++ b/docs/plans/2026-08-29-focus-trap-and-hovercard-focus.md
@@ -1,0 +1,135 @@
+# Focus trap initial target, and HoverCard opening on programmatic focus
+
+Drafted 2026-08-29 from an external report against 3.15.0. Both defects were re-confirmed
+against `develop` at 3.16.0 before this plan was written; neither is already fixed.
+
+| # | Step | Size | Breaking |
+|---|---|---|---|
+| 1 | `createFocusTrap` honours an initial-focus target | M | no |
+| 2 | `InitialFocus` parameter on the four trapping components | S | no |
+| 3 | HoverCard: do not open on programmatic focus | S | no |
+| 4 | Decide whether `OpenDelay` applies to keyboard focus | S | see below |
+
+---
+
+## 1. The focus trap always focuses the first tabbable descendant
+
+`focus-trap.js:57-61` ends `createFocusTrap` with an unconditional
+`focusableElements[0].focus()`. `createFocusTrap(container)` takes one argument, and so does
+`IFocusManager.TrapFocus(ElementReference container)`, so there is no override anywhere in the
+chain.
+
+The reporter's point about the container is correct. `Primitives/Dialog/BbDialogContent.razor`
+renders its container with `@ref="_contentRef"` (line 14) and `tabindex="-1"` (line 20), and
+passes that same reference to `TrapFocus` on line 104. The container is focusable and already in
+hand; the trap reaches past it.
+
+**Consequence.** Any dialog whose first tabbable descendant has an on-focus side effect fires it
+on open. The only consumer workaround is a dummy `tabindex="0"` element, which adds a phantom tab
+stop.
+
+### The library already has an autofocus convention
+
+Worth knowing before designing anything: `[data-autofocus]` is **already** honoured, but by a
+different mechanism. `portal.js:168-190` installs a `blazorblueprint:visible` listener that
+focuses `[data-autofocus]` within the element that became visible, and
+`BbDropdownMenuContent.razor:165` relies on it.
+
+Two things follow. The fix is cheaper than the report assumes — teaching the trap the same
+attribute matches an existing convention rather than inventing one. And the two mechanisms can
+**race** today: a consumer who puts `data-autofocus` inside a dialog has the portal listener and
+`focusableElements[0].focus()` both firing, with the winner decided by event ordering. That race
+is a live bug even before this work, and closing it is part of the value here.
+
+### Proposed resolution order
+
+Inside `createFocusTrap`, pick the initial focus target in this order:
+
+1. an explicit element passed from C#
+2. `[data-autofocus]` within the container
+3. the container itself, **if** the caller asked for it
+4. the first tabbable descendant — today's behaviour, and still the default
+
+Steps 1-2 are additive. Step 4 stays the default so no existing dialog changes.
+
+## 2. `InitialFocus` on the trapping components
+
+`TrapFocus` gains an optional argument, and the parameter is plumbed through the four components
+that call it:
+
+- `Primitives/Dialog/BbDialogContent.razor:104`
+- `Primitives/Sheet/BbSheetContent.razor:105`
+- `Components/Drawer/BbDrawerContent.razor:80`
+- `Components/Dialog/BbDialogProvider.razor:140`
+
+`IFocusManager.TrapFocus` is public, so the new argument must be optional — adding a required
+parameter to a public interface method breaks any consumer implementing it.
+
+**Radix parity is a separate decision.** Radix focuses the container by default and exposes
+`onOpenAutoFocus` to redirect. Matching that default would change behaviour for every existing
+dialog, so it belongs behind the parameter (option 3 above) rather than as the new default. If it
+is ever made the default, that is a major.
+
+## 3. HoverCard opens on any focus, including programmatic
+
+Confirmed in both branches:
+
+| path | mouse | focus |
+|---|---|---|
+| `AsChild="false"` | `HandleMouseEnter:235` → `Timer(Context.OpenDelay)` | `HandleFocus:263` → `Context.Open` immediately |
+| `AsChild` | `HandleMouseEnterForContext:120` → `Timer(Context.OpenDelay)` | `HandleFocusForContext:146` → `Context.Open` immediately |
+
+The sharper half of the report is 2(b), not 2(a). Opening on *any* focus means a focus trap
+moving focus onto the trigger — or any explicit `.focus()` — pops the card open with no user
+intent behind it. Gating the focus path on `:focus-visible` fixes that, and keyboard users still
+get the card because Tab sets `:focus-visible`.
+
+**`:focus-visible` does not work. Measured, not assumed.** It was implemented and tested in the
+running demo, and Chrome reports `:focus-visible` as **true** for a programmatic `.focus()` on the
+trigger's `div[tabindex="0"]` — including directly after a real, trusted mouse click. The card
+still opened. `BbTableRow.razor:58-59` already recorded the same limitation from the other
+direction.
+
+**What was shipped instead:** `element-utils.js` tracks the timestamp of the last `Tab` keydown at
+the document, in the capture phase, and `isKeyboardFocus(element)` returns true only when a Tab
+happened within 500 ms — or when the element is a text field, where focus is unambiguous. Tab is
+how a keyboard user reaches a trigger, and nothing moves focus programmatically in response to
+Tab, so it separates the two cases where the selector cannot. The check returns true whenever it
+cannot run (prerender, module unavailable), because a keyboard user losing the card is a worse
+regression than the bug.
+
+## 4. Should `OpenDelay` apply to keyboard focus? — recommend **no**
+
+The report asks for it on consistency grounds. I think that is wrong, and it is the one place
+this plan does not follow the report.
+
+`OpenDelay` defaults to **700 ms** (`BbHoverCard.razor:64`, `HoverCardContext.cs:19`). The delay
+exists because a pointer sweeps across elements incidentally, so an immediate open would fire
+cards the user never asked for. Tab does not do that — landing on a trigger is deliberate. So the
+two input methods differ for a real reason, not an unstated one.
+
+Applying the delay would make a keyboard user wait 700 ms for something a mouse user gets by
+resting still. That is a straight accessibility regression, and WCAG 1.4.13 is the reason the
+focus path exists at all.
+
+Once step 3 lands, the reported symptom is gone: programmatic focus no longer opens the card.
+What is left is a deliberate difference. **Recommendation: gate on `:focus-visible` and keep the
+focus path immediate.** If consistency is still wanted afterwards, expose a separate
+`FocusOpenDelay` defaulting to 0, rather than reusing `OpenDelay`.
+
+## Verification
+
+- A dialog whose first tabbable child has an on-focus side effect: the effect must not fire on
+  open once `InitialFocus` or `[data-autofocus]` is set.
+- The existing default path must be unchanged — a dialog with no `InitialFocus` still focuses the
+  first tabbable descendant.
+- `data-autofocus` inside a dialog must be deterministic, not a race.
+- Tab onto a HoverCard trigger opens the card, in Chrome, Firefox and Safari.
+- A programmatic `.focus()` on the trigger does **not** open it.
+- Blur still closes; `CloseDelay` unchanged.
+
+## Not included
+
+- Making container-focus the default. Behaviour change; needs a major.
+- `onOpenAutoFocus`-style callbacks. The parameter covers the reported need; a callback can be
+  added later without breaking it.

--- a/src/BlazorBlueprint.Components/Components/Dialog/BbDialogContent.razor
+++ b/src/BlazorBlueprint.Components/Components/Dialog/BbDialogContent.razor
@@ -15,6 +15,8 @@
         class="@GetClassNames()"
         CloseOnEscape="@CloseOnEscape"
         TrapFocus="@TrapFocus"
+        InitialFocus="@InitialFocus"
+        InitialFocusElement="@InitialFocusElement"
         LockScroll="@LockScroll"
         OnEscapeKeyDown="@OnEscapeKeyDown"
         @attributes="AdditionalAttributes">
@@ -85,6 +87,26 @@
     /// </summary>
     [Parameter]
     public bool TrapFocus { get; set; } = true;
+
+    /// <summary>
+    /// What to focus when the focus trap is established. Defaults to the first tabbable
+    /// descendant.
+    /// </summary>
+    /// <remarks>
+    /// Set this to <see cref="FocusTrapInitialFocus.Container"/> when the first tabbable child
+    /// has a side effect on focus, or use <see cref="InitialFocusElement"/> to name a target.
+    /// An element carrying <c>data-autofocus</c> wins over this setting.
+    /// </remarks>
+    [Parameter]
+    public FocusTrapInitialFocus InitialFocus { get; set; } = FocusTrapInitialFocus.FirstFocusable;
+
+    /// <summary>
+    /// An explicit element to focus when the focus trap is established, beating both
+    /// <see cref="InitialFocus"/> and any <c>data-autofocus</c> element. Ignored when it is not
+    /// inside the dialog.
+    /// </summary>
+    [Parameter]
+    public ElementReference? InitialFocusElement { get; set; }
 
     /// <summary>
     /// Whether to lock body scroll when dialog is open.

--- a/src/BlazorBlueprint.Components/Components/Drawer/BbDrawerContent.razor
+++ b/src/BlazorBlueprint.Components/Components/Drawer/BbDrawerContent.razor
@@ -50,6 +50,26 @@
     [Parameter]
     public bool TrapFocus { get; set; } = true;
 
+    /// <summary>
+    /// What to focus when the focus trap is established. Defaults to the first tabbable
+    /// descendant.
+    /// </summary>
+    /// <remarks>
+    /// Set this to <see cref="FocusTrapInitialFocus.Container"/> when the first tabbable child
+    /// has a side effect on focus, or use <see cref="InitialFocusElement"/> to name a target.
+    /// An element carrying <c>data-autofocus</c> wins over this setting.
+    /// </remarks>
+    [Parameter]
+    public FocusTrapInitialFocus InitialFocus { get; set; } = FocusTrapInitialFocus.FirstFocusable;
+
+    /// <summary>
+    /// An explicit element to focus when the focus trap is established, beating both
+    /// <see cref="InitialFocus"/> and any <c>data-autofocus</c> element. Ignored when it is not
+    /// inside the drawer.
+    /// </summary>
+    [Parameter]
+    public ElementReference? InitialFocusElement { get; set; }
+
     [Parameter]
     public bool LockScroll { get; set; } = true;
 
@@ -77,7 +97,7 @@
             {
                 try
                 {
-                    _focusTrap = await FocusManager.TrapFocus(_contentRef);
+                    _focusTrap = await FocusManager.TrapFocus(_contentRef, InitialFocus, InitialFocusElement);
                 }
                 catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
                 {

--- a/src/BlazorBlueprint.Components/Components/Sheet/BbSheetContent.razor
+++ b/src/BlazorBlueprint.Components/Components/Sheet/BbSheetContent.razor
@@ -15,6 +15,8 @@
         class="@GetClassNames()"
         CloseOnEscape="@CloseOnEscape"
         TrapFocus="@TrapFocus"
+        InitialFocus="@InitialFocus"
+        InitialFocusElement="@InitialFocusElement"
         LockScroll="@LockScroll"
         OnEscapeKeyDown="@OnEscapeKeyDown"
         @attributes="AdditionalAttributes">
@@ -95,6 +97,26 @@
     /// </summary>
     [Parameter]
     public bool TrapFocus { get; set; } = true;
+
+    /// <summary>
+    /// What to focus when the focus trap is established. Defaults to the first tabbable
+    /// descendant.
+    /// </summary>
+    /// <remarks>
+    /// Set this to <see cref="FocusTrapInitialFocus.Container"/> when the first tabbable child
+    /// has a side effect on focus, or use <see cref="InitialFocusElement"/> to name a target.
+    /// An element carrying <c>data-autofocus</c> wins over this setting.
+    /// </remarks>
+    [Parameter]
+    public FocusTrapInitialFocus InitialFocus { get; set; } = FocusTrapInitialFocus.FirstFocusable;
+
+    /// <summary>
+    /// An explicit element to focus when the focus trap is established, beating both
+    /// <see cref="InitialFocus"/> and any <c>data-autofocus</c> element. Ignored when it is not
+    /// inside the sheet.
+    /// </summary>
+    [Parameter]
+    public ElementReference? InitialFocusElement { get; set; }
 
     /// <summary>
     /// Whether to lock body scroll when sheet is open.

--- a/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialogContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Dialog/BbDialogContent.razor
@@ -55,6 +55,26 @@
     public bool TrapFocus { get; set; } = true;
 
     /// <summary>
+    /// What to focus when the focus trap is established. Defaults to the first tabbable
+    /// descendant.
+    /// </summary>
+    /// <remarks>
+    /// Set this to <see cref="FocusTrapInitialFocus.Container"/> when the first tabbable child
+    /// has a side effect on focus, or use <see cref="InitialFocusElement"/> to name a target.
+    /// An element carrying <c>data-autofocus</c> wins over this setting.
+    /// </remarks>
+    [Parameter]
+    public FocusTrapInitialFocus InitialFocus { get; set; } = FocusTrapInitialFocus.FirstFocusable;
+
+    /// <summary>
+    /// An explicit element to focus when the focus trap is established, beating both
+    /// <see cref="InitialFocus"/> and any <c>data-autofocus</c> element. Ignored when it is not
+    /// inside the dialog.
+    /// </summary>
+    [Parameter]
+    public ElementReference? InitialFocusElement { get; set; }
+
+    /// <summary>
     /// Whether to lock body scroll when dialog is open.
     /// Default is true for modal dialogs.
     /// </summary>
@@ -101,7 +121,7 @@
             {
                 try
                 {
-                    _focusTrap = await FocusManager.TrapFocus(_contentRef);
+                    _focusTrap = await FocusManager.TrapFocus(_contentRef, InitialFocus, InitialFocusElement);
                 }
                 catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
                 {

--- a/src/BlazorBlueprint.Primitives/Primitives/FocusTrapInitialFocus.cs
+++ b/src/BlazorBlueprint.Primitives/Primitives/FocusTrapInitialFocus.cs
@@ -1,0 +1,29 @@
+namespace BlazorBlueprint.Primitives;
+
+/// <summary>
+/// Controls what a focus trap focuses when it is established.
+/// </summary>
+/// <remarks>
+/// Declared in the <c>BlazorBlueprint.Primitives</c> namespace rather than a nested one so that
+/// an application importing <c>BlazorBlueprint.Components</c> can name it without ambiguity.
+/// An element carrying <c>data-autofocus</c>, or an explicit target passed to
+/// <c>IFocusManager.TrapFocus</c>, takes precedence over this setting.
+/// </remarks>
+public enum FocusTrapInitialFocus
+{
+    /// <summary>
+    /// Focus the first tabbable descendant. This is the default and the historical behaviour.
+    /// </summary>
+    FirstFocusable = 0,
+
+    /// <summary>
+    /// Focus the trapping container itself. Matches the Radix default, and avoids firing an
+    /// on-focus side effect belonging to the first tabbable descendant.
+    /// </summary>
+    Container = 1,
+
+    /// <summary>
+    /// Leave focus where it is. The trap still constrains Tab, but moves nothing on open.
+    /// </summary>
+    None = 2,
+}

--- a/src/BlazorBlueprint.Primitives/Primitives/HoverCard/BbHoverCardTrigger.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/HoverCard/BbHoverCardTrigger.razor
@@ -2,9 +2,10 @@
 @using System.Timers
 @using BlazorBlueprint.Primitives.Utilities
 @using Microsoft.Extensions.Logging
-@implements IDisposable
+@implements IAsyncDisposable
 @inject ILogger<BbHoverCardTrigger> Logger
 @inject IServiceProvider Services
+@inject IJSRuntime JSRuntime
 
 @* HoverCardTrigger primitive - trigger element that opens on hover *@
 @if (AsChild)
@@ -30,6 +31,7 @@ else
 
 @code {
     private ElementReference _triggerRef;
+    private IJSObjectReference? _elementUtils;
     private System.Timers.Timer? _openTimer;
     private System.Timers.Timer? _closeTimer;
     private bool _disposed;
@@ -146,11 +148,14 @@ else
     private void HandleFocusForContext()
     {
         CancelCloseTimer();
-        if (!Context.IsOpen)
-        {
-            Context.Open(_asChildTriggerRef);
-            InvokeAsync(StateHasChanged);
-        }
+
+        // TriggerContext.OnFocus is an Action, and widening it to Func<Task> would break every
+        // consumer implementing the AsChild pattern. Start the work and observe its faults here
+        // instead, so nothing is left unhandled.
+        _ = OpenOnVisibleFocusAsync(_asChildTriggerRef)
+            .ContinueWith(
+                t => Logger.LogDebug(t.Exception, "HoverCardTrigger failed to open on focus."),
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
     }
 
     private void HandleBlurForContext()
@@ -174,8 +179,23 @@ else
         }
     }
 
-    protected override void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            try
+            {
+                _elementUtils = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                    "import", "./_content/BlazorBlueprint.Primitives/js/primitives/element-utils.js");
+            }
+            catch (Exception ex) when (ex is JSException or InvalidOperationException or TaskCanceledException)
+            {
+                // Prerendering, or a circuit torn down mid-import. Without the module the focus
+                // path opens as it always did rather than becoming unreachable.
+                Logger.LogDebug(ex, "HoverCardTrigger could not load element-utils; focus opens without a keyboard-arrival check.");
+            }
+        }
+
         // Proactively set the trigger element reference so it's available
         // even when the hover card is opened programmatically (via @bind-Open)
         if (!AsChild)
@@ -260,16 +280,55 @@ else
         }
     }
 
-    private void HandleFocus()
+    /// <summary>
+    /// Whether the trigger was reached by a deliberate keyboard focus, rather than by focus moved
+    /// programmatically by a focus trap or an explicit <c>.focus()</c> call.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <c>:focus-visible</c>. Chrome reports that selector as true for a
+    /// programmatic <c>.focus()</c> on a <c>div[tabindex="0"]</c> even directly after a real mouse
+    /// click, so it does not separate the two cases; the JS side keys off a recent Tab instead.
+    ///
+    /// Returns true when the check cannot run — during prerendering, or with the module
+    /// unavailable. WCAG 1.4.13 requires the card to be keyboard reachable, so an unavailable
+    /// check must never withhold it.
+    /// </remarks>
+    private async Task<bool> IsKeyboardFocusAsync(ElementReference element)
+    {
+        if (_elementUtils == null) return true;
+
+        try
+        {
+            return await _elementUtils.InvokeAsync<bool>("isKeyboardFocus", element);
+        }
+        catch (Exception ex) when (ex is JSException or JSDisconnectedException or ObjectDisposedException or TaskCanceledException)
+        {
+            Logger.LogDebug(ex, "HoverCardTrigger could not evaluate keyboard focus; treating focus as deliberate.");
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Opens on focus, but only when the focus is visible. Opening on any focus meant a focus
+    /// trap, or any explicit <c>.focus()</c>, popped the card open with no user intent behind it.
+    /// </summary>
+    private async Task OpenOnVisibleFocusAsync(ElementReference? element)
+    {
+        if (_disposed || Context.IsOpen || !element.HasValue) return;
+
+        if (!await IsKeyboardFocusAsync(element.Value)) return;
+
+        // Re-check: the await gives a blur or a mouse path time to land.
+        if (_disposed || Context.IsOpen) return;
+
+        Context.Open(element.Value);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task HandleFocus()
     {
         CancelCloseTimer();
-
-        if (!Context.IsOpen)
-        {
-            // Open immediately on focus (keyboard navigation)
-            Context.Open(_triggerRef);
-            InvokeAsync(StateHasChanged);
-        }
+        await OpenOnVisibleFocusAsync(_triggerRef);
     }
 
     private void HandleBlur()
@@ -337,10 +396,25 @@ else
         }
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         _disposed = true;
         CancelOpenTimer();
         CancelCloseTimer();
+
+        if (_elementUtils != null)
+        {
+            try
+            {
+                await _elementUtils.DisposeAsync();
+            }
+            catch (Exception ex) when (ex is JSDisconnectedException or ObjectDisposedException or TaskCanceledException)
+            {
+                // Circuit already gone; nothing to release.
+                Logger.LogDebug(ex, "HoverCardTrigger could not dispose element-utils.");
+            }
+
+            _elementUtils = null;
+        }
     }
 }

--- a/src/BlazorBlueprint.Primitives/Primitives/Sheet/BbSheetContent.razor
+++ b/src/BlazorBlueprint.Primitives/Primitives/Sheet/BbSheetContent.razor
@@ -56,6 +56,26 @@
     public bool TrapFocus { get; set; } = true;
 
     /// <summary>
+    /// What to focus when the focus trap is established. Defaults to the first tabbable
+    /// descendant.
+    /// </summary>
+    /// <remarks>
+    /// Set this to <see cref="FocusTrapInitialFocus.Container"/> when the first tabbable child
+    /// has a side effect on focus, or use <see cref="InitialFocusElement"/> to name a target.
+    /// An element carrying <c>data-autofocus</c> wins over this setting.
+    /// </remarks>
+    [Parameter]
+    public FocusTrapInitialFocus InitialFocus { get; set; } = FocusTrapInitialFocus.FirstFocusable;
+
+    /// <summary>
+    /// An explicit element to focus when the focus trap is established, beating both
+    /// <see cref="InitialFocus"/> and any <c>data-autofocus</c> element. Ignored when it is not
+    /// inside the sheet.
+    /// </summary>
+    [Parameter]
+    public ElementReference? InitialFocusElement { get; set; }
+
+    /// <summary>
     /// Whether to lock body scroll when sheet is open.
     /// Default is true for modal sheets.
     /// </summary>
@@ -102,7 +122,7 @@
             {
                 try
                 {
-                    _focusTrap = await FocusManager.TrapFocus(_contentRef);
+                    _focusTrap = await FocusManager.TrapFocus(_contentRef, InitialFocus, InitialFocusElement);
                 }
                 catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
                 {

--- a/src/BlazorBlueprint.Primitives/Services/FocusManager.cs
+++ b/src/BlazorBlueprint.Primitives/Services/FocusManager.cs
@@ -43,12 +43,27 @@ public class FocusManager : IFocusManager, IAsyncDisposable
     }
 
     /// <inheritdoc />
-    public async Task<IAsyncDisposable> TrapFocus(ElementReference container)
+    public Task<IAsyncDisposable> TrapFocus(ElementReference container)
+        => TrapFocus(container, FocusTrapInitialFocus.FirstFocusable);
+
+    /// <inheritdoc />
+    public async Task<IAsyncDisposable> TrapFocus(
+        ElementReference container,
+        FocusTrapInitialFocus initialFocus,
+        ElementReference? initialFocusElement = null)
     {
         var module = await GetModuleAsync();
-        var cleanupFunction = await module.InvokeAsync<IJSObjectReference>("createFocusTrap", container);
+        var cleanupFunction = await module.InvokeAsync<IJSObjectReference>(
+            "createFocusTrap", container, ToJsMode(initialFocus), initialFocusElement);
         return new FocusTrapHandle(cleanupFunction);
     }
+
+    private static string ToJsMode(FocusTrapInitialFocus initialFocus) => initialFocus switch
+    {
+        FocusTrapInitialFocus.Container => "container",
+        FocusTrapInitialFocus.None => "none",
+        _ => "first",
+    };
 
     /// <inheritdoc />
     public async Task RestoreFocus(ElementReference? previousElement)

--- a/src/BlazorBlueprint.Primitives/Services/IFocusManager.cs
+++ b/src/BlazorBlueprint.Primitives/Services/IFocusManager.cs
@@ -16,6 +16,35 @@ public interface IFocusManager
     public Task<IAsyncDisposable> TrapFocus(ElementReference container);
 
     /// <summary>
+    /// Traps focus within the specified container element, choosing what to focus once the trap
+    /// is established.
+    /// </summary>
+    /// <param name="container">The container element to trap focus within.</param>
+    /// <param name="initialFocus">
+    /// What to focus once the trap is established. Defaults to the first tabbable descendant,
+    /// which is the historical behaviour.
+    /// </param>
+    /// <param name="initialFocusElement">
+    /// An explicit element to focus, which beats both <paramref name="initialFocus"/> and any
+    /// <c>data-autofocus</c> element. Ignored if it is not inside <paramref name="container"/>.
+    /// </param>
+    /// <returns>A task that completes when the focus trap is established.</returns>
+    /// <remarks>
+    /// Resolution order is: <paramref name="initialFocusElement"/>, then an element carrying
+    /// <c>data-autofocus</c> within the container, then <paramref name="initialFocus"/>.
+    ///
+    /// This is a default interface implementation so that adding it did not break existing
+    /// implementers of <see cref="IFocusManager"/>. The default ignores both new arguments and
+    /// defers to the single-argument overload, so a custom implementation keeps working exactly
+    /// as before — but does not gain the initial-focus behaviour until it overrides this.
+    /// </remarks>
+    public Task<IAsyncDisposable> TrapFocus(
+        ElementReference container,
+        FocusTrapInitialFocus initialFocus,
+        ElementReference? initialFocusElement = null)
+        => TrapFocus(container);
+
+    /// <summary>
     /// Restores focus to the previously focused element.
     /// Typically used when closing a dialog to return focus to the trigger.
     /// </summary>

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/element-utils.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/element-utils.js
@@ -56,3 +56,59 @@ export function isNearBottom(element, threshold = 80) {
     if (!element) return false;
     return element.scrollTop + element.clientHeight >= element.scrollHeight - threshold;
 }
+
+// ============================================================================
+// Keyboard arrival tracking
+//
+// `:focus-visible` cannot answer "did the user tab here?". Chrome reports it as true for a
+// programmatic .focus() on a div[tabindex="0"] even straight after a real mouse click - measured,
+// not assumed - so a hover card gated on it still opened when a focus trap moved focus. The same
+// limitation is recorded at Primitives/Table/BbTableRow.razor:58.
+//
+// Tab is how a keyboard user reaches a trigger, and nothing moves focus programmatically in
+// response to Tab, so "a Tab keydown happened just before this focus" separates the two cases
+// where the selector cannot.
+// ============================================================================
+
+let lastTabKeyAt = 0;
+let keyboardArrivalListenerInitialized = false;
+
+function initKeyboardArrivalListener() {
+    if (keyboardArrivalListenerInitialized) return;
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Tab') {
+            lastTabKeyAt = performance.now();
+        }
+    }, true);
+
+    keyboardArrivalListenerInitialized = true;
+}
+
+initKeyboardArrivalListener();
+
+/**
+ * Reports whether an element was reached by a deliberate keyboard focus, rather than by focus
+ * moved programmatically - by a focus trap, or an explicit .focus() call.
+ *
+ * Returns true when the check cannot run, so that an unsupported browser never withholds a
+ * hover card from a keyboard user. WCAG 1.4.13 is why the focus path exists at all.
+ *
+ * @param {HTMLElement} element - The element to test
+ * @param {number} [withinMs=500] - How recently a Tab keydown must have happened
+ * @returns {boolean} True when focus arrived from the keyboard
+ */
+export function isKeyboardFocus(element, withinMs = 500) {
+    if (!element) return false;
+
+    // A text field is always focus-visible, and typing into one is unambiguous intent.
+    try {
+        if (element.matches('input:not([type="button"]):not([type="submit"]), textarea, select')) {
+            return true;
+        }
+    } catch {
+        return true;
+    }
+
+    return (performance.now() - lastTabKeyAt) <= withinMs;
+}

--- a/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/focus-trap.js
+++ b/src/BlazorBlueprint.Primitives/wwwroot/js/primitives/focus-trap.js
@@ -14,10 +14,22 @@ const focusableSelectors = [
 
 /**
  * Creates a focus trap within the specified container element.
+ *
+ * The initial focus target is resolved in this order, so that a caller can always win over
+ * the default without having to inject a dummy tab stop:
+ *   1. an explicit element passed as `initialFocusElement`
+ *   2. `[data-autofocus]` within the container - the same convention portal.js already honours
+ *   3. `mode`: 'container' focuses the container itself, 'none' leaves focus where it is
+ *   4. the first tabbable descendant - the historical behaviour, and still the default
+ *
  * @param {HTMLElement} container - The container element to trap focus within
- * @returns {Function} Cleanup function to remove the focus trap
+ * @param {'first'|'container'|'none'} [mode='first'] - What to focus when no explicit target
+ *   or [data-autofocus] element is present
+ * @param {HTMLElement} [initialFocusElement=null] - Explicit element to focus, beating every
+ *   other rule
+ * @returns {Object} Object with an `apply` cleanup function, for IJSObjectReference
  */
-export function createFocusTrap(container) {
+export function createFocusTrap(container, mode = 'first', initialFocusElement = null) {
     if (!container) {
         console.warn('Focus trap: container is null or undefined');
         return () => {};
@@ -54,10 +66,29 @@ export function createFocusTrap(container) {
 
     container.addEventListener('keydown', handleKeyDown);
 
-    // Focus first element on initialization
-    const focusableElements = getFocusableElements();
-    if (focusableElements.length > 0) {
-        focusableElements[0].focus();
+    // Resolve the initial focus target. `container.contains` guards an explicit element that
+    // is not actually inside the trap, which would put focus outside the thing being trapped.
+    const resolveInitialFocus = () => {
+        if (initialFocusElement && container.contains(initialFocusElement)) {
+            return initialFocusElement;
+        }
+
+        const autofocusTarget = container.matches('[data-autofocus]')
+            ? container
+            : container.querySelector('[data-autofocus]');
+        if (autofocusTarget) {
+            return autofocusTarget;
+        }
+
+        if (mode === 'none') return null;
+        if (mode === 'container') return container;
+
+        return getFocusableElements()[0] ?? null;
+    };
+
+    const initialTarget = resolveInitialFocus();
+    if (initialTarget) {
+        initialTarget.focus();
     }
 
     // Return cleanup function wrapped in object for C# IJSObjectReference

--- a/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/ComponentsApiSurfaceTests.ComponentsApiSurfaceMatchesBaseline.verified.txt
@@ -1270,6 +1270,8 @@
   - CloseOnEscape : Boolean
   - CloseOnOverlayClick : Boolean
   - Container : String
+  - InitialFocus : FocusTrapInitialFocus
+  - InitialFocusElement : ElementReference?
   - LockScroll : Boolean
   - OnEscapeKeyDown : EventCallback<KeyboardEventArgs>
   - ShowClose : Boolean
@@ -1353,6 +1355,8 @@
   - ChildContent : RenderFragment
   - Class : String
   - CloseOnEscape : Boolean
+  - InitialFocus : FocusTrapInitialFocus
+  - InitialFocusElement : ElementReference?
   - LockScroll : Boolean
   - ShowHandle : Boolean
   - TrapFocus : Boolean
@@ -3238,6 +3242,8 @@
   - CloseOnEscape : Boolean
   - CloseOnOverlayClick : Boolean
   - Container : String
+  - InitialFocus : FocusTrapInitialFocus
+  - InitialFocusElement : ElementReference?
   - LockScroll : Boolean
   - OnEscapeKeyDown : EventCallback<KeyboardEventArgs>
   - ShowClose : Boolean

--- a/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
+++ b/tests/BlazorBlueprint.Tests/ApiSurface/PrimitivesApiSurfaceTests.PrimitivesApiSurfaceMatchesBaseline.verified.txt
@@ -246,6 +246,8 @@
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
   - ChildContent : RenderFragment
   - CloseOnEscape : Boolean
+  - InitialFocus : FocusTrapInitialFocus
+  - InitialFocusElement : ElementReference?
   - LockScroll : Boolean
   - OnEscapeKeyDown : EventCallback<KeyboardEventArgs>
   - TrapFocus : Boolean
@@ -624,6 +626,8 @@
   - AdditionalAttributes : Dictionary<String, Object> [CaptureUnmatchedValues]
   - ChildContent : RenderFragment
   - CloseOnEscape : Boolean
+  - InitialFocus : FocusTrapInitialFocus
+  - InitialFocusElement : ElementReference?
   - LockScroll : Boolean
   - OnEscapeKeyDown : EventCallback<KeyboardEventArgs>
   - TrapFocus : Boolean
@@ -998,6 +1002,11 @@
   - And = 0
   - Or = 1
 
+### FocusTrapInitialFocus (BlazorBlueprint.Primitives)
+  - FirstFocusable = 0
+  - Container = 1
+  - None = 2
+
 ### PopoverAlign (BlazorBlueprint.Primitives)
   - Start = 0
   - Center = 1
@@ -1168,6 +1177,7 @@
   - FocusLast(ElementReference container) : Task
   - RestoreFocus(ElementReference? previousElement) : Task
   - TrapFocus(ElementReference container) : Task<IAsyncDisposable>
+  - TrapFocus(ElementReference container, FocusTrapInitialFocus initialFocus, ElementReference? initialFocusElement) : Task<IAsyncDisposable>
 
 ### IKeyboardShortcutService (BlazorBlueprint.Primitives.Services)
   - IsSuspended : Boolean { get; }

--- a/tests/BlazorBlueprint.Tests/Focus/FocusTrapInitialFocusTests.cs
+++ b/tests/BlazorBlueprint.Tests/Focus/FocusTrapInitialFocusTests.cs
@@ -1,0 +1,108 @@
+using BlazorBlueprint.Primitives;
+using BlazorBlueprint.Primitives.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using Xunit;
+
+namespace BlazorBlueprint.Tests.Focus;
+
+/// <summary>
+/// Guards the contract <see cref="FocusManager"/> hands to <c>focus-trap.js</c>.
+///
+/// The JS decides the initial focus target, so what is testable here is that the mode and the
+/// explicit element arrive intact. That is where a silent regression would live: the trap would
+/// still work, still trap Tab, and quietly go back to focusing the first tabbable child — which
+/// is exactly the reported bug (#504), and it produces no error.
+/// </summary>
+public class FocusTrapInitialFocusTests
+{
+    [Fact]
+    public async Task TrapFocusDefaultsToTheFirstTabbableDescendant()
+    {
+        var module = new RecordingModule();
+        var manager = new FocusManager(new StubJsRuntime(module));
+
+        await manager.TrapFocus(default);
+
+        Assert.Equal("createFocusTrap", module.LastIdentifier);
+        Assert.Equal("first", module.LastArgs![1]);
+        Assert.Null(module.LastArgs[2]);
+    }
+
+    [Theory]
+    [InlineData(FocusTrapInitialFocus.FirstFocusable, "first")]
+    [InlineData(FocusTrapInitialFocus.Container, "container")]
+    [InlineData(FocusTrapInitialFocus.None, "none")]
+    public async Task TrapFocusSendsTheModeTheCallerAskedFor(
+        FocusTrapInitialFocus initialFocus, string expected)
+    {
+        var module = new RecordingModule();
+        var manager = new FocusManager(new StubJsRuntime(module));
+
+        await manager.TrapFocus(default, initialFocus);
+
+        Assert.Equal(expected, module.LastArgs![1]);
+    }
+
+    [Fact]
+    public async Task TrapFocusForwardsAnExplicitElement()
+    {
+        var module = new RecordingModule();
+        var manager = new FocusManager(new StubJsRuntime(module));
+        var target = new ElementReference("the-target");
+
+        await manager.TrapFocus(default, FocusTrapInitialFocus.Container, target);
+
+        // The mode still travels: JS falls back to it when the explicit element turns out not to
+        // be inside the container.
+        Assert.Equal("container", module.LastArgs![1]);
+        Assert.Equal(target, Assert.IsType<ElementReference>(module.LastArgs[2]));
+    }
+
+    /// <summary>Hands out the one module; anything else is a call the manager should not make.</summary>
+    private sealed class StubJsRuntime(RecordingModule module) : IJSRuntime
+    {
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) =>
+            InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+
+        public ValueTask<TValue> InvokeAsync<TValue>(
+            string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            if (identifier != "import")
+            {
+                throw new InvalidOperationException(
+                    $"FocusManager should only call 'import' on IJSRuntime, not '{identifier}'.");
+            }
+
+            return ValueTask.FromResult((TValue)(object)module);
+        }
+    }
+
+    /// <summary>Records the last call so a test can assert on the arguments that reached JS.</summary>
+    private sealed class RecordingModule : IJSObjectReference
+    {
+        public string? LastIdentifier { get; private set; }
+
+        public object?[]? LastArgs { get; private set; }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) =>
+            InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+
+        public ValueTask<TValue> InvokeAsync<TValue>(
+            string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            LastIdentifier = identifier;
+            LastArgs = args;
+
+            // The cleanup handle the real module returns.
+            if (typeof(TValue) == typeof(IJSObjectReference))
+            {
+                return ValueTask.FromResult((TValue)(object)this);
+            }
+
+            return ValueTask.FromResult(default(TValue)!);
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Closes #504.

## Focus trap

`createFocusTrap` ended with an unconditional `focusableElements[0].focus()` and took no argument, so a dialog whose first tabbable descendant acts *on focus* fired that side effect the moment it opened. The only consumer workaround was a dummy `tabindex="0"` element, which adds a phantom tab stop.

`InitialFocus` and `InitialFocusElement` on `BbDialogContent`, `BbSheetContent` and `BbDrawerContent`. Resolution order: explicit element, then `[data-autofocus]`, then the mode (`FirstFocusable` / `Container` / `None`), then the first tabbable descendant. **The default is unchanged.**

`[data-autofocus]` rather than a new convention, because the library already honours it — `portal.js` focuses it on a `blazorblueprint:visible` event and `BbDropdownMenuContent` relies on that. Both mechanisms could previously fire inside a dialog and race; they now agree on one target.

`IFocusManager.TrapFocus` gained an **overload** with a default interface implementation, not extra parameters. Widening the existing signature would break anyone implementing the interface, which a bug fix should not cost.

## HoverCard

The trigger opened on *any* focus, so a focus trap or an explicit `.focus()` popped the card open with no user intent. Both `AsChild` branches did it.

**Gating on `:focus-visible` does not work, and that is measured rather than assumed.** It was implemented and tested in the running demo: Chrome reports `:focus-visible` as **true** for a programmatic `.focus()` on the trigger's `div[tabindex="0"]`, including directly after a real, trusted mouse click. The card still opened. `BbTableRow.razor:58` had already recorded the same limitation from the other direction.

What ships instead keys off `Tab`: `element-utils.js` records the last `Tab` keydown at the document in the capture phase, and the trigger opens on focus only when a Tab landed within 500 ms — or when the focused element is a text field, where intent is unambiguous. Nothing moves focus programmatically *in response to* Tab, so this separates the two cases the selector cannot. The check returns true whenever it cannot run (prerender, module unavailable), because a keyboard user silently losing the card is worse than the bug.

## One deliberate departure from the report

`OpenDelay` still does **not** apply to the focus path. It defaults to 700 ms and exists because a pointer sweeps across elements incidentally; Tab does not, so landing on a trigger is already deliberate. Making a keyboard user wait 700 ms for what a mouse user gets by holding still is an accessibility regression, and WCAG 1.4.13 is why the focus path exists at all. Once the Tab gate is in, the reported symptom is gone and what remains is a difference with a reason.

## Verification

Verified in the running demo, not only in unit tests:

| case | result |
|---|---|
| default dialog | focuses the first field, as before |
| `InitialFocus="Container"` | focuses `div[role=dialog][tabindex=-1]` |
| `data-autofocus` on a footer button | focuses that button, not the field above it |
| programmatic `.focus()` on a HoverCard trigger | card stays closed |
| real `Tab` onto the trigger | card opens |

Full solution builds clean. 171/171 tests pass, including 5 new ones guarding the mode and element that reach JS — that is where a regression would be silent, since the trap would still trap and just quietly focus the first child again.

API surface snapshots are **additive**: 16 lines added, none removed or changed.