### PR TITLE
fix(a11y): themed focus ring on five overlay and disclosure triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Five overlay and disclosure triggers showed the browser's own focus outline instead of the theme's ring** — first tranche of [#459](https://github.com/blazorblueprintui/ui/issues/459). `BbCollapsibleTrigger`, `BbAccordionTrigger`, `BbDialogTrigger`, `BbSheetTrigger` and `BbPopoverTrigger` set no focus style at all, so Chrome painted its blue rectangle while the input above showed `ring-ring`. Focus stayed visible, so this passed WCAG 2.4.7 — it simply looked as though focus changed style as you tabbed down the page. The collapsible trigger is what the docs site's own "View Code" toggle uses, so the site showed it too.
+
+  All five now carry `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`, the standalone-control treatment [#458](https://github.com/blazorblueprintui/ui/issues/458) settled on.
+
+  The ring goes in the **Components** layer, not Primitives — the primitives are headless and set no classes, which is the whole point of the split. For Dialog, Sheet and Popover the styled wrapper passes it as `class` into the primitive, which splats it onto the `<button>` it owns. That branch only renders when `AsChild` is false, so an `AsChild` trigger keeps its child's own focus styling rather than gaining a second ring.
+
+  Verified in the running demo rather than only by reading classes: on a real Tab the computed `box-shadow` is the themed ring and `outline-style` is `none`. A class in the markup proves nothing on its own if Tailwind never emitted the rule.
+
+  **[#459](https://github.com/blazorblueprintui/ui/issues/459) stays open** — 27 components were affected and 5 are done. Twelve of the rest are the same mechanical treatment; eight need a visual judgement the issue already flags, such as `BbSidebarRail` being a thin drag strip where a 2px ring is most of the control. The last two, `BbDrawerTrigger` and `BbDrawerClose`, are blocked on [#507](https://github.com/blazorblueprintui/ui/issues/507): they render a bare `<div>` with `@onclick` and no `tabindex`, so there is nothing to draw a focus ring on until they become focusable.
+
 - **`BbHoverCardTrigger` opened on any focus, including focus moved programmatically** — the other half of [#504](https://github.com/blazorblueprintui/ui/issues/504). Opening on focus is correct and required — WCAG 1.4.13 means a hover card must be keyboard reachable — but the handler could not tell a deliberate Tab from a focus trap or an explicit `.focus()`, so an unrelated dialog opening nearby popped the card open with no user intent behind it. Both the `AsChild` and `AsChild="false"` paths behaved this way.
 
   **The obvious fix does not work, and the measurement is the useful part of this entry.** Gating on `:focus-visible` was implemented and tested in the running demo: Chrome reports it as **true** for a programmatic `.focus()` on the trigger's `div[tabindex="0"]`, including directly after a real mouse click. The card still opened. `BbTableRow.razor:58` had already recorded the same limitation from the other direction.

--- a/src/BlazorBlueprint.Components/Components/Accordion/BbAccordionTrigger.razor
+++ b/src/BlazorBlueprint.Components/Components/Accordion/BbAccordionTrigger.razor
@@ -85,6 +85,8 @@
     /// </summary>
     private string CssClass => ClassNames.cn(
         "flex w-full items-center justify-between text-sm font-medium transition-all",
+        // #459: see BbCollapsibleTrigger — the browser's own outline otherwise.
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         Class
     );
 }

--- a/src/BlazorBlueprint.Components/Components/Collapsible/BbCollapsibleTrigger.razor.cs
+++ b/src/BlazorBlueprint.Components/Components/Collapsible/BbCollapsibleTrigger.razor.cs
@@ -92,5 +92,10 @@ public partial class BbCollapsibleTrigger : ComponentBase
     /// <value>
     /// A string containing all CSS classes to be applied to the button element.
     /// </value>
-    private string CssClass => ClassNames.cn("group", Class);
+    private string CssClass => ClassNames.cn(
+        "group",
+        // #459: without this the browser paints its own outline, which reads as a different
+        // focus style from the themed ring used everywhere else on the same page.
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        Class);
 }

--- a/src/BlazorBlueprint.Components/Components/Dialog/BbDialogTrigger.razor
+++ b/src/BlazorBlueprint.Components/Components/Dialog/BbDialogTrigger.razor
@@ -5,7 +5,9 @@
     Renders the trigger button for opening the dialog.
 *@
 
-<BlazorBlueprint.Primitives.Dialog.BbDialogTrigger AsChild="@AsChild" @attributes="AdditionalAttributes">
+<BlazorBlueprint.Primitives.Dialog.BbDialogTrigger AsChild="@AsChild"
+    class="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    @attributes="AdditionalAttributes">
     @ChildContent
 </BlazorBlueprint.Primitives.Dialog.BbDialogTrigger>
 

--- a/src/BlazorBlueprint.Components/Components/Popover/BbPopoverTrigger.razor
+++ b/src/BlazorBlueprint.Components/Components/Popover/BbPopoverTrigger.razor
@@ -5,6 +5,7 @@
 <BlazorBlueprint.Primitives.Popover.BbPopoverTrigger AsChild="@AsChild"
                                                    OnClick="@OnClick"
                                                    CustomClickHandling="@CustomClickHandling"
+                                                   class="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                                                    @attributes="AdditionalAttributes">
     @ChildContent
 </BlazorBlueprint.Primitives.Popover.BbPopoverTrigger>

--- a/src/BlazorBlueprint.Components/Components/Sheet/BbSheetTrigger.razor
+++ b/src/BlazorBlueprint.Components/Components/Sheet/BbSheetTrigger.razor
@@ -5,7 +5,9 @@
     Renders the trigger button for opening the sheet.
 *@
 
-<BlazorBlueprint.Primitives.Sheet.BbSheetTrigger AsChild="@AsChild" @attributes="AdditionalAttributes">
+<BlazorBlueprint.Primitives.Sheet.BbSheetTrigger AsChild="@AsChild"
+    class="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    @attributes="AdditionalAttributes">
     @ChildContent
 </BlazorBlueprint.Primitives.Sheet.BbSheetTrigger>
 


### PR DESCRIPTION
First tranche of #459. **Does not close it** — 27 components are affected and this does 5.

## What

`BbCollapsibleTrigger`, `BbAccordionTrigger`, `BbDialogTrigger`, `BbSheetTrigger` and `BbPopoverTrigger` set no focus style at all, so Chrome painted its blue rectangle while the input above showed `ring-ring`. Focus stayed visible, so this passed WCAG 2.4.7 — it simply looked as though focus changed style as you tabbed down the page. The collapsible trigger is what the docs site's own "View Code" toggle uses, which is the screenshot on the issue.

All five now carry `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`, the standalone-control treatment #458 settled on.

## Where the ring goes, and why

The **Components** layer, not Primitives. The primitives are headless and set no classes; that is the point of the split. For Dialog, Sheet and Popover the styled wrapper passes the ring as `class` into the primitive, which splats it onto the `<button>` it owns. That branch only renders when `AsChild` is false, so an `AsChild` trigger keeps its child's own focus styling rather than gaining a second ring.

## Verification

Verified in the running demo rather than only by reading classes — a class in the markup proves nothing if Tailwind never emitted the rule. On a real Tab:

```
box-shadow:     ... rgb(255,255,255) 0 0 0 2px, oklch(0.552 0.016 285.94) 0 0 0 4px ...
outline-style:  none
```

That is `ring-ring` with `ring-offset-2`, and the user agent outline suppressed.

Full solution builds clean. 171/171 tests pass, including the `FocusIndicatorTests` convention guards.

## What is left on #459

- **12** are the same mechanical treatment.
- **8** need a visual judgement the issue already flags — `BbSidebarRail` is a thin drag strip where a 2px ring is most of the control, `BbCarouselNext`/`Previous` sit over slide images so contrast depends on the photo, `BbMarker` and `BbRating` are small repeated elements where an offset ring collides with neighbours, and three are containers where the ring may belong on a child instead.
- **2** are blocked on #507, filed from this work: `BbDrawerTrigger` and `BbDrawerClose` render a bare `<div>` with `@onclick` and no `tabindex`, so there is nothing focusable to draw a ring on.